### PR TITLE
fix: Show ExposureSubmissionTestResultViewController after inputting TAN

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureSubmission.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureSubmission.storyboard
@@ -57,6 +57,7 @@
                         <outlet property="tanInput" destination="pJo-7q-izL" id="L25-fC-HNa"/>
                         <segue destination="JPa-EJ-yrk" kind="show" identifier="sentSegue" id="HlT-ix-3R2"/>
                         <segue destination="IeT-ta-YWf" kind="show" identifier="warnOthersSegue" id="aeq-iH-Hkk"/>
+                        <segue destination="efh-V6-b47" kind="show" identifier="labResultsSegue" id="n8Y-d3-Pny"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cv3-qo-bBS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -160,7 +161,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Positionieren Sie den Rahmen über dem QR Code Ihres Dokuments" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aTI-P6-3Zh" customClass="DynamicTypeLabel" customModule="ENA" customModuleProvider="target">
-                                <rect key="frame" x="62" y="147" width="290" height="41"/>
+                                <rect key="frame" x="62" y="145.5" width="290" height="42.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -313,8 +314,9 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="5YR-5A-F8h"/>
-        <segue reference="7vS-vS-v87"/>
+        <segue reference="HlT-ix-3R2"/>
+        <segue reference="aeq-iH-Hkk"/>
+        <segue reference="n8Y-d3-Pny"/>
         <segue reference="TMI-YH-9ne"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
@@ -115,6 +115,7 @@ extension ExposureSubmissionTanInputViewController: ExposureSubmissionNavigation
 	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 		if segue.identifier == Segue.labResultsSegue.rawValue,
 			let vc = segue.destination as? ExposureSubmissionTestResultViewController {
+			vc.exposureSubmissionService = exposureSubmissionService
 			vc.testResult = .positive
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
@@ -76,7 +76,7 @@ class ExposureSubmissionTanInputViewController: UIViewController, SpinnerInjecta
 extension ExposureSubmissionTanInputViewController {
 	enum Segue: String, SegueIdentifiers {
 		case sentSegue
-		case warnOthers = "warnOthersSegue"
+		case labResultsSegue
 	}
 }
 
@@ -99,7 +99,7 @@ extension ExposureSubmissionTanInputViewController: ExposureSubmissionNavigation
 					return
 				case .success:
 					self.performSegue(
-						withIdentifier: Segue.warnOthers,
+						withIdentifier: Segue.labResultsSegue,
 						sender: self
 					)
 				}
@@ -110,5 +110,12 @@ extension ExposureSubmissionTanInputViewController: ExposureSubmissionNavigation
 
 	func tanChanged(isValid: Bool) {
 		setButtonEnabled(enabled: isValid)
+	}
+
+	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+		if segue.identifier == Segue.labResultsSegue.rawValue,
+			let vc = segue.destination as? ExposureSubmissionTestResultViewController {
+			vc.testResult = .positive
+		}
 	}
 }


### PR DESCRIPTION
Added a segue between the Exposure Submission - TAN Input screen & the Test Result screen. Now, after entering your TAN, you will get shown in a screen that you are positive (same flow as from the QR code flow).