### PR TITLE
[Feature] add restricted state handling

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -251,6 +251,8 @@ Da nur unpersönliche Zufallscodes übertragen werden, bleibt ihre Identität un
 "ExposureNotificationSetting_Activate_Internet" = "Internetverbindung herstellen";
 "ExposureNotificationSetting_Internet_Description" = "Die Risikoermittlung benötigt eine Internetverbindung um Risikobegegnungen berechnen zu können. Bitte aktivieren Sie WLAN oder Mobile Daten in Ihren Einstellungen.";
 "ExposureNotificationSetting_Detail_Action_Button" = "Einstellungen App öffnen";
+"ExposureNotificationSetting_Activate_OSENSetting" = "COVID-19-Kontaktmitteilungen aktivieren";
+"ExposureNotificationSetting_Activate_OSENSetting_Description" = "Die Risikoermiitlung benötigt aktivierte COVID-19-Kontaktmitteilungen in den Systemeinstellungen um Begegnungen zu protokollieren. Bitte aktivieren Sie COVID-19-Kontaktmitteilungen in Ihren Systemeinstellungen.";
 
 // Home
 // Home Cards

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -242,6 +242,7 @@ Da nur unpersönliche Zufallscodes übertragen werden, bleibt ihre Identität un
 "ExposureNotificationSetting_TracingSettingTitle" = "Risikoermittlung";
 "ExposureNotificationSetting_EnableTracing" = "Risikoermittlung";
 "ExposureNotificationSetting_Tracing_Limited" = "Eingeschränkt";
+"ExposureNotificationSetting_Tracing_Deactivated" = "Deaktiviert";
 "ExposureNotificationSetting_ActionCell_Header" = "Einstellung";
 "ExposureNotificationSetting_DescriptionTitle" = "Aktivieren Sie die Aufzeichnung Ihrer Begegnungen";
 "ExposureNotificationSetting_DescriptionText1" = "Um zu erkennen, ob für Sie ein Ansteckungsrisiko vorliegt, müssen Sie die Risikoermittlung aktivieren. Die Risiko-Ermittlung funktioniert, indem Ihr Handy per Bluetooth verschlüsselte Zufallscodes anderer User empfängt und Ihren eigenen Zufallscode an deren Smartphones weitergibt. Die Funktion lässt sich jederzeit wieder deaktivieren.";
@@ -252,7 +253,7 @@ Da nur unpersönliche Zufallscodes übertragen werden, bleibt ihre Identität un
 "ExposureNotificationSetting_Internet_Description" = "Die Risikoermittlung benötigt eine Internetverbindung um Risikobegegnungen berechnen zu können. Bitte aktivieren Sie WLAN oder Mobile Daten in Ihren Einstellungen.";
 "ExposureNotificationSetting_Detail_Action_Button" = "Einstellungen App öffnen";
 "ExposureNotificationSetting_Activate_OSENSetting" = "COVID-19-Kontaktmitteilungen aktivieren";
-"ExposureNotificationSetting_Activate_OSENSetting_Description" = "Die Risikoermiitlung benötigt aktivierte COVID-19-Kontaktmitteilungen in den Systemeinstellungen um Begegnungen zu protokollieren. Bitte aktivieren Sie COVID-19-Kontaktmitteilungen in Ihren Systemeinstellungen.";
+"ExposureNotificationSetting_Activate_OSENSetting_Description" = "Die Risikoermittlung benötigt aktivierte COVID-19-Kontaktmitteilungen in den Systemeinstellungen um Begegnungen zu protokollieren. Bitte aktivieren Sie COVID-19-Kontaktmitteilungen in Ihren Systemeinstellungen.";
 
 // Home
 // Home Cards

--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
@@ -234,11 +234,9 @@
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XhU-KP-won" customClass="CircularProgressView" customModule="ENA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="75" height="2238"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 </view>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hgh-tM-Jzj">
                                                     <rect key="frame" x="90" y="0.0" width="284" height="2238"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                     <color key="textColor" name="textPrimary3"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -280,7 +278,6 @@
                                                 </label>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13X-VL-dxy">
                                                     <rect key="frame" x="0.0" y="40.5" width="382" height="280"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                     <color key="textColor" name="textPrimary1"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -288,7 +285,6 @@
                                                 </textView>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f8X-gB-tQa">
                                                     <rect key="frame" x="0.0" y="340.5" width="382" height="280"/>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                     <color key="textColor" name="textPrimary1"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
@@ -129,7 +129,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yp9-fh-bpb">
                                                             <rect key="frame" x="0.0" y="0.0" width="350" height="128"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jEQ-Jd-cnW">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jEQ-Jd-cnW">
                                                                     <rect key="frame" x="0.0" y="0.0" width="287" height="128"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                     <color key="textColor" name="textPrimary1"/>
