### PR TITLE
Installing fastlane including xcov

### DIFF
--- a/src/xcode/fastlane/README.md
+++ b/src/xcode/fastlane/README.md
@@ -8,9 +8,10 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-Install _fastlane_ using
+Install _fastlane_ including _xcov_ using
 ```
 [sudo] gem install fastlane -NV
+[sudo] gem install xcov
 ```
 or alternatively using `brew cask install fastlane`
 


### PR DESCRIPTION
I needed an extra 
```
sudo gem install xcov
```
Before, ```fastlane ios test``` has been complaining on missing xcov.

<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [-] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
