### PR TITLE
reduce complexity of Exposure Manager state

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -30,22 +30,19 @@ struct ExposureManagerState {
 	init(
 		authorized: Bool = false,
 		enabled: Bool = false,
-		active: Bool = false,
-		bluetoothOff: Bool = false
+		status: ENStatus = .unknown
 	) {
 		self.authorized = authorized
 		self.enabled = enabled
-		self.active = active
-		self.bluetoothOff = bluetoothOff
+		self.status = status
 	}
 
 	// MARK: Properties
 
 	let authorized: Bool
 	let enabled: Bool
-	let active: Bool
-	let bluetoothOff: Bool
-	var isGood: Bool { authorized && enabled && active }
+	let status: ENStatus
+	var isGood: Bool { authorized && enabled && status == .active }
 }
 
 @objc protocol Manager: NSObjectProtocol {
@@ -168,8 +165,7 @@ final class ENAExposureManager: NSObject, ExposureManager {
 		.init(
 			authorized: type(of: manager).authorizationStatus == .authorized,
 			enabled: manager.exposureNotificationEnabled,
-			active: manager.exposureNotificationStatus == .active,
-			bluetoothOff: manager.exposureNotificationStatus == .bluetoothOff
+			status: manager.exposureNotificationStatus
 		)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
@@ -90,9 +90,9 @@ final class ENStateTests: XCTestCase {
 		assert(mockDelegate.getCurrentState() == .disabled)
 	}
 
-	func testDisableTracingAndBluetoothOffAndInternetOn() {
+	func testDisableTracingAndBluetoothOnAndInternetOn() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .disabled)
 		mockDelegate.exposureManagerState = exposureManagerState
 		mockDelegate.reachabilityChanged(false)
 		assert(mockDelegate.getCurrentState() == .disabled)
@@ -100,7 +100,7 @@ final class ENStateTests: XCTestCase {
 		assert(mockDelegate.getCurrentState() == .disabled)
 	}
 
-	func testEnableTracingAndBluetoothOffAndInternetOff() {
+	func testEnableTracingStepByStep() {
 		assert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
@@ -114,5 +114,19 @@ final class ENStateTests: XCTestCase {
 		assert(mockDelegate.getCurrentState() == .internetOff)
 		mockDelegate.reachabilityChanged(true)
 		assert(mockDelegate.getCurrentState() == .enabled)
+	}
+
+	// MARK: Tests different ENStatus states
+
+	func testRestrictedState() {
+		exposureManagerState = ExposureManagerState(authorized: false, enabled: false, status: .restricted)
+		mockDelegate.exposureManagerState = exposureManagerState
+		assert(mockDelegate.getCurrentState() == .disabled)
+	}
+
+	func testUnknownState() {
+		exposureManagerState = ExposureManagerState(authorized: false, enabled: false, status: .unknown)
+		mockDelegate.exposureManagerState = exposureManagerState
+		assert(mockDelegate.getCurrentState() == .disabled)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
@@ -26,7 +26,7 @@ final class ENStateTests: XCTestCase {
 	// setup stateHandler to be in enabled state
 	override func setUp() {
 		super.setUp()
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, active: true, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .active)
 		mockDelegate = MockStateHandlerObserverDelegate(exposureManagerState: exposureManagerState)
 	}
 
@@ -44,7 +44,7 @@ final class ENStateTests: XCTestCase {
 	// statehandler should reflect disabled state
 	func testDisableTracing() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, active: false, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .disabled)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .disabled)
 	}
@@ -54,7 +54,7 @@ final class ENStateTests: XCTestCase {
 	// when statehandler is enabled bluetooth is turnedOff statehandler should be bluetooth off
 	func testTurnOffBluetooth() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, active: false, bluetoothOff: true)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .bluetoothOff)
 	}
@@ -63,7 +63,7 @@ final class ENStateTests: XCTestCase {
 
 	// when internet is turned off and turned on again
 	func testTurnOffTurnOnInternet() {
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, active: true, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .active)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .enabled)
 		mockDelegate.reachabilityChanged(false)
@@ -76,7 +76,7 @@ final class ENStateTests: XCTestCase {
 
 	func testDisableTracingAndBluetoothOff() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, active: false, bluetoothOff: true)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .disabled)
 	}
