### PR TITLE
[Bug] Hide Navigation Bar on Initial Onboarding Screen (closes #98)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -87,6 +87,18 @@ final class OnboardingInfoViewController: UIViewController {
 		setupAccessibility()
 	}
 
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+		if pageType == .togetherAgainstCoronaPage {
+			navigationController?.setNavigationBarHidden(true, animated: true)
+		}
+	}
+
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+		navigationController?.setNavigationBarHidden(false, animated: true)
+	}
+
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
 		let height = footerView.frame.height + 20


### PR DESCRIPTION
On the initial onboarding view controller, an empty navigation bar is displayed. In the next view controllers in the onboarding flow, the nav bar shows a back button, but on the first one, the bar should be hidden.

|**Current**|**Fixed**|
|----|----|
|![current](https://user-images.githubusercontent.com/37324823/83416671-4ebb5f80-a421-11ea-913f-5046160713b6.png)| ![expected](https://user-images.githubusercontent.com/37324823/83416723-609d0280-a421-11ea-85a3-886447c3f3b6.png)|
