### PR TITLE
[Technical] Unit tests for SQLiteKeyValueStore (closes #21)

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		85D7594E24570491008175F0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85D7594C24570491008175F0 /* LaunchScreen.storyboard */; };
 		85D7596424570491008175F0 /* ENAUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D7596324570491008175F0 /* ENAUITests.swift */; };
 		85E33444247EB357006E74EC /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E33443247EB357006E74EC /* CircularProgressView.swift */; };
+		A173665324844F41006BE209 /* SQLiteKeyValueStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A173665124844F29006BE209 /* SQLiteKeyValueStoreTests.swift */; };
 		A3C4F96024812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */; };
 		A3E5E71A247D4FFB00237116 /* ExposureSubmissionViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */; };
 		A3E5E71E247E6F7A00237116 /* SpinnerInjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */; };
@@ -425,6 +426,7 @@
 		85D7596324570491008175F0 /* ENAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAUITests.swift; sourceTree = "<group>"; };
 		85D7596524570491008175F0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		85E33443247EB357006E74EC /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
+		A173665124844F29006BE209 /* SQLiteKeyValueStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteKeyValueStoreTests.swift; sourceTree = "<group>"; };
 		A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionWarnOthersViewController.swift; sourceTree = "<group>"; };
 		A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionViewUtils.swift; sourceTree = "<group>"; };
 		A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerInjectable.swift; sourceTree = "<group>"; };
@@ -769,6 +771,7 @@
 		51D420B224583AA400AD70CA /* Workers */ = {
 			isa = PBXGroup;
 			children = (
+				A1C2B2DA24834934004A3BD5 /* __tests__ */,
 				0D5611B7247FD36F00B5B094 /* PersistedAndPublished.swift */,
 				CD99A3C6246155C300BF12AF /* Logger.swift */,
 				013DC101245DAC4E00EE58B0 /* Store.swift */,
@@ -1080,6 +1083,14 @@
 				CD99A3A8245C272400BF12AF /* ExposureSubmissionService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		A1C2B2DA24834934004A3BD5 /* __tests__ */ = {
+			isa = PBXGroup;
+			children = (
+				A173665124844F29006BE209 /* SQLiteKeyValueStoreTests.swift */,
+			);
+			path = __tests__;
 			sourceTree = "<group>";
 		};
 		B102BDC12460405F00CD55A2 /* Backend */ = {
@@ -1806,6 +1817,7 @@
 				B16177E824802F9B006E435A /* DownloadedPackagesSQLLiteStoreTests.swift in Sources */,
 				CD678F6F246C43FC00B6A0F8 /* MockURLSession.swift in Sources */,
 				EE22DB91247FB479001B0A71 /* MockStateHandlerObserverDelegate.swift in Sources */,
+				A173665324844F41006BE209 /* SQLiteKeyValueStoreTests.swift in Sources */,
 				B15382E5248273F30010F007 /* MockTestStore.swift in Sources */,
 				B15382E7248290BB0010F007 /* AppleFilesWriterTests.swift in Sources */,
 				B1A76E9F24714AC700EA5208 /* HTTPClient+Configuration.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
@@ -1,0 +1,136 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+@testable import ENA
+import FMDB
+import XCTest
+
+final class SQLiteKeyValueStoreTests: XCTestCase {
+
+	private var kvStore: SQLiteKeyValueStore!
+
+	let rawMockData: [(key: String, data: Data)] = [
+		// swiftlint:disable force_unwrapping
+		("key", "testing".data(using: .utf8)!),
+		("key2", "testing2".data(using: .utf8)!),
+		("developerSubmissionBaseURLOverride", "testing3".data(using: .utf8)!),
+		("developerDistributionBaseURLOverride", "testing4".data(using: .utf8)!),
+		("developerVerificationBaseURLOverride", "testing5".data(using: .utf8)!)
+		// swiftlint:enable force_unwrapping
+	]
+
+	override func setUp() {
+		super.setUp()
+		// Old DB is deinited and hence connection closed at every setUp() call
+		kvStore = SQLiteKeyValueStore(with: URL(staticString: "file::memory"))
+	}
+
+	// MARK: - Positive Tests
+
+	func testStoreRawData_Success() {
+		kvStore[rawMockData[0].key] = rawMockData[0].data
+		XCTAssertEqual(kvStore[rawMockData[0].key], rawMockData[0].data)
+	}
+
+	func testNilOutValue_Success() {
+		kvStore[rawMockData[0].key] = rawMockData[0].data
+		kvStore[rawMockData[0].key] = nil
+		XCTAssertNil(kvStore[rawMockData[0].key])
+	}
+
+	func testOverwriteValue_Success() {
+		kvStore[rawMockData[0].key] = rawMockData[0].data
+		// swiftlint:disable:next force_unwrapping
+		let someOtherData = "someOtherData".data(using: .utf8)!
+		kvStore[rawMockData[0].key] = someOtherData
+		XCTAssertEqual(kvStore[rawMockData[0].key], someOtherData)
+	}
+
+	func testClearAll_Success() {
+		kvStore[rawMockData[0].key] = rawMockData[0].data
+		kvStore[rawMockData[1].key] = rawMockData[1].data
+
+		kvStore.clearAll()
+
+		XCTAssertNil(kvStore[rawMockData[0].key])
+		XCTAssertNil(kvStore[rawMockData[1].key])
+	}
+
+	func testFlush_OverridesNotCleared() {
+		kvStore[rawMockData[0].key] = rawMockData[0].data
+		kvStore[rawMockData[1].key] = rawMockData[1].data
+
+		kvStore[rawMockData[2].key] = rawMockData[2].data
+		kvStore[rawMockData[3].key] = rawMockData[3].data
+		kvStore[rawMockData[4].key] = rawMockData[4].data
+
+		kvStore.flush()
+
+		XCTAssertNil(kvStore[rawMockData[0].key])
+		XCTAssertNil(kvStore[rawMockData[1].key])
+		// A flush clears most values except for a few known developer override keys
+		XCTAssertEqual(kvStore[rawMockData[2].key], rawMockData[2].data)
+		XCTAssertEqual(kvStore[rawMockData[3].key], rawMockData[3].data)
+		XCTAssertEqual(kvStore[rawMockData[4].key], rawMockData[4].data)
+	}
+
+	func testStoreCodable_Success() {
+		let someCodable = SomeCodable(someDouble: 1.1)
+		kvStore["someCodable"] = someCodable
+
+		XCTAssertEqual(kvStore["someCodable"], someCodable)
+	}
+
+	func testCodableStore_ValueForKeyNotExists() {
+		XCTAssertNil(kvStore["abc"] as Int64?)
+	}
+
+	func test_ValueForKeyNotExists() {
+		XCTAssertNil(kvStore["a"])
+	}
+
+	func testStore_EmptyData() {
+		kvStore["a"] = Data()
+		XCTAssert(kvStore["a"]?.isEmpty == true)
+	}
+
+	// MARK: - Negative Tests
+
+	func testEncodingError_ReturnNil() {
+		kvStore["shouldFail"] = SomeCodable(someDouble: Double.nan)
+		// Since encoding failed, nothing is stored
+		XCTAssertNil(kvStore["shouldFail"])
+	}
+
+	func testDecodingError_ReturnNil() {
+		kvStore["someCodable"] = SomeCodable(someDouble: 1.1)
+		XCTAssertNil(kvStore["someCodable"] as SomeOtherCodable?)
+	}
+}
+
+private extension SQLiteKeyValueStoreTests {
+	// Also Equatable for ease of use - synthesized conformance will compare all properties
+	struct SomeCodable: Codable, Equatable {
+		let someDouble: Double
+	}
+
+	struct SomeOtherCodable: Codable, Equatable {
+		let someString: String
+	}
+}


### PR DESCRIPTION
This PR adds unit tests to `SQLiteKeyValueStore`, as well as some doc comments.  

Some behaviors of `SQLiteKeyValueStore` have also been modified:
- inserting empty `Data` into the store now results in getting empty `Data` out instead of `nil`
- accessing the value for a key that does not exist now returns `nil` instead of empty `Data`
- it is now possible to overwrite a value with `nil`