### PR TITLE
Add HairlineConstraint; apply to InfoCollectionViewCell dividers.

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		51FE277B2475340300BB8144 /* HomeRiskLoadingItemViewConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE277A2475340300BB8144 /* HomeRiskLoadingItemViewConfigurator.swift */; };
 		51FE277D247535C400BB8144 /* RiskLoadingItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51FE277C247535C400BB8144 /* RiskLoadingItemView.xib */; };
 		51FE277F247535E300BB8144 /* RiskLoadingItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FE277E247535E300BB8144 /* RiskLoadingItemView.swift */; };
+		5BAB5B632487066E00935F43 /* HairlineConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAB5B622487066E00935F43 /* HairlineConstraint.swift */; };
 		710ABB1F2475115500948792 /* UITableViewController+Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710ABB1E2475115500948792 /* UITableViewController+Enum.swift */; };
 		710ABB23247513E300948792 /* DynamicTypeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710ABB22247513E300948792 /* DynamicTypeTableViewCell.swift */; };
 		710ABB25247514BD00948792 /* UIViewController+Segue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710ABB24247514BD00948792 /* UIViewController+Segue.swift */; };
@@ -373,6 +374,7 @@
 		51FE277A2475340300BB8144 /* HomeRiskLoadingItemViewConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRiskLoadingItemViewConfigurator.swift; sourceTree = "<group>"; };
 		51FE277C247535C400BB8144 /* RiskLoadingItemView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RiskLoadingItemView.xib; sourceTree = "<group>"; };
 		51FE277E247535E300BB8144 /* RiskLoadingItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiskLoadingItemView.swift; sourceTree = "<group>"; };
+		5BAB5B622487066E00935F43 /* HairlineConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HairlineConstraint.swift; sourceTree = "<group>"; };
 		710ABB1E2475115500948792 /* UITableViewController+Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Enum.swift"; sourceTree = "<group>"; };
 		710ABB22247513E300948792 /* DynamicTypeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeTableViewCell.swift; sourceTree = "<group>"; };
 		710ABB24247514BD00948792 /* UIViewController+Segue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Segue.swift"; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				71CC3EA0246D6BBF00217F2C /* DynamicTypeLabel.swift */,
 				713EA25A247818B000AB7EE8 /* DynamicTypeButton.swift */,
 				85E33443247EB357006E74EC /* CircularProgressView.swift */,
+				5BAB5B622487066E00935F43 /* HairlineConstraint.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1806,6 +1809,7 @@
 				51CE1B87246078B6002CF42A /* ActivateCollectionViewCell.swift in Sources */,
 				B1C6ED00247F23730066138F /* NotificationName.swift in Sources */,
 				EE22DB8D247FB43A001B0A71 /* ActionTableViewCell.swift in Sources */,
+				5BAB5B632487066E00935F43 /* HairlineConstraint.swift in Sources */,
 				51CE1BBD2460B1CB002CF42A /* CollectionViewCellConfigurator.swift in Sources */,
 				CD2EC329247D82EE00C6B3F9 /* NotificationSettingsViewController.swift in Sources */,
 				51C737BD245B349700286105 /* OnboardingInfoViewController.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Views/HairlineConstraint.swift
+++ b/src/xcode/ENA/ENA/Source/Views/HairlineConstraint.swift
@@ -1,0 +1,29 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import UIKit
+
+class HairlineConstraint: NSLayoutConstraint {
+	
+	override func awakeFromNib() {
+		super.awakeFromNib()
+		self.constant = 1.0 / UIScreen.main.scale
+	}
+	
+}

--- a/src/xcode/ENA/ENA/Source/Views/HairlineConstraint.swift
+++ b/src/xcode/ENA/ENA/Source/Views/HairlineConstraint.swift
@@ -23,7 +23,7 @@ class HairlineConstraint: NSLayoutConstraint {
 	
 	override func awakeFromNib() {
 		super.awakeFromNib()
-		self.constant = 1.0 / UIScreen.main.scale
+		constant = 1.0 / ((firstItem as? UIView)?.window?.screen.scale ?? UIScreen.main.scale)
 	}
 	
 }

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/InfoCollectionViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/InfoCollectionViewCell.xib
@@ -53,14 +53,14 @@
                                 <rect key="frame" x="0.0" y="0.0" width="511" height="1"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="Cw1-60-Y7w"/>
+                                    <constraint firstAttribute="height" constant="1" id="Cw1-60-Y7w" customClass="HairlineConstraint" customModule="ENA" customModuleProvider="target"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XOU-zh-DXY">
                                 <rect key="frame" x="0.0" y="189" width="511" height="1"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="zQG-IC-duh"/>
+                                    <constraint firstAttribute="height" constant="1" id="zQG-IC-duh" customClass="HairlineConstraint" customModule="ENA" customModuleProvider="target"/>
                                 </constraints>
                             </view>
                         </subviews>


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

The hairline constraint is used on top and bottom divider view height constraints to render the separators with 1px height instead of 1pt. This makes the collection view cells look more similar to the grouped table view cells that are being used in many other views of the app.