@@ -149,7 +149,7 @@
                                                                                     </constraints>
                                                                                     <userDefinedRuntimeAttributes>
                                                                                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                                            <integer key="value" value="10"/>
+                                                                                            <integer key="value" value="6"/>
                                                                                         </userDefinedRuntimeAttribute>
                                                                                     </userDefinedRuntimeAttributes>
                                                                                 </imageView>
@@ -161,7 +161,7 @@
                                                                                     </constraints>
                                                                                     <userDefinedRuntimeAttributes>
                                                                                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                                            <integer key="value" value="10"/>
+                                                                                            <integer key="value" value="6"/>
                                                                                         </userDefinedRuntimeAttribute>
                                                                                     </userDefinedRuntimeAttributes>
                                                                                 </imageView>

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
@@ -38,25 +38,25 @@ final class ENStateTests: XCTestCase {
 
 	// statehandler should reflect enabled state after setup
 	func testInitialState() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 	}
 
 	// statehandler should reflect disabled state
 	func testDisableTracing() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .disabled)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 	}
 
 	// MARK: Bluetooth State Tests
 
 	// when statehandler is enabled bluetooth is turnedOff statehandler should be bluetooth off
 	func testTurnOffBluetooth() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .bluetoothOff)
+		XCTAssert(mockDelegate.getCurrentState() == .bluetoothOff)
 	}
 
 	// MARK: Internet State Tests
@@ -65,55 +65,55 @@ final class ENStateTests: XCTestCase {
 	func testTurnOffTurnOnInternet() {
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .active)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		mockDelegate.reachabilityChanged(false)
-		assert(mockDelegate.getCurrentState() == .internetOff)
+		XCTAssert(mockDelegate.getCurrentState() == .internetOff)
 		mockDelegate.reachabilityChanged(true)
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 	}
 
 	// MARK: Tests with combined state changes
 
 	func testDisableTracingAndBluetoothOff() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 	}
 
 	func testDisableTracingAndBluetoothOffAndInternetOff() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		mockDelegate.reachabilityChanged(false)
-		assert(mockDelegate.getCurrentState() == .internetOff)
+		XCTAssert(mockDelegate.getCurrentState() == .internetOff)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 	}
 
 	func testDisableTracingAndBluetoothOnAndInternetOn() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .disabled)
 		mockDelegate.exposureManagerState = exposureManagerState
 		mockDelegate.reachabilityChanged(false)
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 		mockDelegate.reachabilityChanged(true)
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 	}
 
 	func testEnableTracingStepByStep() {
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: false, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
 		mockDelegate.reachabilityChanged(false)
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .bluetoothOff)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .bluetoothOff)
+		XCTAssert(mockDelegate.getCurrentState() == .bluetoothOff)
 		exposureManagerState = ExposureManagerState(authorized: true, enabled: true, status: .active)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .internetOff)
+		XCTAssert(mockDelegate.getCurrentState() == .internetOff)
 		mockDelegate.reachabilityChanged(true)
-		assert(mockDelegate.getCurrentState() == .enabled)
+		XCTAssert(mockDelegate.getCurrentState() == .enabled)
 	}
 
 	// MARK: Tests different ENStatus states
