### PR TITLE
[WIP] [Bug] Fix Onboarding dismiss issue (closes #122)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store.swift
@@ -18,6 +18,7 @@
 import Foundation
 
 protocol Store: AnyObject {
+	/// - note: Should post `Notification.Name.isOnboardedDidChange` on change
 	var isOnboarded: Bool { get set }
 	var dateLastExposureDetection: Date? { get set }
 	var dateOfAcceptedPrivacyNotice: Date? { get set }
@@ -163,7 +164,10 @@ final class SecureStore: Store {
 
 	var isOnboarded: Bool {
 		get { kvStore["isOnboarded"] as Bool? ?? false }
-		set { kvStore["isOnboarded"] = newValue }
+		set {
+			kvStore["isOnboarded"] = newValue
+			NotificationCenter.default.post(name: Notification.Name.isOnboardedDidChange, object: nil)
+		}
 	}
 
 	var dateLastExposureDetection: Date? {


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

In a previous commit, many `NotificationCenter` notifications were removed. `SceneDelegate` relies on the `.isOnboardedDidChange` notification to dismiss the onboarding UI & show the main app UI. This broke the dismissing flow:

![2020-06-01_18-50-07](https://user-images.githubusercontent.com/66173406/83471558-d44b0980-a439-11ea-8629-8862be3f81dd.gif)

A quick fix would be to add the notification back into `SecureStore`. This is implemented here.