### PR TITLE
[Feature] iOS: User skips the activation and go to next view of onboarding (closes #441)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "Alert_TitleGeneral" = "Ein Fehler ist aufgetreten";
 "Alert_MessageGeneral" = "Bitte versuche Sie es erneut.";
 "Alert_ActionOk" = "Ok";
+"Alert_ActionCancel" = "Abbrechen";
 "Alert_ActionNo" = "Nein";
 "Alert_TitleKeySubmit" = "Tan Generierung";
 "Alert_DescriptionKeySubmit" = "Sind Sie damit einverstanden, Ihre TAN generieren zu lassen?";
@@ -143,6 +144,9 @@ Wenn Sie nach Hause kommen, vermeiden Sie auch den Kontakt zu Familienmitglieder
 "OnboardingInfo_enableLoggingOfContactsPage_title" = "Wie Sie die Risikoerkennung ermöglichen";
 "OnboardingInfo_enableLoggingOfContactsPage_boldText" = "Damit sich Covid-19-Risiken analysieren lassen, müssen Sie die Erfassung von Zufalls-IDs und deren Weitergabe an andere Smartphones per Bluetooth erlauben. Die Funktion lässt sich jederzeit wieder deaktivieren.";
 "OnboardingInfo_enableLoggingOfContactsPage_normalText" = "";
+
+"OnboardingInfo_warningIfNoLoggingOfContactsPage_title" = "Corona-Warn-App kann dadurch keine Benachrichtigungen zu COVID-19-Risikostatus versenden und empfangen";
+"OnboardingInfo_warningIfNoLoggingOfContactsPage_normalText" = "Sie können die Funktion jederzeit einschalten";
 
 "OnboardingInfo_howDoesDataExchangeWorkPage_title" = "Sie sind positiv getestet? ";
 "OnboardingInfo_howDoesDataExchangeWorkPage_boldText" = "Dann melden Sie es bitte über die COVID Warn-App. Freiwillig und sicher. Für die Gesundheit aller.";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -46,6 +46,9 @@
 "OnboardingInfo_enableLoggingOfContactsPage_boldText" = "To be able to analyze Covid 19 risks, you must allow the acquisition of random IDs and their transfer to other smartphones via Bluetooth. The function can be deactivated again at any time.";
 "OnboardingInfo_enableLoggingOfContactsPage_normalText" = "";
 
+"OnboardingInfo_warningIfNoLoggingOfContactsPage_title" = "As a result, the Corona Warning app cannot send and receive notifications about COVID-19 risk status";
+"OnboardingInfo_warningIfNoLoggingOfContactsPage_normalText" = "You can switch the function on at any time";
+
 "OnboardingInfo_howDoesDataExchangeWorkPage_title" = "Have you been tested positive?";
 "OnboardingInfo_howDoesDataExchangeWorkPage_boldText" = "Then please report it via the COVID warning app. Voluntarily and safely. For everyone's health.";
 "OnboardingInfo_howDoesDataExchangeWorkPage_normalText" = "Your message is reliably encrypted and processed via a secure server. As a result, your contacts can be warned, isolated or tested.";

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -105,6 +105,15 @@ final class OnboardingInfoViewController: UIViewController {
 			completion()
 		}
 	}
+	func runIgnoreActionForPageType(completion: @escaping () -> Void) {
+		switch pageType {
+		case .enableLoggingOfContactsPage:
+			warnUserAboutDisablingExposureManager(completion: completion)
+		default:
+			completion()
+		}
+	}
+
 
 	private func updateUI() {
 		guard isViewLoaded else { return }
@@ -206,6 +215,18 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 	}
 
+	private func warnUserAboutDisablingExposureManager(completion: (() -> Void)?) {
+		let alert = UIAlertController(
+			title: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_alertTitle,
+			message: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_alertMessage,
+			preferredStyle: .alert)
+		alert.addAction(UIAlertAction(title: AppStrings.Common.alertActionOk, style: .default) { _ in
+			completion?()
+		})
+		alert.addAction(UIAlertAction(title: AppStrings.Common.alertActionCancel, style: .cancel))
+		present(alert, animated: true)
+	}
+
 	private func askLocalNotificationsPermissions(completion: (() -> Void)?) {
 		if TestEnvironment.shared.isUITesting {
 			completion?()
@@ -244,7 +265,11 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 
 	@IBAction func didTapIgnoreButton(_: Any) {
-		gotoNextScreen()
+		runIgnoreActionForPageType(
+			completion: {
+				self.gotoNextScreen()
+			}
+		)
 	}
 
 	func gotoNextScreen() {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -24,6 +24,7 @@ enum AppStrings {
 		static let alertMessageGeneral = NSLocalizedString("Alert_MessageGeneral", comment: "")
 		static let alertActionOk = NSLocalizedString("Alert_ActionOk", comment: "")
 		static let alertActionNo = NSLocalizedString("Alert_ActionNo", comment: "")
+		static let alertActionCancel = NSLocalizedString("Alert_ActionCancel", comment: "")
 		static let alertTitleKeySubmit = NSLocalizedString("Alert_TitleKeySubmit", comment: "")
 		static let alertDescriptionKeySubmit = NSLocalizedString("Alert_DescriptionKeySubmit", comment: "")
 	}
@@ -221,6 +222,9 @@ enum AppStrings {
 		static let onboardingInfo_enableLoggingOfContactsPage_title = NSLocalizedString("OnboardingInfo_enableLoggingOfContactsPage_title", comment: "")
 		static let onboardingInfo_enableLoggingOfContactsPage_boldText = NSLocalizedString("OnboardingInfo_enableLoggingOfContactsPage_boldText", comment: "")
 		static let onboardingInfo_enableLoggingOfContactsPage_normalText = NSLocalizedString("OnboardingInfo_enableLoggingOfContactsPage_normalText", comment: "")
+		static let onboardingInfo_enableLoggingOfContactsPage_alertTitle = NSLocalizedString("OnboardingInfo_warningIfNoLoggingOfContactsPage_title", comment: "")
+		static let onboardingInfo_enableLoggingOfContactsPage_alertMessage = NSLocalizedString("OnboardingInfo_warningIfNoLoggingOfContactsPage_normalText", comment: "")
+
 		static let onboardingInfo_howDoesDataExchangeWorkPage_title = NSLocalizedString("OnboardingInfo_howDoesDataExchangeWorkPage_title", comment: "")
 		static let onboardingInfo_howDoesDataExchangeWorkPage_boldText = NSLocalizedString("OnboardingInfo_howDoesDataExchangeWorkPage_boldText", comment: "")
 		static let onboardingInfo_howDoesDataExchangeWorkPage_normalText = NSLocalizedString("OnboardingInfo_howDoesDataExchangeWorkPage_normalText", comment: "")


### PR DESCRIPTION
**Summary**
If the user taps 'skip' on the exposure activation screen while onboarding, they should be prompted to inform them that this disables the app's ability to send and receive notifications about COVID-19 risk status.

**How to test**
From the onboarding screens, proceed to the screen titled 'Wie Sie die Risikoerkennung ermöglichen', and tap 'Nicht Aktivieren' (1)
An alert is presented (2)
- Tapping 'Abbrechen' (3) dismisses the alert, and allows the user to tap 'Weiter' or 'Nicht Aktivieren' again
- Tapping 'Ok' (4) dismisses the alert, and proceeds to the next screen

![IMG_D594DECA0CF5-1](https://user-images.githubusercontent.com/24432039/83403112-f6c03100-a3ff-11ea-9e9b-930f6002a2c7.jpeg)