### PR TITLE
Feature/bgtask3

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		134F0F2D2475794900D88934 /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134FFA0F247466BD00D82D14 /* Accessibility.swift */; };
 		134FFA10247466BD00D82D14 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134FFA0E247466BD00D82D14 /* TestEnvironment.swift */; };
 		134FFA11247466BD00D82D14 /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134FFA0F247466BD00D82D14 /* Accessibility.swift */; };
+		1363CB382482780800F8CD8A /* Flogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1363CB372482780800F8CD8A /* Flogger.swift */; };
 		13722044247AEEAD00152764 /* LocalNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13722043247AEEAD00152764 /* LocalNotificationManager.swift */; };
 		138910C5247A909000D739F6 /* ENATaskScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138910C4247A909000D739F6 /* ENATaskScheduler.swift */; };
 		13BAE9B12472FB1E00CEE58A /* CellConfiguratorIndexPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BAE9B02472FB1E00CEE58A /* CellConfiguratorIndexPosition.swift */; };
@@ -292,6 +293,7 @@
 		134F0F2B2475793400D88934 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = ../../fastlane/SnapshotHelper.swift; sourceTree = "<group>"; };
 		134FFA0E247466BD00D82D14 /* TestEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnvironment.swift; sourceTree = "<group>"; };
 		134FFA0F247466BD00D82D14 /* Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		1363CB372482780800F8CD8A /* Flogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Flogger.swift; sourceTree = "<group>"; };
 		13722043247AEEAD00152764 /* LocalNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotificationManager.swift; sourceTree = "<group>"; };
 		138910C4247A909000D739F6 /* ENATaskScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENATaskScheduler.swift; sourceTree = "<group>"; };
 		13BAE9B02472FB1E00CEE58A /* CellConfiguratorIndexPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellConfiguratorIndexPosition.swift; sourceTree = "<group>"; };
@@ -785,6 +787,7 @@
 				01A158042470042A008BA581 /* PayloadStore.swift */,
 				A3FF84EB247BFAF00053E947 /* Hasher.swift */,
 				0D5611B3247F852C00B5B094 /* SQLiteKeyValueStore.swift */,
+				1363CB372482780800F8CD8A /* Flogger.swift */,
 			);
 			path = Workers;
 			sourceTree = "<group>";
@@ -1633,6 +1636,7 @@
 				51FE277B2475340300BB8144 /* HomeRiskLoadingItemViewConfigurator.swift in Sources */,
 				0D5611B4247F852C00B5B094 /* SQLiteKeyValueStore.swift in Sources */,
 				13BAE9B12472FB1E00CEE58A /* CellConfiguratorIndexPosition.swift in Sources */,