@@ -85,14 +85,14 @@ final class ENStateTests: XCTestCase {
 		assert(mockDelegate.getCurrentState() == .enabled)
 		mockDelegate.reachabilityChanged(false)
 		assert(mockDelegate.getCurrentState() == .internetOff)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, active: false, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .disabled)
 	}
 
 	func testDisableTracingAndBluetoothOffAndInternetOn() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, active: false, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		mockDelegate.reachabilityChanged(false)
 		assert(mockDelegate.getCurrentState() == .disabled)
@@ -102,14 +102,14 @@ final class ENStateTests: XCTestCase {
 
 	func testEnableTracingAndBluetoothOffAndInternetOff() {
 		assert(mockDelegate.getCurrentState() == .enabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, active: false, bluetoothOff: true)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		mockDelegate.reachabilityChanged(false)
 		assert(mockDelegate.getCurrentState() == .disabled)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, active: false, bluetoothOff: true)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .bluetoothOff)
-		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, active: true, bluetoothOff: false)
+		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .active)
 		mockDelegate.exposureManagerState = exposureManagerState
 		assert(mockDelegate.getCurrentState() == .internetOff)
 		mockDelegate.reachabilityChanged(true)

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/Mocks/MockExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/Mocks/MockExposureManager.swift
@@ -53,7 +53,7 @@ extension MockExposureManager: ExposureManager {
 	}
 
 	func preconditions() -> ExposureManagerState {
-		ExposureManagerState(authorized: true, enabled: true, active: true, bluetoothOff: false)
+		ExposureManagerState(authorized: true, enabled: true, status: .active)
 	}
 
 	func detectExposures(configuration _: ENExposureConfiguration, diagnosisKeyURLs _: [URL], completionHandler _: @escaping ENDetectExposuresHandler) -> Progress {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -130,7 +130,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		// entitlements to skip the exposure setup step in the iOS Simulator
 		presentHomeVC()
 		#else
-		if exposureManager.preconditions().active {
+		if exposureManager.preconditions().status == .active {
 			presentHomeVC()
 		} else {
 			log(message: "ExposureManager not activate yet.")
@@ -279,7 +279,7 @@ extension SceneDelegate: ENAExposureManagerObserver {
 		New status of EN framework:
 		Authorized: \(newState.authorized)
 		enabled: \(newState.enabled)
-		active: \(newState.active)
+		status: \(newState.status)
 		"""
 		log(message: message)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
@@ -74,21 +74,26 @@ class ENStateHandler {
 	}
 
 	private func determineCurrentState(from enManagerState: ExposureManagerState) -> RiskDetectionState {
-		if enManagerState.active == true {
+
+		switch enManagerState.status {
+		case .active:
 			guard !internetOff else {
 				return .internetOff
 			}
 			return .enabled
-		} else {
-			if enManagerState.enabled == true {
-				if enManagerState.bluetoothOff == true {
-					return .bluetoothOff
-				} else {
-					return .disabled
-				}
-			} else {
+		case .bluetoothOff:
+			guard !enManagerState.enabled == false else {
 				return .disabled
 			}
+			return .bluetoothOff
+		case .disabled:
+			return .disabled
+		case .restricted:
+			return .disabled
+		case .unknown:
+			return .disabled
+		@unknown default:
+			fatalError("New state was added that is not being covered by ENStateHandler")
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -184,7 +184,7 @@ final class HomeViewController: UIViewController {
 			return
 		}
 
-		guard status.active else {
+		guard status.status == .active else {
 			activate(then: enableIfNeeded)
 			return
 		}


### PR DESCRIPTION
ENStatus can have restricted state, which might be caused by parental controls. Therefore we need to propagate ENStatus to the respective view controllers and not hide it in Exposure Manager. 