### PR TITLE
[Bug] Onboarding "Continue" non-functional

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -22,6 +22,8 @@ enum ExposureNotificationError: Error {
 	case exposureNotificationRequired
 	case exposureNotificationAuthorization
 	case exposureNotificationUnavailable
+	/// Typically occurs when `activate()` is called more than once.
+	case apiMisuse
 }
 
 struct ExposureManagerState {
@@ -208,6 +210,8 @@ final class ENAExposureManager: NSObject, ExposureManager {
 				completion(ExposureNotificationError.exposureNotificationRequired)
 			case .restricted:
 				completion(ExposureNotificationError.exposureNotificationUnavailable)
+			case .apiMisuse:
+				completion(ExposureNotificationError.apiMisuse)
 			default:
 				let error = "[ExposureManager] Not implemented \(error.localizedDescription)"
 				logError(message: error)

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -99,6 +99,9 @@ extension ExposureNotificationSettingViewController {
 		case .exposureNotificationUnavailable:
 			logError(message: "Failed to enable")
 			alertError(message: "ExposureNotification is not availabe due to the sytem policy", title: "Error")
+		case .apiMisuse:
+			// This error should not happen as we toggle the enabled status on off - we can not enable without disabling first
+			alertError(message: "ExposureNotification is already enabled", title: "Note")
 		}
 		tableView.reloadData()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -184,6 +184,10 @@ final class OnboardingInfoViewController: UIViewController {
 					log(message: "Encourage the user to authorize this application", level: .warning)
 				case .exposureNotificationUnavailable:
 					log(message: "Tell the user that Exposure Notifications is currently not available.", level: .warning)
+				case .apiMisuse:
+					// User already enabled notifications, but went back to the previous screen. Just ignore error and proceed
+					completion?()
+					return
 				}
 				self.showError(error, from: self, completion: completion)
 				completion?()
@@ -197,6 +201,10 @@ final class OnboardingInfoViewController: UIViewController {
 							log(message: "Encourage the user to authorize this application", level: .warning)
 						case .exposureNotificationUnavailable:
 							log(message: "Tell the user that Exposure Notifications is currently not available.", level: .warning)
+						case .apiMisuse:
+							// User already enabled notifications, but went back to the previous screen. Just ignore error and proceed.
+							// The error condition here should not really happen as we are inside the `enable()` completion block
+							completion?()
 						}
 					}
 					self.taskScheduler.scheduleBackgroundTaskRequests()

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
@@ -225,6 +225,8 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 			switch exposureNotificationError {
 			case .exposureNotificationRequired, .exposureNotificationAuthorization, .exposureNotificationUnavailable:
 				return .enNotEnabled
+			case .apiMisuse:
+				return .other("ENErrorCodeAPIMisuse")
 			}
 		}
 


### PR DESCRIPTION
## Summary

It is an error to call `ENManager.activate()` more than once without disabling it first.
Current onboarding & error handling logic did not cover this case (doesn't handle `ENErrorCodeAPIMisuse`), and so the button became non-functional.

The fix was to handle this error - and in the case of onboarding simply go to the next screen.

## Steps to Reproduce

1. Delete app & clear permissions cache (so you get prompted again)
2. In the third onboarding page, grant permissions as normal
3. Observe that we go to the next page
4. Hit the back button in the nav bar
5. Observe that the continue button does not work anymore.

## Alternative Fixes Considered

We could simply guard against the `enabled` precondition on `ExposureManager` like so:

```swift
guard !exposureManager.preconditions().enabled else {
	completion?()
        return
}
```

## Future Considerations

A scenario this PR does not cover is this flow:
1. User hits "Continue"
2. User denies Exposure Notifications in the system prompt
3. User is directed to next onboarding step
4. User, having changed their mind, goes back and hits "Continue"
5. The app just goes forward an onboarding step.

A nice UX thing here might be to direct the user to Settings.app