+				1363CB382482780800F8CD8A /* Flogger.swift in Sources */,
 				514C0A0D247AFB0200F235F6 /* RiskTextItemView.swift in Sources */,
 				CD99A3A9245C272400BF12AF /* ExposureSubmissionService.swift in Sources */,
 				51B5B41C246EC8B800DC5D3E /* HomeCardCollectionViewCell.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -6,7 +6,6 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).detect-exposures.exposure-notification</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).exposure-notification</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -5,8 +5,8 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).detect-exposures.exposure-notification</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results.exposure-notification</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST.exposure-notification</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -4,9 +4,9 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).exposure-notification</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).detect-exposures.exposure-notification</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results.exposure-notification</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).SIMPLETEST.exposure-notification</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -167,7 +167,7 @@ extension AppDelegate: ENATaskExecutionDelegate {
 
 			// reschedule background task again
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
-            self.taskScheduler.scheduleBackgroundTask(for: .exposureNotification)
+			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
         }
         
         task.expirationHandler = {
@@ -180,7 +180,7 @@ extension AppDelegate: ENATaskExecutionDelegate {
 
 			// reschedule background task again
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
-			self.taskScheduler.scheduleBackgroundTask(for: .exposureNotification)
+			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
         }
     }
 
@@ -249,6 +249,7 @@ extension AppDelegate: ENATaskExecutionDelegate {
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
             self.taskScheduler.scheduleBackgroundTask(for: .SIMPLETEST)
 		}
+		
         task.expirationHandler = {
 			// handle background task expiration
             log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -157,7 +157,6 @@ extension AppDelegate: CoronaWarnAppDelegate {
 }
 
 extension AppDelegate: ENATaskExecutionDelegate {
-    
 	func executeExposureDetectionRequest(task: BGTask) {
         // start background task execution
 		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
@@ -208,10 +207,11 @@ extension AppDelegate: ENATaskExecutionDelegate {
                 log(message: "# TASKSHED # \(#line) \(#function) TESTRESULT \(task.identifier)\(testResult)")
 
                 if testResult != .pending {
-                    self.taskScheduler.notificationManager.presentNotification(
-                        title: AppStrings.LocalNotifications.testResultsTitle,
-                        body: AppStrings.LocalNotifications.testResultsBody,
-                        identifier: ENATaskIdentifier.fetchTestResults.rawValue)
+						self.taskScheduler.notificationManager.presentNotification(
+							title: AppStrings.LocalNotifications.testResultsTitle,
+							body: AppStrings.LocalNotifications.testResultsBody,
+							identifier: ENATaskIdentifier.fetchTestResults.rawValue)
+					}
                 }
 
 				// mark background task as completed
@@ -238,36 +238,4 @@ extension AppDelegate: ENATaskExecutionDelegate {
         }
 
     }
-
-	func executeSIMPLETEST(task: BGTask) {
-        // start background task execution
-		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
-
-		DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
-            // handle completed background task
-			log(message: "# TASKSHED # \(#line) \(#function) RETURN \(task.identifier)")
-
-			// mark background task as completed
-            log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
-            task.setTaskCompleted(success: true)
-
-			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
-            self.taskScheduler.scheduleBackgroundTask(for: .SIMPLETEST)
-		}
-		
-        task.expirationHandler = {
-			// handle background task expiration
-            log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
-			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
-			
-            // mark background task as completed
-            task.setTaskCompleted(success: false)
-
-			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
-			self.taskScheduler.scheduleBackgroundTask(for: .SIMPLETEST)
-        }
-	}
-
 }

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -29,7 +29,6 @@ protocol CoronaWarnAppDelegate: AnyObject {
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-	// swiftlint:disable:next force_unwrapping
 	let taskScheduler = ENATaskScheduler()
 	private var exposureManager: ExposureManager = ENAExposureManager()
 	private var exposureDetectionTransaction: ExposureDetectionTransaction?
@@ -84,6 +83,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	func application(_: UIApplication,
 					 didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+
+		log(message: "# TASKSHED #")
+		log(message: "# TASKSHED # \(#line) \(#function)")
+		log(message: "# TASKSHED #")
+		
 		taskScheduler.taskDelegate = self
 		taskScheduler.registerBackgroundTaskRequests()
 		return true

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -85,10 +85,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 					 didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
 		UIDevice.current.isBatteryMonitoringEnabled = true
-		log(message: "# TASKSHED #")
-		log(message: "# TASKSHED # RUNNING ON DEVICE \(UIDevice().name)")
-		log(message: "# TASKSHED # \(#line) \(#function) options = \(options)")
-		log(message: "# TASKSHED #")
 
 		taskScheduler.taskDelegate = self
 		taskScheduler.registerBackgroundTaskRequests()
@@ -159,52 +155,40 @@ extension AppDelegate: CoronaWarnAppDelegate {
 extension AppDelegate: ENATaskExecutionDelegate {
 	func executeExposureDetectionRequest(task: BGTask) {
 		// start background task execution
-		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
 
 		let exposureDetectionTransaction = ExposureDetectionTransaction(delegate: self, client: client, keyPackagesStore: downloadedPackagesStore)
 		exposureDetectionTransaction.start {
-			// handle completed background task
-			log(message: "# TASKSHED # \(#line) \(#function) RETURN \(task.identifier)")
-
 			// mark background task as completed
-			log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
 			task.setTaskCompleted(success: true)
 
 			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
 		}
 
 		task.expirationHandler = {
 			// handle background task expiration
-			log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
 			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
 
 			// mark background task as completed
 			task.setTaskCompleted(success: false)
 
 			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
 		}
 	}
 
 	func executeFetchTestResults(task: BGTask) {
 		// start background task execution
-		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
 
 		let exposureSubmissionService = ENAExposureSubmissionService(manager: exposureManager, client: client, store: store)
 		exposureSubmissionService.getTestResult { result in
 			// handle completed background task
-			log(message: "# TASKSHED # \(#line) \(#function) RETURN \(task.identifier)")
 
 			switch result {
 			case .failure(let error):
-				log(message: "# TASKSHED # \(#line) \(#function) ERROR \(task.identifier) \(error)")
 				logError(message: error.localizedDescription)
 
 			case .success(let testResult):
-				log(message: "# TASKSHED # \(#line) \(#function) TESTRESULT \(task.identifier)\(testResult)")
 
 				if testResult != .pending {
 					self.taskScheduler.notificationManager.presentNotification(
@@ -215,24 +199,20 @@ extension AppDelegate: ENATaskExecutionDelegate {
 			}
 
 			// mark background task as completed
-			log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
 			task.setTaskCompleted(success: true)
 
 			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
 		}
 
 		task.expirationHandler = {
 			// handle background task expiration
-			log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
 			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
 
 			// mark background task as completed
 			task.setTaskCompleted(success: false)
 
 			// reschedule background task again
-			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
 		}
 

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -82,10 +82,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	}()
 
 	func application(_: UIApplication,
-					 didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+					 didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
 		log(message: "# TASKSHED #")
-		log(message: "# TASKSHED # \(#line) \(#function)")
+		log(message: "# TASKSHED # \(#line) \(#function), options = \(options)")
 		log(message: "# TASKSHED #")
 		
 		taskScheduler.taskDelegate = self

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -66,7 +66,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			let distributionURL = URL(string: distributionURLString),
 			let verificationURL = URL(string: verificationURLString),
 			let submissionURL = URL(string: submissionURLString) else {
-			return HTTPClient(configuration: .production)
+				return HTTPClient(configuration: .production)
 		}
 
 		let config = HTTPClient.Configuration(
@@ -89,7 +89,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		log(message: "# TASKSHED # RUNNING ON DEVICE \(UIDevice().name)")
 		log(message: "# TASKSHED # \(#line) \(#function) options = \(options)")
 		log(message: "# TASKSHED #")
-		
+
 		taskScheduler.taskDelegate = self
 		taskScheduler.registerBackgroundTaskRequests()
 		return true
@@ -158,84 +158,83 @@ extension AppDelegate: CoronaWarnAppDelegate {
 
 extension AppDelegate: ENATaskExecutionDelegate {
 	func executeExposureDetectionRequest(task: BGTask) {
-        // start background task execution
+		// start background task execution
 		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
-        
-        let exposureDetectionTransaction = ExposureDetectionTransaction(delegate: self, client: client, keyPackagesStore: downloadedPackagesStore)
-        exposureDetectionTransaction.start {
-            // handle completed background task
+
+		let exposureDetectionTransaction = ExposureDetectionTransaction(delegate: self, client: client, keyPackagesStore: downloadedPackagesStore)
+		exposureDetectionTransaction.start {
+			// handle completed background task
 			log(message: "# TASKSHED # \(#line) \(#function) RETURN \(task.identifier)")
 
 			// mark background task as completed
-            log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
-            task.setTaskCompleted(success: true)
+			log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
+			task.setTaskCompleted(success: true)
 
 			// reschedule background task again
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
-        }
-        
-        task.expirationHandler = {
+		}
+
+		task.expirationHandler = {
 			// handle background task expiration
-            log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
+			log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
 			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
-			
-            // mark background task as completed
-            task.setTaskCompleted(success: false)
+
+			// mark background task as completed
+			task.setTaskCompleted(success: false)
 
 			// reschedule background task again
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .detectExposures)
-        }
-    }
+		}
+	}
 
-    func executeFetchTestResults(task: BGTask) {
-        // start background task execution
+	func executeFetchTestResults(task: BGTask) {
+		// start background task execution
 		log(message: "# TASKSHED # \(#line) \(#function) STARTED \(task.identifier)")
 
-        let exposureSubmissionService = ENAExposureSubmissionService(manager: exposureManager, client: client, store: store)
-        exposureSubmissionService.getTestResult { result in
-            // handle completed background task
+		let exposureSubmissionService = ENAExposureSubmissionService(manager: exposureManager, client: client, store: store)
+		exposureSubmissionService.getTestResult { result in
+			// handle completed background task
 			log(message: "# TASKSHED # \(#line) \(#function) RETURN \(task.identifier)")
 
-            switch result {
-            case .failure(let error):
-                log(message: "# TASKSHED # \(#line) \(#function) ERROR \(task.identifier) \(error)")
-                logError(message: error.localizedDescription)
+			switch result {
+			case .failure(let error):
+				log(message: "# TASKSHED # \(#line) \(#function) ERROR \(task.identifier) \(error)")
+				logError(message: error.localizedDescription)
 
-            case .success(let testResult):
-                log(message: "# TASKSHED # \(#line) \(#function) TESTRESULT \(task.identifier)\(testResult)")
+			case .success(let testResult):
+				log(message: "# TASKSHED # \(#line) \(#function) TESTRESULT \(task.identifier)\(testResult)")
 
-                if testResult != .pending {
-						self.taskScheduler.notificationManager.presentNotification(
-							title: AppStrings.LocalNotifications.testResultsTitle,
-							body: AppStrings.LocalNotifications.testResultsBody,
-							identifier: ENATaskIdentifier.fetchTestResults.rawValue)
-					}
-                }
+				if testResult != .pending {
+					self.taskScheduler.notificationManager.presentNotification(
+						title: AppStrings.LocalNotifications.testResultsTitle,
+						body: AppStrings.LocalNotifications.testResultsBody,
+						identifier: ENATaskIdentifier.fetchTestResults.rawValue)
+				}
+			}
 
-				// mark background task as completed
-                log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
-                task.setTaskCompleted(success: true)
-
-				// reschedule background task again
-				log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
-                self.taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
-            }
-        }
-    
-        task.expirationHandler = {
-			// handle background task expiration
-            log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
-			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
-			
-            // mark background task as completed
-            task.setTaskCompleted(success: false)
+			// mark background task as completed
+			log(message: "# TASKSHED # \(#line) \(#function) COMPLETE \(task.identifier)")
+			task.setTaskCompleted(success: true)
 
 			// reschedule background task again
 			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
 			self.taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
-        }
+		}
 
-    }
+		task.expirationHandler = {
+			// handle background task expiration
+			log(message: "# TASKSHED # \(#line) \(#function) EXPIRED \(task.identifier)")
+			logError(message: NSLocalizedString("BACKGROUND_TIMEOUT", comment: "Error"))
+
+			// mark background task as completed
+			task.setTaskCompleted(success: false)
+
+			// reschedule background task again
+			log(message: "# TASKSHED # \(#line) \(#function) RESCHEDULING TASK \(task.identifier)")
+			self.taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
+		}
+
+	}
 }

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -84,8 +84,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	func application(_: UIApplication,
 					 didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
+		UIDevice.current.isBatteryMonitoringEnabled = true
 		log(message: "# TASKSHED #")
-		log(message: "# TASKSHED # \(#line) \(#function), options = \(options)")
+		log(message: "# TASKSHED # RUNNING ON DEVICE \(UIDevice().name)")
+		log(message: "# TASKSHED # \(#line) \(#function) options = \(options)")
 		log(message: "# TASKSHED #")
 		
 		taskScheduler.taskDelegate = self

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -55,7 +55,6 @@ public class ENATaskScheduler {
 
 	public func registerBackgroundTaskRequests() {
 		log(message: "# TASKSHED # \(#line), \(#function) STARTED")
-		cancelAllBackgroundTaskRequests()
 		registerTask(with: .detectExposures, taskHander: executeExposureDetectionRequest(_:))
 		registerTask(with: .fetchTestResults, taskHander: executeFetchTestResults(_:))
 		registerTask(with: .SIMPLETEST, taskHander: executeSIMPLETEST(_:))

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -85,6 +85,14 @@ public class ENATaskScheduler {
 		}
 	}
 
+	public func listPendingTasks() {
+		self.fetchPendingBackgroundTaskRequests { requests in
+			requests.forEach { request in
+				log(message: "# TASKSHED # \(#line) \(#function) PENDING REQUEST \(request.identifier) at \(request.earliestBeginDate?.description(with: .current) ?? "<unknown>")")
+			}
+		}
+	}
+
 	public func cancelAllBackgroundTaskRequests() {
 		log(message: "# TASKSHED # \(#line), \(#function)")
 		BGTaskScheduler.shared.cancelAllTaskRequests()
@@ -113,7 +121,7 @@ public class ENATaskScheduler {
 		taskRequest.earliestBeginDate = earliestBeginDate
 		do {
 			try BGTaskScheduler.shared.submit(taskRequest)
-			log(message: "# TASKSHED # \(#line), \(#function) SCHEDULED \(taskIdentifier.backgroundTaskSchedulerIdentifier) at \(earliestBeginDate)")
+			log(message: "# TASKSHED # \(#line), \(#function) SCHEDULED \(taskIdentifier.backgroundTaskSchedulerIdentifier) at \(earliestBeginDate.description(with: .current))")
 		} catch {
 			log(message: "# TASKSHED # FAILED TO SCHEDULE \(taskIdentifier.backgroundTaskSchedulerIdentifier): \(error)")
 		}

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -90,8 +90,9 @@ public class ENATaskScheduler {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
 	}
 
-	private func registerTask(with identifier: ENATaskIdentifier, taskHander: @escaping ((BGTask) -> Void)) {
-		let identifierString = identifier.backgroundTaskSchedulerIdentifier
+	private func registerTask(with taskIdentifier: ENATaskIdentifier, taskHander: @escaping ((BGTask) -> Void)) {
+		log(message: "# TASKSHED # \(#line), \(#function) REGISTERING \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
+		let identifierString = taskIdentifier.backgroundTaskSchedulerIdentifier
 		BGTaskScheduler.shared.register(forTaskWithIdentifier: identifierString, using: nil) { task in
 			taskHander(task)
 		}
@@ -106,17 +107,15 @@ public class ENATaskScheduler {
 		}
 
 		let earliestBeginDate = Date(timeIntervalSinceNow: taskIdentifier.backgroundTaskScheduleInterval)
-		log(message: "# TASKSHED # \(#line), \(#function) TIME NOW IS  :\(Date(timeIntervalSinceNow: 0))")
-		log(message: "# TASKSHED # \(#line), \(#function) SCHEDULED at :\(earliestBeginDate)")
-
 		let taskRequest = BGProcessingTaskRequest(identifier: taskIdentifier.backgroundTaskSchedulerIdentifier)
 		taskRequest.requiresNetworkConnectivity = true
 		taskRequest.requiresExternalPower = false
 		taskRequest.earliestBeginDate = earliestBeginDate
 		do {
 			try BGTaskScheduler.shared.submit(taskRequest)
+			log(message: "# TASKSHED # \(#line), \(#function) SCHEDULED \(taskIdentifier.backgroundTaskSchedulerIdentifier) at \(earliestBeginDate)")
 		} catch {
-			log(message: "# TASHSHED # Unable to schedule background task \(taskIdentifier.backgroundTaskSchedulerIdentifier): \(error)")
+			log(message: "# TASKSHED # FAILED TO SCHEDULE \(taskIdentifier.backgroundTaskSchedulerIdentifier): \(error)")
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -89,10 +89,15 @@ public class ENATaskScheduler {
 	// Task Handlers:
 	private func executeExposureDetectionRequest(_ task: BGTask) {
 		if task.identifier == ENATaskIdentifier.detectExposures.backgroundTaskSchedulerIdentifier,
-			(manager.preconditions().isGood == false || UIApplication.shared.backgroundRefreshStatus != .available) {
+			(manager.preconditions().authorized == false || UIApplication.shared.backgroundRefreshStatus != .available) {
+			logError(message: "Conditions for background task execution not met")
+			task.setTaskCompleted(success: false)
+			scheduleBackgroundTask(for: .detectExposures)
 			return
 		}
 		guard let taskDelegate = taskDelegate else {
+			task.setTaskCompleted(success: false)
+			scheduleBackgroundTask(for: .detectExposures)
 			return
 		}
 		taskDelegate.executeExposureDetectionRequest(task: task)
@@ -100,6 +105,8 @@ public class ENATaskScheduler {
 
 	private func executeFetchTestResults(_ task: BGTask) {
 		guard let taskDelegate = taskDelegate else {
+			task.setTaskCompleted(success: false)
+			scheduleBackgroundTask(for: .fetchTestResults)
 			return
 		}
 		taskDelegate.executeFetchTestResults(task: task)

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -45,7 +45,6 @@ protocol ENATaskExecutionDelegate: AnyObject {
 
 public class ENATaskScheduler {
 	weak var taskDelegate: ENATaskExecutionDelegate?
-	lazy var manager = ENAExposureManager()
 	lazy var notificationManager = LocalNotificationManager()
 	typealias CompletionHandler = (() -> Void)
 
@@ -88,13 +87,6 @@ public class ENATaskScheduler {
 
 	// Task Handlers:
 	private func executeExposureDetectionRequest(_ task: BGTask) {
-		if task.identifier == ENATaskIdentifier.detectExposures.backgroundTaskSchedulerIdentifier,
-			(manager.preconditions().authorized == false || UIApplication.shared.backgroundRefreshStatus != .available) {
-			logError(message: "Conditions for background task execution not met")
-			task.setTaskCompleted(success: false)
-			scheduleBackgroundTask(for: .detectExposures)
-			return
-		}
 		guard let taskDelegate = taskDelegate else {
 			task.setTaskCompleted(success: false)
 			scheduleBackgroundTask(for: .detectExposures)

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -63,30 +63,6 @@ public class ENATaskScheduler {
 		scheduleBackgroundTask(for: .fetchTestResults)
 	}
 
-	public func isBackgroundRefreshEnabled() -> Bool {
-		UIApplication.shared.backgroundRefreshStatus == .available
-	}
-
-	public func arePendingTasksScheduled(completionHandler: @escaping ((Bool) -> Void)) {
-		fetchPendingBackgroundTaskRequests { requests in
-			completionHandler(!requests.isEmpty)
-		}
-	}
-
-	public func fetchPendingBackgroundTaskRequests(completionHandler: @escaping (([BGTaskRequest]) -> Void)) {
-		BGTaskScheduler.shared.getPendingTaskRequests { requests in
-			completionHandler(requests)
-		}
-	}
-
-	public func listPendingTasks() {
-		self.fetchPendingBackgroundTaskRequests { requests in
-			requests.forEach { request in
-				log(message: "# TASKSHED # \(#line) \(#function) PENDING REQUEST \(request.identifier) at \(request.earliestBeginDate?.description(with: .current) ?? "<unknown>")")
-			}
-		}
-	}
-
 	public func cancelAllBackgroundTaskRequests() {
 		log(message: "# TASKSHED # \(#line), \(#function)")
 		BGTaskScheduler.shared.cancelAllTaskRequests()

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -29,7 +29,7 @@ public enum ENATaskIdentifier: String, CaseIterable {
 		// set to trigger every 2 hours
 		case .detectExposures: return 2 * 60 * 60
 		// set to trigger every 30 min
-		case .fetchTestResults: return 30 * 60
+		case .fetchTestResults: return 2 * 60 * 60
 		// set to trigger every 15 min
 		case .SIMPLETEST: return 15 * 60
 		}

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -22,11 +22,11 @@ import UIKit
 public enum ENATaskIdentifier: String, CaseIterable {
 	case exposureNotification = "exposure-notification"
 	case fetchTestResults = "fetch-test-results"
+	case SIMPLETEST = "SIMPLETEST"
 
 	var backgroundTaskScheduleInterval: TimeInterval {
 		switch self {
-		case .exposureNotification: return 15 * 60 // 2 * 60 * 60 // set to trigger every 2 hours
-		case .fetchTestResults: return 5 * 60 // 30 * 60     // set to trigger every 30 min
+		case .SIMPLETEST: return 15 * 60
 		}
 	}
 
@@ -36,8 +36,9 @@ public enum ENATaskIdentifier: String, CaseIterable {
 }
 
 protocol ENATaskExecutionDelegate: AnyObject {
-	func executeExposureDetectionRequest(task: BGTask, completionHandler: (Bool) -> Void)
-	func executeFetchTestResults(task: BGTask, completionHandler: (Bool) -> Void)
+	func executeExposureDetectionRequest(task: BGTask)
+	func executeFetchTestResults(task: BGTask)
+	func executeSIMPLETEST(task: BGTask)
 }
 
 public class ENATaskScheduler {
@@ -51,6 +52,7 @@ public class ENATaskScheduler {
 		cancelAllBackgroundTaskRequests()
 		registerTask(with: .exposureNotification, taskHander: executeExposureDetectionRequest(_:))
 		registerTask(with: .fetchTestResults, taskHander: executeFetchTestResults(_:))
+		registerTask(with: .SIMPLETEST, taskHander: executeSIMPLETEST(_:))
 		log(message: "# TASKSHED # \(#line), \(#function) COMPLETED")
 	}
 
@@ -59,6 +61,7 @@ public class ENATaskScheduler {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
 		scheduleBackgroundTask(for: .exposureNotification)
 		scheduleBackgroundTask(for: .fetchTestResults)
+		scheduleBackgroundTask(for: .SIMPLETEST)
 	}
 
 	public func isBackgroundRefreshEnabled() -> Bool {
@@ -120,9 +123,7 @@ public class ENATaskScheduler {
 			log(message: "# TASKSHED # \(#line), \(#function) taskDelegate = nil")
 			return
 		}
-		taskDelegate.executeExposureDetectionRequest(task: task) { success in
-			task.setTaskCompleted(success: success)
-		}
+		taskDelegate.executeExposureDetectionRequest(task: task)
 	}
 
 	private func executeFetchTestResults(_ task: BGTask) {
@@ -132,8 +133,16 @@ public class ENATaskScheduler {
 			log(message: "# TASKSHED # \(#line), \(#function) taskDelegate = nil")
 			return
 		}
-		taskDelegate.executeFetchTestResults(task: task) { success in
-			task.setTaskCompleted(success: success)
+		taskDelegate.executeFetchTestResults(task: task)
 		}
+
+	private func executeSIMPLETEST(_ task: BGTask) {
+		let scheduler: ENATaskScheduler? = self
+		log(message: "# TASKSHED # \(#line), \(#function) taskScheduler = \(String(describing: scheduler))")
+		guard let taskDelegate = taskDelegate else {
+			log(message: "# TASKSHED # \(#line), \(#function) taskDelegate = nil")
+			return
+		}
+		taskDelegate.executeSIMPLETEST(task: task)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -20,9 +20,10 @@ import ExposureNotification
 import UIKit
 
 public enum ENATaskIdentifier: String, CaseIterable {
+	// only one task identifier is allowed have the .exposure-notification suffix
 	case detectExposures = "detect-exposures.exposure-notification"
-	case fetchTestResults = "fetch-test-results.exposure-notification"
-	case SIMPLETEST = "SIMPLETEST.exposure-notification"
+	case fetchTestResults = "fetch-test-results"
+	case SIMPLETEST = "SIMPLETEST"
 
 	var backgroundTaskScheduleInterval: TimeInterval {
 		switch self {

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -20,12 +20,17 @@ import ExposureNotification
 import UIKit
 
 public enum ENATaskIdentifier: String, CaseIterable {
-	case exposureNotification = "exposure-notification"
-	case fetchTestResults = "fetch-test-results"
-	case SIMPLETEST = "SIMPLETEST"
+	case detectExposures = "detect-exposures.exposure-notification"
+	case fetchTestResults = "fetch-test-results.exposure-notification"
+	case SIMPLETEST = "SIMPLETEST.exposure-notification"
 
 	var backgroundTaskScheduleInterval: TimeInterval {
 		switch self {
+		// set to trigger every 2 hours
+		case .detectExposures: return 2 * 60 * 60
+		// set to trigger every 30 min
+		case .fetchTestResults: return 30 * 60
+		// set to trigger every 15 min
 		case .SIMPLETEST: return 15 * 60
 		}
 	}
@@ -50,7 +55,7 @@ public class ENATaskScheduler {
 	public func registerBackgroundTaskRequests() {
 		log(message: "# TASKSHED # \(#line), \(#function) STARTED")
 		cancelAllBackgroundTaskRequests()
-		registerTask(with: .exposureNotification, taskHander: executeExposureDetectionRequest(_:))
+		registerTask(with: .detectExposures, taskHander: executeExposureDetectionRequest(_:))
 		registerTask(with: .fetchTestResults, taskHander: executeFetchTestResults(_:))
 		registerTask(with: .SIMPLETEST, taskHander: executeSIMPLETEST(_:))
 		log(message: "# TASKSHED # \(#line), \(#function) COMPLETED")
@@ -59,7 +64,7 @@ public class ENATaskScheduler {
 	public func scheduleBackgroundTaskRequests() {
 		log(message: "# TASKSHED # \(#line), \(#function)")
 		BGTaskScheduler.shared.cancelAllTaskRequests()
-		scheduleBackgroundTask(for: .exposureNotification)
+		scheduleBackgroundTask(for: .detectExposures)
 		scheduleBackgroundTask(for: .fetchTestResults)
 		scheduleBackgroundTask(for: .SIMPLETEST)
 	}
@@ -95,7 +100,7 @@ public class ENATaskScheduler {
 	public func scheduleBackgroundTask(for taskIdentifier: ENATaskIdentifier) {
 		log(message: "# TASKSHED # \(#line), \(#function) SCHEDULING \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
 
-		if taskIdentifier == .exposureNotification, manager.preconditions().isGood == false || UIApplication.shared.backgroundRefreshStatus != .available {
+		if taskIdentifier == .detectExposures, manager.preconditions().isGood == false || UIApplication.shared.backgroundRefreshStatus != .available {
 			log(message: "# TASKSHED # \(#line), \(#function) UNABLE TO SCHEDULE \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
 			return
 		}
@@ -134,7 +139,7 @@ public class ENATaskScheduler {
 			return
 		}
 		taskDelegate.executeFetchTestResults(task: task)
-		}
+	}
 
 	private func executeSIMPLETEST(_ task: BGTask) {
 		let scheduler: ENATaskScheduler? = self

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -23,7 +23,6 @@ public enum ENATaskIdentifier: String, CaseIterable {
 	// only one task identifier is allowed have the .exposure-notification suffix
 	case detectExposures = "detect-exposures.exposure-notification"
 	case fetchTestResults = "fetch-test-results"
-	case SIMPLETEST = "SIMPLETEST"
 
 	var backgroundTaskScheduleInterval: TimeInterval {
 		switch self {
@@ -31,8 +30,6 @@ public enum ENATaskIdentifier: String, CaseIterable {
 		case .detectExposures: return 2 * 60 * 60
 		// set to trigger every 30 min
 		case .fetchTestResults: return 2 * 60 * 60
-		// set to trigger every 15 min
-		case .SIMPLETEST: return 15 * 60
 		}
 	}
 
@@ -44,7 +41,6 @@ public enum ENATaskIdentifier: String, CaseIterable {
 protocol ENATaskExecutionDelegate: AnyObject {
 	func executeExposureDetectionRequest(task: BGTask)
 	func executeFetchTestResults(task: BGTask)
-	func executeSIMPLETEST(task: BGTask)
 }
 
 public class ENATaskScheduler {
@@ -57,7 +53,6 @@ public class ENATaskScheduler {
 		log(message: "# TASKSHED # \(#line), \(#function) STARTED")
 		registerTask(with: .detectExposures, taskHander: executeExposureDetectionRequest(_:))
 		registerTask(with: .fetchTestResults, taskHander: executeFetchTestResults(_:))
-		registerTask(with: .SIMPLETEST, taskHander: executeSIMPLETEST(_:))
 		log(message: "# TASKSHED # \(#line), \(#function) COMPLETED")
 	}
 
@@ -66,7 +61,6 @@ public class ENATaskScheduler {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
 		scheduleBackgroundTask(for: .detectExposures)
 		scheduleBackgroundTask(for: .fetchTestResults)
-		scheduleBackgroundTask(for: .SIMPLETEST)
 	}
 
 	public func isBackgroundRefreshEnabled() -> Bool {
@@ -147,13 +141,4 @@ public class ENATaskScheduler {
 		taskDelegate.executeFetchTestResults(task: task)
 	}
 
-	private func executeSIMPLETEST(_ task: BGTask) {
-		let scheduler: ENATaskScheduler? = self
-		log(message: "# TASKSHED # \(#line), \(#function) taskScheduler = \(String(describing: scheduler))")
-		guard let taskDelegate = taskDelegate else {
-			log(message: "# TASKSHED # \(#line), \(#function) taskDelegate = nil")
-			return
-		}
-		taskDelegate.executeSIMPLETEST(task: task)
-	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -66,7 +66,7 @@ public class ENATaskScheduler {
 
 	private func registerTask(with taskIdentifier: ENATaskIdentifier, taskHander: @escaping ((BGTask) -> Void)) {
 		let identifierString = taskIdentifier.backgroundTaskSchedulerIdentifier
-		BGTaskScheduler.shared.register(forTaskWithIdentifier: identifierString, using: nil) { task in
+		BGTaskScheduler.shared.register(forTaskWithIdentifier: identifierString, using: .main) { task in
 			taskHander(task)
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -109,11 +109,6 @@ public class ENATaskScheduler {
 	public func scheduleBackgroundTask(for taskIdentifier: ENATaskIdentifier) {
 		log(message: "# TASKSHED # \(#line), \(#function) SCHEDULING \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
 
-		if taskIdentifier == .detectExposures, manager.preconditions().isGood == false || UIApplication.shared.backgroundRefreshStatus != .available {
-			log(message: "# TASKSHED # \(#line), \(#function) UNABLE TO SCHEDULE \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
-			return
-		}
-
 		let earliestBeginDate = Date(timeIntervalSinceNow: taskIdentifier.backgroundTaskScheduleInterval)
 		let taskRequest = BGProcessingTaskRequest(identifier: taskIdentifier.backgroundTaskSchedulerIdentifier)
 		taskRequest.requiresNetworkConnectivity = true
@@ -129,6 +124,10 @@ public class ENATaskScheduler {
 
 	// Task Handlers:
 	private func executeExposureDetectionRequest(_ task: BGTask) {
+//		if taskIdentifier == .detectExposures, manager.preconditions().isGood == false || UIApplication.shared.backgroundRefreshStatus != .available {
+//			log(message: "# TASKSHED # \(#line), \(#function) UNABLE TO SCHEDULE \(taskIdentifier.backgroundTaskSchedulerIdentifier)")
+//			return
+//		}
 		let scheduler: ENATaskScheduler? = self
 		log(message: "# TASKSHED # \(#line), \(#function) taskScheduler = \(String(describing: scheduler))")
 		guard let taskDelegate = taskDelegate else {

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/LocalNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/LocalNotificationManager.swift
@@ -57,6 +57,7 @@ class LocalNotificationManager {
 			switch taskId {
 			case .exposureNotification: openActionIdentifier = LocalNotificationAction.openExposureDetectionResults
 			case .fetchTestResults: openActionIdentifier = LocalNotificationAction.openTestResults
+			default: openActionIdentifier = LocalNotificationAction.ignore
 			}
 
 			let viewAction = UNNotificationAction(

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/LocalNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/LocalNotificationManager.swift
@@ -55,7 +55,7 @@ class LocalNotificationManager {
 		if let taskId = ENATaskIdentifier(rawValue: identifier) {
 			let openActionIdentifier: LocalNotificationAction
 			switch taskId {
-			case .exposureNotification: openActionIdentifier = LocalNotificationAction.openExposureDetectionResults
+			case .detectExposures: openActionIdentifier = LocalNotificationAction.openExposureDetectionResults
 			case .fetchTestResults: openActionIdentifier = LocalNotificationAction.openTestResults
 			default: openActionIdentifier = LocalNotificationAction.ignore
 			}

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -233,6 +233,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 	func sceneWillResignActive(_: UIScene) {
 		showPrivacyProtectionWindow()
+		taskScheduler.scheduleBackgroundTaskRequests()
 	}
 
 	private var privacyProtectionWindow: UIWindow?

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -234,6 +234,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 	func sceneWillResignActive(_: UIScene) {
 		showPrivacyProtectionWindow()
+	}
+
+	func sceneDidEnterBackground(_ scene: UIScene) {
 		taskScheduler.scheduleBackgroundTaskRequests()
 	}
 

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -18,6 +18,7 @@
 import BackgroundTasks
 import ExposureNotification
 import UIKit
+import Reachability
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	// MARK: Properties
@@ -233,6 +234,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	func sceneWillResignActive(_: UIScene) {
+		log(message: "# TASKSHED # \(#line) \(#function) ExternalPower == \(UIDevice.current.batteryState != .unplugged) (UIDevice.current.batteryState == \(UIDevice.current.batteryState.rawValue), .unplugged==1)")
+		do {
+			let reach = try Reachability()
+			log(message: "# TASKSHED # \(#line) \(#function) NetworkConnectivity == \(reach.connection != .unavailable) (Reachability().connection == \(reach.connection))")
+		} catch {
+			log(message: "# TASKSHED # \(#line) \(#function) NetworkConnectivity == <unknown>")
+		}
+
 		showPrivacyProtectionWindow()
 		taskScheduler.scheduleBackgroundTaskRequests()
 		taskScheduler.listPendingTasks()

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -230,7 +230,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	func sceneDidBecomeActive(_: UIScene) {
 		hidePrivacyProtectionWindow()
 		UIApplication.shared.applicationIconBadgeNumber = 0
-		taskScheduler.listPendingTasks()
 	}
 
 	func sceneWillResignActive(_: UIScene) {
@@ -244,7 +243,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 		showPrivacyProtectionWindow()
 		taskScheduler.scheduleBackgroundTaskRequests()
-		taskScheduler.listPendingTasks()
 	}
 
 	private var privacyProtectionWindow: UIWindow?

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -100,7 +100,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		exposureManager.resume(observer: self)
 
 		UNUserNotificationCenter.current().delegate = self
-		taskScheduler.scheduleBackgroundTaskRequests()
 
 		setupUI()
 

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -305,7 +305,7 @@ extension SceneDelegate: UNUserNotificationCenterDelegate {
 
 	func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
 		switch response.notification.request.identifier {
-		case ENATaskIdentifier.exposureNotification.backgroundTaskSchedulerIdentifier:
+		case ENATaskIdentifier.detectExposures.backgroundTaskSchedulerIdentifier:
 			log(message: "Handling notification for \(response.notification.request.identifier)")
 
 			switch response.actionIdentifier {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -229,11 +229,13 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	func sceneDidBecomeActive(_: UIScene) {
 		hidePrivacyProtectionWindow()
 		UIApplication.shared.applicationIconBadgeNumber = 0
+		taskScheduler.listPendingTasks()
 	}
 
 	func sceneWillResignActive(_: UIScene) {
 		showPrivacyProtectionWindow()
 		taskScheduler.scheduleBackgroundTaskRequests()
+		taskScheduler.listPendingTasks()
 	}
 
 	private var privacyProtectionWindow: UIWindow?

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -233,14 +233,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	func sceneWillResignActive(_: UIScene) {
-		log(message: "# TASKSHED # \(#line) \(#function) ExternalPower == \(UIDevice.current.batteryState != .unplugged) (UIDevice.current.batteryState == \(UIDevice.current.batteryState.rawValue), .unplugged==1)")
-		do {
-			let reach = try Reachability()
-			log(message: "# TASKSHED # \(#line) \(#function) NetworkConnectivity == \(reach.connection != .unavailable) (Reachability().connection == \(reach.connection))")
-		} catch {
-			log(message: "# TASKSHED # \(#line) \(#function) NetworkConnectivity == <unknown>")
-		}
-
 		showPrivacyProtectionWindow()
 		taskScheduler.scheduleBackgroundTaskRequests()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -92,12 +92,6 @@ final class HomeInteractor {
 
 		// TODO: handle state of pending scheduled tasks to determin active state for manual refresh button
 		// TODO: disable manual trigger button
-		taskScheduler.arePendingTasksScheduled { tasksAreSecheduled in
-			if tasksAreSecheduled {
-				// TODO: enable manual trigger button
-			}
-		}
-
 		guard let indexPath = indexPathForRiskCell() else { return }
 		riskConfigurator?.startLoading()
 		homeViewController.reloadCell(at: indexPath)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction.swift
@@ -66,18 +66,18 @@ final class ExposureDetectionTransaction {
 
 	func start(taskCompletion: (() -> Void)? = nil) {
 		let today = formattedToday()
-		client.availableDaysAndHoursUpUntil(today) { result in
+		client.availableDaysAndHoursUpUntil(today) { [weak self] result in
 			switch result {
 			case let .success(daysAndHours):
-				self.continueWith(remoteDaysAndHours: daysAndHours) {
+				self?.continueWith(remoteDaysAndHours: daysAndHours) {
 					taskCompletion?()
 				}
 			case .failure:
-				self.endPrematurely(reason: .noDaysAndHours)
+				self?.endPrematurely(reason: .noDaysAndHours)
 				taskCompletion?()
 
 			}
-		}
+		} 
 	}
 
 	// MARK: Working with the Delegate

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction.swift
@@ -67,15 +67,18 @@ final class ExposureDetectionTransaction {
 	func start(taskCompletion: (() -> Void)? = nil) {
 		let today = formattedToday()
 		client.availableDaysAndHoursUpUntil(today) { [weak self] result in
+			guard let self = self else {
+				taskCompletion?()
+				return
+			}
 			switch result {
 			case let .success(daysAndHours):
-				self?.continueWith(remoteDaysAndHours: daysAndHours) {
+				self.continueWith(remoteDaysAndHours: daysAndHours) {
 					taskCompletion?()
 				}
 			case .failure:
-				self?.endPrematurely(reason: .noDaysAndHours)
+				self.endPrematurely(reason: .noDaysAndHours)
 				taskCompletion?()
-
 			}
 		} 
 	}
@@ -118,7 +121,10 @@ final class ExposureDetectionTransaction {
 				return
 			}
 			self.remoteExposureConfiguration { [weak self] configuration in
-				guard let self = self else { return }
+				guard let self = self else {
+					taskCompletion?()
+					return
+				}
 				do {
 					let writer = try self.createAppleFilesWriter()
 					self.detectExposures(writer: writer, configuration: configuration) {
@@ -194,7 +200,10 @@ final class ExposureDetectionTransaction {
 		taskCompletion: (() -> Void)? = nil
 	) {
 		writer.with { [weak self] diagnosisURLs, done in
-			guard let self = self else { return }
+			guard let self = self else {
+				taskCompletion?()
+				return
+			}
 			self._detectExposures(
 				diagnosisKeyURLs: diagnosisURLs,
 				configuration: configuration,

--- a/src/xcode/ENA/ENA/Source/Workers/Flogger.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Flogger.swift
@@ -24,6 +24,7 @@ public class Flogger {
 	init(isOn: Bool) {
 		self.isOn = isOn
 		queue.maxConcurrentOperationCount = 1
+		reset()
 	}
 
 	private lazy var url: URL = {

--- a/src/xcode/ENA/ENA/Source/Workers/Flogger.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Flogger.swift
@@ -1,0 +1,84 @@
+//
+//  Flogger.swift
+//  ENA
+//
+//  Created by Dunne, Liam on 24/05/2020.
+//  Copyright © 2020 SAP SE. All rights reserved.
+//
+
+import Foundation
+import BackgroundTasks
+
+public class Flogger {
+	static let shared = Flogger(isOn: true)
+	public static func write(_ trace: String, message: String? = nil) {
+		shared.write(trace, message: message)
+	}
+	public static func read() {
+		shared.read()
+	}
+	
+	private var isOn: Bool = false
+	private var didReset: Bool = false
+	private let queue = OperationQueue()
+	init(isOn: Bool) {
+		self.isOn = isOn
+		queue.maxConcurrentOperationCount = 1
+	}
+
+	private lazy var url: URL = {
+		// swiftlint:disable:next force_unwrapping
+        return  FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last!.appendingPathComponent("log.txt")
+	}()
+
+	public func reset() {
+		guard didReset == false else { return }
+		didReset = true
+		guard FileManager.default.fileExists(atPath: url.path) else { return }
+		do {
+			try FileManager.default.removeItem(atPath: url.path)
+		} catch {
+			logError(message: error.localizedDescription)
+		}
+	}
+    public func write(_ trace: String, message: String? = nil) {
+		guard isOn else { return }
+		let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let timestamp = formatter.string(from: Date())
+        var logMessage = "\(timestamp): \(trace)"
+		if let message = message { logMessage += "\n\t\(message)" }
+		queue.addOperation {
+			self.write(logMessage)
+		}
+    }
+    public func read() {
+		guard isOn else { return }
+        print("#", #line, #function)
+        print("########################")
+        do {
+            let result = try String(contentsOf: url as URL, encoding: String.Encoding.utf8)
+            print(result)
+        } catch {
+            print(error)
+        }
+        print("########################")
+    }
+    private func write(_ message: String) {
+		do {
+		let outputMessage = message + "\n"
+			guard let data = outputMessage.data(using: String.Encoding.utf8) else { return }
+			if FileManager.default.fileExists(atPath: url.path) {
+				if let fileHandle = try? FileHandle(forWritingTo: url) {
+					fileHandle.seekToEndOfFile()
+					fileHandle.write(data)
+					fileHandle.closeFile()
+				}
+			} else {
+				try data.write(to: url, options: .atomicWrite)
+			}
+		} catch {
+			logError(message: error.localizedDescription)
+		}
+    }
+}

--- a/src/xcode/ENA/ENA/Source/Workers/Logger.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logger.swift
@@ -20,6 +20,7 @@ import Foundation
 let appLogger = Logger()
 
 func log(message: String, level _: LogLevel = .info, file _: String = #file, line _: UInt = #line, function _: String = #function) {
+	Flogger.write(message)
 	NSLog("%@", message)
 }
 


### PR DESCRIPTION
Updated the handling of background tasks in conjunction with ExposureDetectionTransaction

What was needed:
- The previous implementation of ExposureDetectionTransaction used notifications to indicate when the detectExposures() had returned. This caused an issue for the BGTask handling, as it's a requirement of the task execution that it calls setTaskComplete to ensure that if the task expires, the system doesn't end up killing the app.
  - This we accomplished using an optional taskCompletion block passed through from ExposureDetectionTransaction's start() through to _detectExposures():

```
func start(taskCompletion: (() -> Void)? = nil)
private func continueWith(remoteDaysAndHours: Client.DaysAndHours, taskCompletion: (() -> Void)? = nil)
private func detectExposures(writer: AppleFilesWriter, configuration: ENExposureConfiguration, taskCompletion: (() -> Void)? = nil)
private func _detectExposures(diagnosisKeyURLs: [URL], configuration: ENExposureConfiguration, completion: @escaping () -> Void, taskCompletion: (() -> Void)? = nil)
```

Also included:
- Basic test background task to ensure the core functionality is working
- File logging for logging the background tasks activity


Summary of updates:
- Added optional taskCompletion block to ExposureDetectionTransaction start methods()
  - This is to allow the ExposureDetectionTransaction to report back to the bgTask it was called from, allowing it to setTaskComplete(_:), as is required by the API
- Added default handler for LocalNotificationAction
  - Uses ignore as the default action, if not specified
- Added SIMPLETEST
  - This is a basic background task, scheduled every 15 min. **Only used for testing purposes**
- Updated ENATaskExecutionDelegate methods
  - We handle task completion in the taskDelegate, so it's no longer necessary in the taskScheduler
- Updated implementation of taskScheduler in AppDelegate
  - backgroundTaskIdentifier is now an var in enum ENATaskIdentifier
  - AppDelegate is the taskDelegate
  - Added the ENATaskExecutionDelegate protocol methods to the AppDelegate
- Added SIMPLETEST as an additional BGTaskSchedulerPermittedIdentifier
  - **Only used for testing purposes**
- Changed .exposureNotification to .detectExposures for clarity
  - Removes confusion as to which ENATaskIdentifier is which
- Appended ".exposure-notification" to all bg tasks
  - This ensures the tasks use the BackgroundTask & ExposureNotification framework's background task prioritization
- Added Flogger to project
  - **Only used for testing purposes**
