### PR TITLE
[Feature] Taskscheduler cleanup (closes #1020)

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -30,21 +30,32 @@ protocol CoronaWarnAppDelegate: AnyObject {
 
 protocol RequiresAppDependencies {
 	var client: Client { get }
-	var downloadedPackagesStore: DownloadedPackagesStore { get }
 	var store: Store { get }
 	var taskScheduler: ENATaskScheduler { get }
+	var downloadedPackagesStore: DownloadedPackagesStore { get }
 }
 
 extension RequiresAppDependencies {
-	var client: Client { UIApplication.coronaWarnDelegate().client }
-	var downloadedPackagesStore: DownloadedPackagesStore { UIApplication.coronaWarnDelegate().downloadedPackagesStore }
-	var store: Store { UIApplication.coronaWarnDelegate().store }
-	var taskScheduler: ENATaskScheduler { UIApplication.coronaWarnDelegate().taskScheduler }
+	var client: Client {
+		UIApplication.coronaWarnDelegate().client
+	}
+
+	var downloadedPackagesStore: DownloadedPackagesStore {
+		UIApplication.coronaWarnDelegate().downloadedPackagesStore
+	}
+
+	var store: Store {
+		UIApplication.coronaWarnDelegate().store
+	}
+
+	var taskScheduler: ENATaskScheduler {
+		UIApplication.coronaWarnDelegate().taskScheduler
+	}
 }
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-	let taskScheduler = ENATaskScheduler()
+	let taskScheduler = ENATaskScheduler.shared
 	private var exposureManager: ExposureManager = ENAExposureManager()
 	private var exposureDetectionTransaction: ExposureDetectionTransaction?
 	private var exposureSubmissionService: ENAExposureSubmissionService?

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -25,11 +25,12 @@ protocol CoronaWarnAppDelegate: AnyObject {
 	var client: Client { get }
 	var downloadedPackagesStore: DownloadedPackagesStore { get }
 	var store: Store { get }
+	var taskScheduler: ENATaskScheduler { get }
 }
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-	let taskScheduler = ENATaskScheduler.shared
+	let taskScheduler = ENATaskScheduler()
 	private var exposureManager: ExposureManager = ENAExposureManager()
 	private var exposureDetectionTransaction: ExposureDetectionTransaction?
 	private var exposureSubmissionService: ENAExposureSubmissionService?
@@ -110,8 +111,6 @@ extension AppDelegate: ExposureDetectionTransactionDelegate {
 	func exposureDetectionTransactionRequiresExposureDetector(_ transaction: ExposureDetectionTransaction) -> ExposureDetector {
 		exposureManager
 	}
-
-
 
 	func exposureDetectionTransaction(_: ExposureDetectionTransaction, didEndPrematurely reason: ExposureDetectionTransaction.DidEndPrematurelyReason) {
 		logError(message: "Exposure transaction failed: \(reason)")

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -28,6 +28,20 @@ protocol CoronaWarnAppDelegate: AnyObject {
 	var taskScheduler: ENATaskScheduler { get }
 }
 
+protocol RequiresAppDependencies {
+	var client: Client { get }
+	var downloadedPackagesStore: DownloadedPackagesStore { get }
+	var store: Store { get }
+	var taskScheduler: ENATaskScheduler { get }
+}
+
+extension RequiresAppDependencies {
+	var client: Client { UIApplication.coronaWarnDelegate().client }
+	var downloadedPackagesStore: DownloadedPackagesStore { UIApplication.coronaWarnDelegate().downloadedPackagesStore }
+	var store: Store { UIApplication.coronaWarnDelegate().store }
+	var taskScheduler: ENATaskScheduler { UIApplication.coronaWarnDelegate().taskScheduler }
+}
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 	let taskScheduler = ENATaskScheduler()

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -29,7 +29,7 @@ protocol CoronaWarnAppDelegate: AnyObject {
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-	let taskScheduler = ENATaskScheduler()
+	let taskScheduler = ENATaskScheduler.shared
 	private var exposureManager: ExposureManager = ENAExposureManager()
 	private var exposureDetectionTransaction: ExposureDetectionTransaction?
 	private var exposureSubmissionService: ENAExposureSubmissionService?
@@ -90,7 +90,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		UIDevice.current.isBatteryMonitoringEnabled = true
 
 		taskScheduler.taskDelegate = self
-		taskScheduler.registerBackgroundTaskRequests()
 		return true
 	}
 

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -44,7 +44,8 @@ protocol ENATaskExecutionDelegate: AnyObject {
 }
 
 final class ENATaskScheduler {
-	init() {
+	static let shared = ENATaskScheduler()
+	private init() {
 		registerBackgroundTaskRequests()
 	}
 

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -19,7 +19,7 @@ import BackgroundTasks
 import ExposureNotification
 import UIKit
 
-public enum ENATaskIdentifier: String, CaseIterable {
+enum ENATaskIdentifier: String, CaseIterable {
 	// only one task identifier is allowed have the .exposure-notification suffix
 	case detectExposures = "detect-exposures.exposure-notification"
 	case fetchTestResults = "fetch-test-results"
@@ -43,10 +43,8 @@ protocol ENATaskExecutionDelegate: AnyObject {
 	func executeFetchTestResults(task: BGTask)
 }
 
-public class ENATaskScheduler {
-	public static let shared = ENATaskScheduler()
-
-	public init() {
+final class ENATaskScheduler {
+	init() {
 		registerBackgroundTaskRequests()
 	}
 
@@ -66,17 +64,17 @@ public class ENATaskScheduler {
 		}
 	}
 
-	public func scheduleBackgroundTaskRequests() {
+	func scheduleBackgroundTaskRequests() {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
 		scheduleBackgroundTask(for: .detectExposures)
 		scheduleBackgroundTask(for: .fetchTestResults)
 	}
 
-	public func cancelAllBackgroundTaskRequests() {
+	func cancelAllBackgroundTaskRequests() {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
 	}
 
-	public func scheduleBackgroundTask(for taskIdentifier: ENATaskIdentifier) {
+	func scheduleBackgroundTask(for taskIdentifier: ENATaskIdentifier) {
 
 		let earliestBeginDate = Date(timeIntervalSinceNow: taskIdentifier.backgroundTaskScheduleInterval)
 		let taskRequest = BGProcessingTaskRequest(identifier: taskIdentifier.backgroundTaskSchedulerIdentifier)

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -44,13 +44,26 @@ protocol ENATaskExecutionDelegate: AnyObject {
 }
 
 public class ENATaskScheduler {
+	public static let shared = ENATaskScheduler()
+
+	public init() {
+		registerBackgroundTaskRequests()
+	}
+
 	weak var taskDelegate: ENATaskExecutionDelegate?
 	lazy var notificationManager = LocalNotificationManager()
 	typealias CompletionHandler = (() -> Void)
 
-	public func registerBackgroundTaskRequests() {
+	private func registerBackgroundTaskRequests() {
 		registerTask(with: .detectExposures, taskHander: executeExposureDetectionRequest(_:))
 		registerTask(with: .fetchTestResults, taskHander: executeFetchTestResults(_:))
+	}
+
+	private func registerTask(with taskIdentifier: ENATaskIdentifier, taskHander: @escaping ((BGTask) -> Void)) {
+		let identifierString = taskIdentifier.backgroundTaskSchedulerIdentifier
+		BGTaskScheduler.shared.register(forTaskWithIdentifier: identifierString, using: .main) { task in
+			taskHander(task)
+		}
 	}
 
 	public func scheduleBackgroundTaskRequests() {
@@ -61,13 +74,6 @@ public class ENATaskScheduler {
 
 	public func cancelAllBackgroundTaskRequests() {
 		BGTaskScheduler.shared.cancelAllTaskRequests()
-	}
-
-	private func registerTask(with taskIdentifier: ENATaskIdentifier, taskHander: @escaping ((BGTask) -> Void)) {
-		let identifierString = taskIdentifier.backgroundTaskSchedulerIdentifier
-		BGTaskScheduler.shared.register(forTaskWithIdentifier: identifierString, using: .main) { task in
-			taskHander(task)
-		}
 	}
 
 	public func scheduleBackgroundTask(for taskIdentifier: ENATaskIdentifier) {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -42,7 +42,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	#else
 	private let exposureManager = ENAExposureManager()
 	#endif
-	private let taskScheduler = ENATaskScheduler.shared
+	private lazy var taskScheduler = ENATaskScheduler()
 	private let navigationController: UINavigationController = .withLargeTitle()
 	private var homeController: HomeViewController?
 	var state = State(summary: nil, exposureManager: .init()) {
@@ -158,15 +158,15 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 	private func presentHomeVC() {
 		let vc = AppStoryboard.home.initiate(viewControllerType: HomeViewController.self) { [unowned self] coder in
-			let homeVC = HomeViewController(
+			HomeViewController(
 				coder: coder,
 				exposureManager: self.exposureManager,
 				client: UIApplication.coronaWarnDelegate().client,
 				store: self.store,
 				keyPackagesStore: self.diagnosisKeysStore,
-				delegate: self
+				delegate: self,
+				taskScheduler: self.taskScheduler
 			)
-			return homeVC
 		}
 
 		homeController = vc // strong ref needed

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -187,7 +187,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 						coder: coder,
 						pageType: .togetherAgainstCoronaPage,
 						exposureManager: self.exposureManager,
-						taskScheduler: self.taskScheduler,
 						store: self.store
 					)
 				}

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -42,7 +42,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	#else
 	private let exposureManager = ENAExposureManager()
 	#endif
-	private let taskScheduler = ENATaskScheduler()
+	private let taskScheduler = ENATaskScheduler.shared
 	private let navigationController: UINavigationController = .withLargeTitle()
 	private var homeController: HomeViewController?
 	var state = State(summary: nil, exposureManager: .init()) {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -20,17 +20,10 @@ import ExposureNotification
 import UIKit
 import Reachability
 
-final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDependencies {
 	// MARK: Properties
 
 	var window: UIWindow?
-	var store: Store {
-		UIApplication.coronaWarnDelegate().store
-	}
-
-	private var diagnosisKeysStore: DownloadedPackagesStore {
-		UIApplication.coronaWarnDelegate().downloadedPackagesStore
-	}
 
 	#if targetEnvironment(simulator) || COMMUNITY
 	// Enable third party contributors that do not have the required
@@ -42,7 +35,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	#else
 	private let exposureManager = ENAExposureManager()
 	#endif
-	private lazy var taskScheduler = ENATaskScheduler()
 	private let navigationController: UINavigationController = .withLargeTitle()
 	private var homeController: HomeViewController?
 	var state = State(summary: nil, exposureManager: .init()) {
@@ -161,9 +153,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 			HomeViewController(
 				coder: coder,
 				exposureManager: self.exposureManager,
-				client: UIApplication.coronaWarnDelegate().client,
+				client: self.client,
 				store: self.store,
-				keyPackagesStore: self.diagnosisKeysStore,
+				keyPackagesStore: self.downloadedPackagesStore,
 				delegate: self,
 				taskScheduler: self.taskScheduler
 			)

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -89,7 +89,7 @@ final class HomeInteractor {
 	}
 
 	private func startCheckRisk() {
-		let taskScheduler = ENATaskScheduler()
+		let taskScheduler = ENATaskScheduler.shared
 
 		// TODO: handle state of pending scheduled tasks to determin active state for manual refresh button
 		// TODO: disable manual trigger button

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -34,7 +34,8 @@ final class HomeViewController: UIViewController {
 		client: Client,
 		store: Store,
 		keyPackagesStore: DownloadedPackagesStore,
-		delegate: HomeViewControllerDelegate
+		delegate: HomeViewControllerDelegate,
+		taskScheduler: ENATaskScheduler
 	) {
 		self.client = client
 		self.store = store
@@ -46,7 +47,8 @@ final class HomeViewController: UIViewController {
 		homeInteractor = HomeInteractor(
 			homeViewController: self,
 			store: store,
-			state: .init(isLoading: false, summary: nil, exposureManager: .init())
+			state: .init(isLoading: false, summary: nil, exposureManager: .init()),
+			taskScheduler: taskScheduler
 		)
 
 		exposureSubmissionService = ENAExposureSubmissionService(

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -41,12 +41,10 @@ final class OnboardingInfoViewController: UIViewController {
 		coder: NSCoder,
 		pageType: OnboardingPageType,
 		exposureManager: ExposureManager,
-		taskScheduler: ENATaskScheduler,
 		store: Store
 	) {
 		self.pageType = pageType
 		self.exposureManager = exposureManager
-		self.taskScheduler = taskScheduler
 		self.store = store
 		super.init(coder: coder)
 	}
@@ -59,7 +57,6 @@ final class OnboardingInfoViewController: UIViewController {
 
 	var pageType: OnboardingPageType
 	var exposureManager: ExposureManager
-	var taskScheduler: ENATaskScheduler
 	var store: Store
 	@IBOutlet var imageView: UIImageView!
 	@IBOutlet var titleLabel: UILabel!
@@ -251,7 +248,6 @@ final class OnboardingInfoViewController: UIViewController {
 							completion?()
 						}
 					}
-					self.taskScheduler.scheduleBackgroundTaskRequests()
 					completion?()
 				}
 			}
@@ -305,7 +301,6 @@ final class OnboardingInfoViewController: UIViewController {
 				coder: coder,
 				pageType: nextPageType,
 				exposureManager: self.exposureManager,
-				taskScheduler: self.taskScheduler,
 				store: self.store
 			)
 		}


### PR DESCRIPTION
[1020](https://jira.itc.sap.com/browse/EXPOSUREAPP-1020)
iOS: Remove unused instances of ENATaskScheduler & ensure register background tasks cannot get called multiple times for the same tasks.

## Changes:
- We no longer use the `ENATaskScheduler` in the `OnboardingInfoViewController`
- The `ENATaskScheduler` is a helper wrapper class around Apple's `BGTaskScheduler`, which we now implement as a singleton, and instantiate in the AppDelegate.
To ensure `BGTaskScheduler.shared.register(forTaskWithIdentifier: , using)` is only called once per background task, we have:
  - Implemented `BGTaskScheduler` as a singleton
  - Made `registerBackgroundTaskRequests()` method private, and call on `init()`
  - Added `taskScheduler` to protocol `RequiresAppDependencies`, allowing other classes needing access to the scheduler to adhere to the protocol


## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
