### PR TITLE
[Feature] ENAButton styles and tap states

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/UIColor+ColorStyle.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UIColor+ColorStyle.swift
@@ -54,6 +54,19 @@ extension UIColor {
 		}
 	}
 
+
+	#if TARGET_INTERFACE_BUILDER
+	static func preferredColor(for style: ColorStyle, interface: UIUserInterfaceStyle = .unspecified) -> UIColor {
+		switch style {
+		case .tint: return UIColor(red: 0 / 255.0, green: 127 / 255.0, blue: 173 / 255.0, alpha: 1)
+		case .separator: return UIColor(red: 245 / 255.0, green: 245 / 255.0, blue: 245 / 255.0, alpha: 1)
+		case .textPrimary1: return UIColor(red: 23 / 255.0, green: 25 / 255.0, blue: 26 / 255.0, alpha: 1)
+		case .backgroundPrimary: return UIColor(red: 255 / 255.0, green: 255 / 255.0, blue: 255 / 255.0, alpha: 1)
+		default:
+			fatalError("Requested color is not available in interface builder: " + style.rawValue)
+		}
+	}
+	#else
 	static func preferredColor(for style: ColorStyle, interface: UIUserInterfaceStyle = .unspecified) -> UIColor {
 		if let color = UIColor(style: style, interface: interface) {
 			return color
@@ -61,4 +74,5 @@ extension UIColor {
 			fatalError("Requested color is not available: " + style.rawValue)
 		}
 	}
+	#endif
 }

--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAButton.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAButton.swift
@@ -23,10 +23,7 @@ class ENAButton: DynamicTypeButton {
 	@IBInspectable var color: UIColor?
 
 	@IBInspectable var isTransparent: Bool = false { didSet { applyStyle() } }
-	@IBInspectable var isLight: Bool = false { didSet { applyStyle() } }
 	@IBInspectable var isInverted: Bool = false { didSet { applyStyle() } }
-
-	private var style: Style = .regular
 
 	override var isEnabled: Bool { didSet { applyStyle() } }
 	override var isHighlighted: Bool { didSet { applyHighlight() } }
@@ -66,15 +63,15 @@ class ENAButton: DynamicTypeButton {
 
 		clipsToBounds = true
 
-		contentEdgeInsets = UIEdgeInsets(top: 14, left: 14, bottom: 14, right: 14)
+		contentEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
 		heightAnchor.constraint(greaterThanOrEqualToConstant: 50).isActive = true
-		titleLabel?.numberOfLines = 0 // TODO
 
 		highlightView?.removeFromSuperview()
 		highlightView = UIView(frame: bounds)
 		highlightView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 		addSubview(highlightView)
 
+		titleLabel?.font = .preferredFont(forTextStyle: .body)
 		cornerRadius = 8
 		dynamicTypeSize = 17
 		dynamicTypeWeight = "semibold"
@@ -84,10 +81,9 @@ class ENAButton: DynamicTypeButton {
 	}
 
 	private func applyStyle() {
+		let style: Style
 		if isTransparent {
 			style = .transparent
-		} else if isLight {
-			style = .regular
 		} else if isInverted {
 			style = .contrast
 		} else {
@@ -110,10 +106,9 @@ class ENAButton: DynamicTypeButton {
 	}
 }
 
-extension ENAButton {
+private extension ENAButton {
 	enum Style {
 		case transparent
-		case regular
 		case emphasized(color: UIColor?)
 		case contrast
 	}
@@ -127,17 +122,15 @@ extension ENAButton.Style {
 	var backgroundColor: UIColor {
 		switch self {
 		case .transparent: return .clear
-		case .regular: return .preferredColor(for: .separator)
 		case .emphasized(let color): return color ?? .preferredColor(for: .tint)
-		case .contrast: return .preferredColor(for: .backgroundPrimary) // TODO
+		case .contrast: return .preferredColor(for: .backgroundPrimary)
 		}
 	}
 
 	var foregroundColor: UIColor {
 		switch self {
 		case .transparent: return .preferredColor(for: .tint)
-		case .regular: return .preferredColor(for: .tint)
-		case .emphasized: return .white // TODO
+		case .emphasized: return .white
 		case .contrast: return .preferredColor(for: .textPrimary1, interface: .dark)
 		}
 	}
@@ -145,7 +138,6 @@ extension ENAButton.Style {
 	var disabledBackgroundColor: UIColor {
 		switch self {
 		case .transparent: return .preferredColor(for: .separator)
-		case .regular: return .preferredColor(for: .separator)
 		case .emphasized: return .preferredColor(for: .separator)
 		case .contrast: return .preferredColor(for: .separator)
 		}
@@ -154,7 +146,6 @@ extension ENAButton.Style {
 	var disabledForegroundColor: UIColor {
 		switch self {
 		case .transparent: return .preferredColor(for: .tint)
-		case .regular: return .preferredColor(for: .tint)
 		case .emphasized: return .preferredColor(for: .textPrimary1)
 		case .contrast: return .preferredColor(for: .textPrimary1)
 		}


### PR DESCRIPTION
This PR implements predefined button styles for the `ENAButton` including tap states.

The following button states are supported:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/64848654/83516096-bed7ed00-a4d6-11ea-9e52-1be66de37980.png">

The respective properties are exposed to interface builder, but can also be used in code (`isTransparent` and `isInverted`). The emphasized color can be set using the `color` property of the button.

The button automatically applies the default font being System, 17pt, Semibold and adjust with dynamic type. When tapped the button is highlighted with a black view with 20% opacity.

To use the button in interface builder a standard `UIButton` with a custom class can be used. There is no need to set any of the properties manually.
