### PR TITLE
[Technical] Add tests for DynamicTableViewModel

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		EEF1067A246EBF8B009DFB4E /* ResetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF10679246EBF8B009DFB4E /* ResetViewController.swift */; };
 		F247572B24838AC8003E1FC5 /* DynamicTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F247572A24838AC8003E1FC5 /* DynamicTableViewControllerTests.swift */; };
 		F252472F2483955B00C5556B /* DynamicTableViewControllerFake.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F252472E2483955B00C5556B /* DynamicTableViewControllerFake.storyboard */; };
+		F25247312484456800C5556B /* DynamicTableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25247302484456800C5556B /* DynamicTableViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -525,6 +526,7 @@
 		EEF10679246EBF8B009DFB4E /* ResetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResetViewController.swift; sourceTree = "<group>"; };
 		F247572A24838AC8003E1FC5 /* DynamicTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewControllerTests.swift; sourceTree = "<group>"; };
 		F252472E2483955B00C5556B /* DynamicTableViewControllerFake.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DynamicTableViewControllerFake.storyboard; sourceTree = "<group>"; };
+		F25247302484456800C5556B /* DynamicTableViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1446,6 +1448,7 @@
 			children = (
 				F247572A24838AC8003E1FC5 /* DynamicTableViewControllerTests.swift */,
 				F252472E2483955B00C5556B /* DynamicTableViewControllerFake.storyboard */,
+				F25247302484456800C5556B /* DynamicTableViewModelTests.swift */,
 			);
 			path = __tests__;
 			sourceTree = "<group>";
@@ -1834,6 +1837,7 @@
 				EE22DB91247FB479001B0A71 /* MockStateHandlerObserverDelegate.swift in Sources */,
 				A173665324844F41006BE209 /* SQLiteKeyValueStoreTests.swift in Sources */,
 				B15382E5248273F30010F007 /* MockTestStore.swift in Sources */,
+				F25247312484456800C5556B /* DynamicTableViewModelTests.swift in Sources */,
 				B15382E7248290BB0010F007 /* AppleFilesWriterTests.swift in Sources */,
 				B1A76E9F24714AC700EA5208 /* HTTPClient+Configuration.swift in Sources */,
 				B1D431C8246C69F300E728AD /* HTTPClient+ConfigurationTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewModelTests.swift
@@ -1,0 +1,139 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import XCTest
+@testable import ENA
+
+class DynamicTableViewModelTests: XCTestCase {
+	
+	var sut: DynamicTableViewModel!
+	var sections: [DynamicSection] = []
+	var cellsSection0: [DynamicCell] = []
+	var cellsSection1: [DynamicCell] = []
+
+	override func setUpWithError() throws {
+		cellsSection0 = [
+			DynamicCell.bold(text: "Foo"),
+			DynamicCell.bold(text: "Bar")
+		]
+		cellsSection1 = [
+			DynamicCell.bold(text: "Baz")
+		]
+		sections = [
+			DynamicSection.section(cells: cellsSection0),
+		  DynamicSection.section(cells: cellsSection1),
+		]
+		sut = DynamicTableViewModel(sections)
+	}
+	
+	override func tearDownWithError() throws {
+		sut = nil
+		sections = []
+		cellsSection0 = []
+		cellsSection1 = []
+	}
+	
+	func testSection_returnsInitializedSection() {
+		
+		let section = sut.section(1)
+		
+		XCTAssertEqual(section.cells.count, 1)
+		let cell = section.cells.first
+		if case .bold(text: let text) = cell {
+			XCTAssertEqual(text, "Baz")
+		} else {
+			XCTFail()
+		}
+	}
+	
+	func testSectionAt_returnsInitializedSection() {
+		
+		let section = sut.section(at: IndexPath(row: 0, section: 1))
+		
+		XCTAssertEqual(section.cells.count, 1)
+		let cell = section.cells.first
+		if case .bold(text: let text) = cell {
+			XCTAssertEqual(text, "Baz")
+		} else {
+			XCTFail()
+		}
+	}
+	
+	func testCellAt_returnsInitializedCell() {
+		
+		let cell = sut.cell(at: IndexPath(row: 0, section: 0))
+		
+		if case .bold(text: let text) = cell {
+			XCTAssertEqual(text, "Foo")
+		} else {
+			XCTFail()
+		}
+	}
+	
+	func testNumberOfSections() {
+		
+		XCTAssertEqual(sut.numberOfSection, sections.count)
+	}
+	
+	func testNumberOfRows_section0() {
+		
+		XCTAssertEqual(sut.numberOfRows(inSection: 0, for: DynamicTableViewController()), cellsSection0.count)
+	}
+	
+	func testAdd_appendsSection() {
+		
+		let cells = [DynamicCell.semibold(text: "23")]
+		sut.add(DynamicSection.section(cells: cells))
+
+		// get last section
+		let section = getLastSection(from: sut)
+		// assert cell type and content
+		let cell = section.cells.first
+		if case .semibold(text: let text) = cell {
+			XCTAssertEqual(text, "23")
+		} else {
+			XCTFail()
+		}
+	}
+	
+	func testWith_returnsAlteredModel() {
+		
+		let model = DynamicTableViewModel.with { model in
+			let cells = [DynamicCell.semibold(text: "42")]
+			model.add(DynamicSection.section(cells: cells))
+		}
+		
+		// get last section
+		let section = getLastSection(from: model)
+		// assert cell type and content
+		let cell = section.cells.first
+		if case .semibold(text: let text) = cell {
+			XCTAssertEqual(text, "42")
+		} else {
+			XCTFail()
+		}
+	}
+}
+
+extension DynamicTableViewModelTests {
+	func getLastSection(from model: DynamicTableViewModel) -> DynamicSection {
+		let numberOfSections = model.numberOfSection
+		return model.section(numberOfSections - 1)
+	}
+}


### PR DESCRIPTION
This commit adds tests for all methods in DynamicTableViewModel.
I didn't want to change the code to make the tests easier. As a result
I couldn't compare DynamicSections directly. So I compare the
number of cells and the content of the contained cell.