@@ -121,12 +121,12 @@ final class ENStateTests: XCTestCase {
 	func testRestrictedState() {
 		exposureManagerState = ExposureManagerState(authorized: false, enabled: false, status: .restricted)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .restricted)
 	}
 
 	func testUnknownState() {
 		exposureManagerState = ExposureManagerState(authorized: false, enabled: false, status: .unknown)
 		mockDelegate.exposureManagerState = exposureManagerState
-		assert(mockDelegate.getCurrentState() == .disabled)
+		XCTAssert(mockDelegate.getCurrentState() == .disabled)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeActivateCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeActivateCellConfigurator.swift
@@ -35,7 +35,7 @@ final class HomeActivateCellConfigurator: CollectionViewCellConfigurator {
 			iconImage = UIImage(named: "Icons_Risikoermittlung")
 			cell.titleTextView.text = AppStrings.Home.activateCardOnTitle
 			cell.iconImageView.tintColor = UIColor.preferredColor(for: .tint)
-		case .disabled:
+		case .disabled, .restricted:
 			iconImage = UIImage(named: "Icons_Risikoermittlung_gestoppt")
 			cell.iconImageView.tintColor = UIColor.preferredColor(for: .negativeRisk)
 			cell.titleTextView.text = AppStrings.Home.activateCardOffTitle

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
@@ -22,6 +22,7 @@ enum RiskDetectionState {
 	case disabled
 	case bluetoothOff
 	case internetOff
+	case restricted
 }
 
 protocol StateHandlerObserverDelegate: AnyObject {
@@ -53,7 +54,7 @@ class ENStateHandler {
 		}
 
 		switch currentState {
-		case .disabled, .bluetoothOff:
+		case .disabled, .bluetoothOff, .restricted:
 			return
 		case .enabled:
 			if !isReachable {
@@ -89,7 +90,7 @@ class ENStateHandler {
 		case .disabled:
 			return .disabled
 		case .restricted:
-			return .disabled
+			return .restricted
 		case .unknown:
 			return .disabled
 		@unknown default:

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -177,7 +177,7 @@ extension ExposureNotificationSettingViewController {
 						)
 						return tracingCell
 					}
-				case .bluetoothOff, .internetOff:
+				case .bluetoothOff, .internetOff, .restricted:
 					cell.configure(for: currentState)
 				}
 			case .descriptionCell:

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -243,6 +243,8 @@ enum AppStrings {
 		static let internetDescription = NSLocalizedString("ExposureNotificationSetting_Internet_Description", comment: "")
 		static let detailActionButtonTitle = NSLocalizedString("ExposureNotificationSetting_Detail_Action_Button", comment: "")
 		static let tracingHistoryDescription = NSLocalizedString("ENSetting_Tracing_History", comment: "")
+		static let activateOSENSetting = NSLocalizedString("ExposureNotificationSetting_Activate_OSENSetting", comment: "")
+		static let activateOSENSettingDescription = NSLocalizedString("ExposureNotificationSetting_Activate_OSENSetting_Description", comment: "")
 	}
 
 	enum Home {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -233,6 +233,7 @@ enum AppStrings {
 		static let title = NSLocalizedString("ExposureNotificationSetting_TracingSettingTitle", comment: "The title of the view")
 		static let enableTracing = NSLocalizedString("ExposureNotificationSetting_EnableTracing", comment: "The enable tracing")
 		static let limitedTracing = NSLocalizedString("ExposureNotificationSetting_Tracing_Limited", comment: "")
+		static let deactivatedTracing = NSLocalizedString("ExposureNotificationSetting_Tracing_Deactivated", comment: "")
 		static let descriptionTitle = NSLocalizedString("ExposureNotificationSetting_DescriptionTitle", comment: "The introduction label")
 		static let descriptionText1 = NSLocalizedString("ExposureNotificationSetting_DescriptionText1", comment: "")
 		static let descriptionText2 = NSLocalizedString("ExposureNotificationSetting_DescriptionText2", comment: "")

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
@@ -59,6 +59,10 @@ class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.activateInternet
 			descriptionTextView.text = AppStrings.ExposureNotificationSetting.internetDescription
 			iconImageView2.isHidden = false
+		case .restricted:
+			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.activateOSENSetting
+			descriptionTextView.text = AppStrings.ExposureNotificationSetting.activateOSENSettingDescription
+			iconImageView2.isHidden = true
 		}
 	}
 
@@ -70,6 +74,8 @@ class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 			return (UIImage(named: "Icons_Bluetooth"), nil)
 		case .internetOff:
 			return (UIImage(named: "Icons_MobileDaten"), UIImage(named: "Icons_iOS_Wifi"))
+		case .restricted:
+			return (UIImage(named: "Icons_iOS_Settings"), nil)
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
@@ -50,9 +50,13 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 		case .enabled, .disabled:
 			detailLabel.isHidden = true
 			actionSwitch.isHidden = false
-		case .bluetoothOff, .internetOff, .restricted:
+		case .bluetoothOff, .internetOff:
 			detailLabel.isHidden = false
 			actionSwitch.isHidden = true
+		case .restricted:
+			detailLabel.isHidden = false
+			actionSwitch.isHidden = true
+			detailLabel.text = AppStrings.ExposureNotificationSetting.deactivatedTracing
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
@@ -50,7 +50,7 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 		case .enabled, .disabled:
 			detailLabel.isHidden = true
 			actionSwitch.isHidden = false
-		case .bluetoothOff, .internetOff:
+		case .bluetoothOff, .internetOff, .restricted:
 			detailLabel.isHidden = false
 			actionSwitch.isHidden = true
 		}

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ImageTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ImageTableViewCell.swift
@@ -35,6 +35,8 @@ class ImageTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 			return UIImage(named: "Illu_Risikoermittlung_On")
 		case .disabled:
 			return UIImage(named: "Illu_Risikoermittlung_Off")
+		case .restricted:
+			return UIImage(named: "Illu_Risikoermittlung_Off")
 		case .bluetoothOff:
 			return UIImage(named: "Illu_Bluetooth_Off")
 		case .internetOff:


### PR DESCRIPTION
The user disables the contact tracing in the OS settings causing the ENManager to fail. ENStatus will show restricted state. The user needs to enable contact tracing in the OS settings again. This UI change shall guide the user how and why to enable settings again. This design is an intermediate solution and might be changed in the future.