### PR TITLE
[bug] TAN entry: continue button inadvertently active on pulling down VC

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
@@ -36,8 +36,8 @@ class ExposureSubmissionTanInputViewController: UIViewController, SpinnerInjecta
 		fetchService()
 	}
 
-	override func viewWillDisappear(_ animated: Bool) {
-		super.viewWillDisappear(animated)
+	override func viewDidDisappear(_ animated: Bool) {
+		super.viewDidDisappear(animated)
 		setButtonEnabled(enabled: true)
 	}
 


### PR DESCRIPTION
When entering a TAN, pulling down the modal view controller window slowly results in the "continue" button to be activated due to a call to "viewWillDisappear".

The button gets activated and can be pressed by the user, upon releasing the view (bouncing back to the top) - even though not all TAN fields are filled.

The solution would be, to activate the button on viewDidDisappear, when it is completely offscreen. 

Current | Fixed
-- | --
![current](https://user-images.githubusercontent.com/2036870/83421255-153a2280-a428-11ea-8b67-8abbb6677709.png) | ![fixed](https://user-images.githubusercontent.com/2036870/83421250-1408f580-a428-11ea-92d0-c08df62c7df1.png)









