### PR TITLE
Fix/homescreen state

### DIFF
--- a/src/xcode/ENA/ENA/Source/Protocols/ExposureStateUpdating.swift
+++ b/src/xcode/ENA/ENA/Source/Protocols/ExposureStateUpdating.swift
@@ -16,5 +16,5 @@
 // under the License.
 
 protocol ExposureStateUpdating {
-	func updateState(_ state: ExposureManagerState)
+	func updateExposureState(_ state: ExposureManagerState)
 }

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -197,7 +197,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			fatalError("received invalid summary notification. this is a programmer error")
 		}
 		state.summary = summary
-		updateState(state.exposureManager)
+		updateExposureState(state.exposureManager)
 	}
 
 	func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -288,7 +288,7 @@ extension SceneDelegate: ENAExposureManagerObserver {
 		}
 
 		state.exposureManager = newState
-		updateState(newState)
+		updateExposureState(newState)
 	}
 }
 
@@ -354,7 +354,8 @@ extension SceneDelegate {
 }
 
 extension SceneDelegate: ExposureStateUpdating {
-	func updateState(_ state: ExposureManagerState) {
-		homeController?.updateState(state)
+	func updateExposureState(_ state: ExposureManagerState) {
+		homeController?.homeInteractor.state.summary = self.state.summary
+		homeController?.updateExposureState(state)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -113,7 +113,7 @@ extension ExposureNotificationSettingViewController {
 }
 
 extension ExposureNotificationSettingViewController: ExposureStateUpdating {
-	func updateState(_: ExposureManagerState) {
+	func updateExposureState(_: ExposureManagerState) {
 		tableView.reloadData()
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -129,7 +129,7 @@ private extension ExposureDetectionViewController {
 }
 
 extension ExposureDetectionViewController: ExposureStateUpdating {
-	func updateState(_ emState: ExposureManagerState) {
+	func updateExposureState(_ emState: ExposureManagerState) {
 		state.exposureManagerState = emState
 		updateUI()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -53,11 +53,10 @@ final class HomeInteractor {
 					summary: state.summary
 				), stateHandler: stateHandler
 			)
+			reloadRiskCell()
+			cells = initialCellConfigurators()
+			homeViewController.reloadData()
 		}
-	}
-
-	var currentState: RiskDetectionState {
-		stateHandler.getState()
 	}
 
 	private unowned var homeViewController: HomeViewController
@@ -128,6 +127,7 @@ final class HomeInteractor {
 
 	func updateActiveCell() {
 		guard let indexPath = indexPathForActiveCell() else { return }
+		let currentState = stateHandler.getState()
 		activeConfigurator.set(newState: currentState)
 		homeViewController.reloadCell(at: indexPath)
 	}
@@ -162,6 +162,7 @@ final class HomeInteractor {
 	}
 
 	private func initialCellConfigurators() -> [CollectionViewCellConfiguratorAny] {
+		let currentState = stateHandler.getState()
 		activeConfigurator = HomeActivateCellConfigurator(state: currentState)
 		let dateLastExposureDetection = store.dateLastExposureDetection
 
@@ -366,7 +367,7 @@ extension HomeInteractor: StateHandlerObserverDelegate {
 }
 
 extension HomeInteractor: ExposureStateUpdating {
-	func updateState(_ state: ExposureManagerState) {
+	func updateExposureState(_ state: ExposureManagerState) {
 		stateHandler.exposureManagerDidUpdate(to: state)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -84,13 +84,11 @@ final class HomeViewController: UIViewController {
 		configureHierarchy()
 		configureDataSource()
 		configureUI()
-
 	}
 
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		// Why shall we update UI?
-		// updateUI()
+		updateOwnUI()
 		navigationItem.largeTitleDisplayMode = .never
 		homeInteractor.developerMenuEnableIfAllowed()
 	}
@@ -295,6 +293,7 @@ final class HomeViewController: UIViewController {
 	}
 
 	func reloadData() {
+		guard isViewLoaded else { return }
 		collectionView.reloadData()
 	}
 
@@ -447,12 +446,12 @@ private extension HomeViewController {
 }
 
 extension HomeViewController: ExposureStateUpdating {
-	func updateState(_ state: ExposureManagerState) {
+	func updateExposureState(_ state: ExposureManagerState) {
 		updateOwnUI()
-		homeInteractor.updateState(state)
+		homeInteractor.updateExposureState(state)
 		exposureDetectionController?.updateUI()
-		settingsController?.updateState(state)
-		notificationSettingsController?.updateState(state)
+		settingsController?.updateExposureState(state)
+		notificationSettingsController?.updateExposureState(state)
 	}
 
 	private func updateOwnUI() {

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -289,9 +289,9 @@ extension SettingsViewController: ExposureNotificationSettingViewControllerDeleg
 }
 
 extension SettingsViewController: ExposureStateUpdating {
-	func updateState(_ state: ExposureManagerState) {
+	func updateExposureState(_ state: ExposureManagerState) {
 		checkTracingStatus()
-		notificationSettingsController?.updateState(state)
+		notificationSettingsController?.updateExposureState(state)
 	}
 }
 


### PR DESCRIPTION
## Most Important Changes

### Renaming in `ExposureStateUpdating`

I have renamed `-updateState:` to `-updateExposureState:`. The former was a bit too generic in my view and confusing because it implied that the exposure related state was the only state in a view controller.

```diff
protocol ExposureStateUpdating {
--	func updateState(_ state: ExposureManagerState)
++	func updateExposureState(_ state: ExposureManagerState)
}
```

### Fixing the displayed Risk on the Home Screen
Up until this PR the home screen risk card was never updated. This is fixed by this PR.

### Remarks
I was irritated by how `HomeViewController`/`HomeInteractor` really work. That is why I have also created an issue (#60) that calls for a complete overhaul of those classes. Several fellow developers working on this project agreed to spend more time on this home part of the app so that it will be easier to change going forward.