### PR TITLE
[Bug] Fix Readability of Content when using Dynamic Type

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
@@ -216,7 +216,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="0Sp-0h-6O3">
                                                     <rect key="frame" x="20" y="16" width="334" height="45.5"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZsC-uh-ys5" customClass="DynamicTypeLabel" customModule="ENA" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZsC-uh-ys5" customClass="DynamicTypeLabel" customModule="ENA" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="334" height="26.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <color key="textColor" name="textPrimary1"/>
@@ -228,7 +228,7 @@
                                                                 <userDefinedRuntimeAttribute type="string" keyPath="dynamicTypeWeight" value="bold"/>
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0XD-bP-Gpw" customClass="DynamicTypeLabel" customModule="ENA" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0XD-bP-Gpw" customClass="DynamicTypeLabel" customModule="ENA" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="27.5" width="334" height="18"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <color key="textColor" name="textPrimary2"/>

--- a/src/xcode/ENA/ENA/Resources/Storyboards/RiskLegend.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/RiskLegend.storyboard
@@ -85,7 +85,7 @@
                                                                 <constraint firstAttribute="height" constant="10" id="TjA-Xw-1BU"/>
                                                             </constraints>
                                                         </view>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brZ-DM-0H9">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brZ-DM-0H9">
                                                             <rect key="frame" x="0.0" y="16" width="300" height="20"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <nil key="textColor"/>


### PR DESCRIPTION
Set numberOfLines in `ExposureDetection` and `RiskLegend` to 0 to let the content scale and make it fully readable when using Dynamic Type. 

To test this use Xcode's environment overrides settings, enable Dynamic Type and set a large font size or change your device setting to use a large font size. 

# `ExposureDetection`
| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-31 at 15 37 25](https://user-images.githubusercontent.com/26111180/83353719-d5563b00-a354-11ea-81d9-f10e0f600f9b.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-31 at 15 36 23](https://user-images.githubusercontent.com/26111180/83353718-d2f3e100-a354-11ea-9dd2-04d327195c84.png) |

# `RiskLegend`
| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-31 at 15 37 45](https://user-images.githubusercontent.com/26111180/83353711-c8d1e280-a354-11ea-818f-9d88d7bb7bab.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-31 at 15 35 19](https://user-images.githubusercontent.com/26111180/83353708-c2dc0180-a354-11ea-9eaa-039bb15d6127.png) |