### PR TITLE
Improve logging performance and don't log in production

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/Logger.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logger.swift
@@ -19,12 +19,14 @@ import Foundation
 
 let appLogger = Logger()
 
-func log(message: String, level _: LogLevel = .info, file _: String = #file, line _: UInt = #line, function _: String = #function) {
-	NSLog("%@", message)
+func log(message: String, level: LogLevel = .info, file: String = #file, line: UInt = #line, function: String = #function) {
+	#if DEBUG
+	print("\(level.rawValue.uppercased()): [\((file as NSString).lastPathComponent):\(line) - \(function)]\n \(message)")
+	#endif
 }
 
-func logError(message: String, level _: LogLevel = .error, file _: String = #file, line _: UInt = #line, function _: String = #function) {
-	NSLog("%@", message)
+func logError(message: String, level: LogLevel = .error, file: String = #file, line: UInt = #line, function: String = #function) {
+	log(message: message, level: .error, file: file, line: line, function: function)
 }
 
 class Logger {
@@ -35,7 +37,7 @@ class Logger {
 	}
 }
 
-enum LogLevel {
+enum LogLevel: String {
 	case info
 	case warning
 	case error


### PR DESCRIPTION
- Prefer print over NSLog since print is less expensive
- Add debug level, file, function and line to log output
- Do not log on production

Logging with NSLog is more expensive than with print. Also please log only in debug sessions not in production.
See: https://developer.apple.com/library/archive/technotes/tn2347/_index.html or https://stackoverflow.com/questions/25951195/swift-print-vs-println-vs-nslog

This PR also adds more context like the file, function and line: see the following example: 
<img width="868" alt="Screenshot 2020-06-03 at 09 15 03" src="https://user-images.githubusercontent.com/397342/83607922-50e60100-a57c-11ea-9aa3-a3cc383f893d.png">
 