### PR TITLE
Update SceneDelegate.swift

### DIFF
--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -125,6 +125,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}
 
 	private func showHome(animated _: Bool = false) {
+		#if targetEnvironment(simulator)
+		// Enable third party contributors that do not have the required
+		// entitlements to skip the exposure setup step in the iOS Simulator
+		presentHomeVC()
+		#else
 		if exposureManager.preconditions().active {
 			presentHomeVC()
 		} else {
@@ -138,6 +143,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 				self?.presentHomeVC()
 			}
 		}
+		#endif
 	}
 
 	private func presentHomeVC() {


### PR DESCRIPTION
Enable third party contributors that do not have the required entitlements to skip the exposure setup step in the iOS Simulator. See #35