### PR TITLE
[Bug] Use tint color for navigation bar

### DIFF
--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -129,6 +129,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 	private func setupUI() {
 		store.isOnboarded ? showHome() : showOnboarding()
+		UINavigationBar.appearance().tintColor = UIColor.preferredColor(for: .tint)
 		window?.rootViewController = navigationController
 		window?.makeKeyAndVisible()
 	}


### PR DESCRIPTION
In the UI setup, change the global tint color for UINavigationBar to the app's tint color. This way all back buttons (and other UIBarButtonItems) will use the light blue accent color. Until now, navigation bars have used the standard iOS blue color.