### PR TITLE
[Feature] If risk level changes, a local notification should be pushed (closes #209)

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -223,6 +223,18 @@ extension AppDelegate: ENATaskExecutionDelegate {
 				return
 			}
 
+			if let previousSummary = self.store.previousSummary {
+				let previousRiskLevel = RiskLevel(riskScore: previousSummary.maximumRiskScore)
+				let newRiskLevel = RiskLevel(riskScore: newSummary.maximumRiskScore)
+
+				if newRiskLevel > previousRiskLevel {
+				self.taskScheduler.notificationManager.presentNotification(
+					title: AppStrings.LocalNotifications.testResultsTitle,
+					body: AppStrings.LocalNotifications.testResultsBody,
+					identifier: ENATaskIdentifier.fetchTestResults.rawValue)
+				}
+			}
+
 			// persist the previous risk score to the store
 			self.store.previousSummary = ENExposureDetectionSummaryContainer(with: newSummary)
 

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/RiskLevel.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/RiskLevel.swift
@@ -18,8 +18,8 @@
 import ExposureNotification
 import Foundation
 
-enum RiskLevel {
-	case unknown
+enum RiskLevel: Int, Comparable {
+	case unknown = 0
 	case inactive
 	case low
 	case high
@@ -30,6 +30,10 @@ enum RiskLevel {
 			return
 		}
 		self = riskScore.riskLevel
+	}
+
+	static func < (lhs: RiskLevel, rhs: RiskLevel) -> Bool {
+		return lhs.rawValue < rhs.rawValue
 	}
 }
 


### PR DESCRIPTION
Background task logic check for determining if the risk level has increased since the previous time a detectExposures() API call was made. 
Present a User Notification, if so.

[issue here](https://sapjira.wdf.sap.corp/projects/EXPOSUREAPP/issues/EXPOSUREAPP-209)

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
