### PR TITLE
[Feature] Add support for attributed strings

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		2F80CFD9247ED988000F06AF /* ExposureSubmissionIntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80CFD8247ED988000F06AF /* ExposureSubmissionIntroViewController.swift */; };
 		2F80CFDB247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80CFDA247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift */; };
 		2F80CFDD247EEB88000F06AF /* DynamicTableViewImageCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80CFDC247EEB88000F06AF /* DynamicTableViewImageCardCell.swift */; };
+		2FF1D62E2487850200381FFB /* NSMutableAttributedString+Generation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1D62D2487850200381FFB /* NSMutableAttributedString+Generation.swift */; };
 		514C0A0624772F3400F235F6 /* HomeRiskViewConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514C0A0524772F3400F235F6 /* HomeRiskViewConfigurator.swift */; };
 		514C0A0824772F5E00F235F6 /* RiskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514C0A0724772F5E00F235F6 /* RiskItemView.swift */; };
 		514C0A0B247AF9F700F235F6 /* RiskTextItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 514C0A0A247AF9F700F235F6 /* RiskTextItemView.xib */; };
@@ -318,6 +319,7 @@
 		2F80CFD8247ED988000F06AF /* ExposureSubmissionIntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionIntroViewController.swift; sourceTree = "<group>"; };
 		2F80CFDA247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionHotlineViewController.swift; sourceTree = "<group>"; };
 		2F80CFDC247EEB88000F06AF /* DynamicTableViewImageCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewImageCardCell.swift; sourceTree = "<group>"; };
+		2FF1D62D2487850200381FFB /* NSMutableAttributedString+Generation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Generation.swift"; sourceTree = "<group>"; };
 		5111E7622460BB1500ED6498 /* HomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInteractor.swift; sourceTree = "<group>"; };
 		514C0A0524772F3400F235F6 /* HomeRiskViewConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRiskViewConfigurator.swift; sourceTree = "<group>"; };
 		514C0A0724772F5E00F235F6 /* RiskItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiskItemView.swift; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 				B1D6B003247DA4920079DDD3 /* UIApplication+CoronaWarn.swift */,
 				EE22DB92247FB4BB001B0A71 /* Reachability+ObserverDelegate.swift */,
 				2F3218CF248063E300A7AC0A /* UIView+Convenience.swift */,
+				2FF1D62D2487850200381FFB /* NSMutableAttributedString+Generation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1791,6 +1794,7 @@
 				7154EB4C247E862100A467FF /* ExposureDetectionLoadingCell.swift in Sources */,
 				A17366552484978A006BE209 /* OnboardingInfoViewControllerUtils.swift in Sources */,
 				B153096A24706F1000A4A1BD /* URLSession+Default.swift in Sources */,
+				2FF1D62E2487850200381FFB /* NSMutableAttributedString+Generation.swift in Sources */,
 				B13FF409247EC67F00535F37 /* HomeViewController+State.swift in Sources */,
 				51CE1B4C246016D1002CF42A /* UICollectionReusableView+Identifier.swift in Sources */,
 				013DC102245DAC4E00EE58B0 /* Store.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -187,14 +187,17 @@ Die App merkt sich Begegnungen zwischen Menschen, indem ihre Smartphones verschl
 "ExposureSubmissionDispatch_TANButtonTitle" = "TAN-Code";
 "ExposureSubmissionDispatch_TANButtonDescription" = "Registrieren Sie Ihren Test per manueller TAN Eingabe.";
 "ExposureSubmissionDispatch_HotlineButtonTitle" = "Noch keine TAN?";
-"ExposureSubmissionDispatch_HotlineButtonDescription" = "Bitte rufen Sie uns an, falls Sie Positiv getestet wurden.";
+"ExposureSubmissionDispatch_HotlineButtonDescription" = "Bitte rufen Sie uns an, falls Sie %@ getestet wurden.";
+"ExposureSubmissionDispatch_HotlineButtonPositiveWord" = "Positiv";
 
 "ExposureSubmissionHotline_Title" = "TAN anfragen";
 "ExposureSubmissionHotline_Description" = "Wir teilen Ihnen Ihren TAN-Code gerne per Telefon mit.";
 "ExposureSubmissionHotline_SectionTitle" = "Info zum Ablauf:";
 "ExposureSubmissionHotline_SectionDescription1" = "Hotline anrufen & TAN erfragen:
 
-+49 (0) 800 7540002";
+%@
+";
+"ExposureSubmission_PhoneNumber" = "+49 (0) 800 7540002";
 "ExposureSubmission_SectionDescription2" = "Test per TAN-Eingabe in der App registrieren";
 "ExposureSubmission_CallButtonTitle" = "Anrufen";
 "ExposureSubmission_TANInputButtonTitle" = "TAN-Code eingeben";

--- a/src/xcode/ENA/ENA/Source/Extensions/NSMutableAttributedString+Generation.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/NSMutableAttributedString+Generation.swift
@@ -1,0 +1,40 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+
+
+extension NSMutableAttributedString {
+
+	/// Generates an attributed string from a normal text + attributed text injected into this text.
+	static func generateAttributedString(normalText: String, attributedText: [NSAttributedString]) -> NSMutableAttributedString {
+
+		let components = normalText.components(separatedBy: "%@")
+		let adjusted: NSMutableAttributedString = NSMutableAttributedString(string: "")
+
+		for (index, element) in components.enumerated() {
+			adjusted.append(NSAttributedString(string: element))
+			if index < attributedText.count {
+				adjusted.append(attributedText[index])
+			}
+		}
+
+		return adjusted
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewImageCardCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewImageCardCell.swift
@@ -144,4 +144,38 @@ class DynamicTableViewImageCardCell: UITableViewCell {
 			cellImage.image = image
 		}
 	}
+
+	/// TODO: Comment me!
+	func configure(title: String, image: UIImage?, body: String, attributedStrings: [NSAttributedString]) {
+		setup()
+		setupConstraints()
+		self.title.text = title
+		self.body.attributedText = NSMutableAttributedString.generateAttributedString(
+			normalText: body,
+			attributedText: attributedStrings
+		)
+		if let image = image {
+			cellImage.image = image
+		}
+	}
+}
+
+// TODO: Move me!
+extension NSMutableAttributedString {
+
+	// TODO: Comment!!
+	static func generateAttributedString(normalText: String, attributedText: [NSAttributedString]) -> NSMutableAttributedString {
+
+		let components = normalText.components(separatedBy: "%@")
+		let adjusted: NSMutableAttributedString = NSMutableAttributedString(string: "")
+
+		for (index, element) in components.enumerated() {
+			adjusted.append(NSAttributedString(string: element))
+			if index < attributedText.count {
+				adjusted.append(attributedText[index])
+			}
+		}
+
+		return adjusted
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewImageCardCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewImageCardCell.swift
@@ -145,7 +145,13 @@ class DynamicTableViewImageCardCell: UITableViewCell {
 		}
 	}
 
-	/// TODO: Comment me!
+	/// This method builds a NSMutableAttributedString for the cell.
+	/// - Parameters:
+	///   - title: The title of the cell.
+	///   - image: The image to be displayed on the right hand of the cell.
+	///   - body: The text shown below the title, which should NOT be formatted in any way.
+	///   - attributedStrings: The text that is injected into `body` with applied attributes, e.g.
+	/// 	bold text, with color.
 	func configure(title: String, image: UIImage?, body: String, attributedStrings: [NSAttributedString]) {
 		setup()
 		setupConstraints()
@@ -157,25 +163,5 @@ class DynamicTableViewImageCardCell: UITableViewCell {
 		if let image = image {
 			cellImage.image = image
 		}
-	}
-}
-
-// TODO: Move me!
-extension NSMutableAttributedString {
-
-	// TODO: Comment!!
-	static func generateAttributedString(normalText: String, attributedText: [NSAttributedString]) -> NSMutableAttributedString {
-
-		let components = normalText.components(separatedBy: "%@")
-		let adjusted: NSMutableAttributedString = NSMutableAttributedString(string: "")
-
-		for (index, element) in components.enumerated() {
-			adjusted.append(NSAttributedString(string: element))
-			if index < attributedText.count {
-				adjusted.append(attributedText[index])
-			}
-		}
-
-		return adjusted
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewStepCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewStepCell.swift
@@ -154,6 +154,17 @@ class DynamicTableViewStepCell: UITableViewCell {
 		separator.centerXAnchor.constraint(equalTo: cellIcon.centerXAnchor).isActive = true
 	}
 
+	/// Default configurator for a DynamicStepCell.
+	/// - Parameters:
+	///   - text: The text shown in the cell which should NOT be formatted in any way.
+	///   - attributedText: The text that is injected into `body` with applied attributes, e.g.
+	/// 	bold text, with color.
+	///   - image: The image to be displayed on the right hand of the cell.
+	///   - hasSeparators: boolean that indicates whether the cell has a grey
+	///     separator or not.
+	///   - isCircle: boolean indicating whether the icon of the cell is circular or not.
+	///   - iconTintColor: tintColor for the icon of the cell.
+	///   - iconBackgroundColor: background color for the icon of the cell.
 	func configure(
 		title: String? = nil,
 		text: String,
@@ -167,6 +178,17 @@ class DynamicTableViewStepCell: UITableViewCell {
 		setConstraints()
 	}
 
+	/// Configurator for a DynamicStepCell that supports NSAttributedStrings.
+	/// - Parameters:
+	///   - text: The text shown in the cell which should NOT be formatted in any way.
+	///   - attributedText: The text that is injected into `body` with applied attributes, e.g.
+	/// 	bold text, with color.
+	///   - image: The image to be displayed on the right hand of the cell.
+	///   - hasSeparators: boolean that indicates whether the cell has a grey
+	///     separator or not.
+	///   - isCircle: boolean indicating whether the icon of the cell is circular or not.
+	///   - iconTintColor: tintColor for the icon of the cell.
+	///   - iconBackgroundColor: background color for the icon of the cell.
 	func configure(
 		text: String,
 		attributedText: [NSAttributedString],

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewStepCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewStepCell.swift
@@ -75,6 +75,42 @@ class DynamicTableViewStepCell: UITableViewCell {
 		separator.isHidden = !hasSeparators
 	}
 
+	private func setUpView(
+		_ attributedText: NSMutableAttributedString,
+		_ image: UIImage?,
+		_ hasSeparators: Bool = false,
+		_: Bool = false,
+		_ iconTintColor: UIColor? = nil,
+		_ iconBackgroundColor: UIColor? = nil
+	) {
+		// MARK: - Cell related changes.
+
+		selectionStyle = .none
+		backgroundColor = .preferredColor(for: .backgroundPrimary)
+
+		// MARK: - Body.
+
+		body.font = .preferredFont(forTextStyle: .body)
+		body.numberOfLines = 0
+		body.lineBreakMode = .byWordWrapping
+		body.attributedText = attributedText
+
+		// MARK: - Cell Icon.
+
+		var loadedImage = image
+		if iconTintColor != nil {
+			loadedImage = image?.withRenderingMode(.alwaysTemplate)
+		}
+		cellIcon = UIImageView(image: loadedImage)
+		cellIcon.tintColor = iconTintColor
+		cellIcon.backgroundColor = iconBackgroundColor
+
+		// MARK: - Separator.
+
+		separator.backgroundColor = .preferredColor(for: .textPrimary2)
+		separator.isHidden = !hasSeparators
+	}
+
 	// MARK: - Constraint handling.
 
 	var heightConstraint: NSLayoutConstraint?
@@ -128,6 +164,29 @@ class DynamicTableViewStepCell: UITableViewCell {
 		iconBackgroundColor: UIColor? = nil
 	) {
 		setUpView(title, text, image, hasSeparators, isCircle, iconTintColor, iconBackgroundColor)
+		setConstraints()
+	}
+
+	func configure(
+		text: String,
+		attributedText: [NSAttributedString],
+		image: UIImage?,
+		hasSeparators: Bool = false,
+		isCircle: Bool = false,
+		iconTintColor: UIColor? = nil,
+		iconBackgroundColor: UIColor? = nil
+	) {
+
+		setUpView(NSMutableAttributedString.generateAttributedString(
+					  normalText: text,
+					  attributedText: attributedText
+				  ),
+				  image,
+				  hasSeparators,
+				  isCircle,
+				  iconTintColor
+		)
+		
 		setConstraints()
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
@@ -272,7 +272,7 @@ extension ExposureDetectionViewController {
 					subtitle: AppStrings.ExposureDetection.explanationSubtitle,
 					action: .open(url: URL(string: AppStrings.ExposureDetection.moreInformationUrl))
 				),
-				.regular(text: text)
+				.body(text: text)
 			]
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
@@ -67,12 +67,15 @@ class ExposureSubmissionHotlineViewController: DynamicTableViewController {
 				DynamicSection.section(
 					cells: [
 						.bigBold(text: AppStrings.ExposureSubmissionHotline.sectionTitle),
-						.identifier(CustomCellReuseIdentifiers.stepCell, action: .none, configure: { _, cell, _ in
-							guard let cell = cell as? DynamicTableViewStepCell else { return }
-							cell.configure(
-								text: AppStrings.ExposureSubmissionHotline.sectionDescription1,
-								image: UIImage(named: "Icons_Grey_1")
-							)
+						.identifier(CustomCellReuseIdentifiers.stepCell,
+									action: .execute { _ in self.callHotline() },
+									configure: { _, cell, _ in
+										guard let cell = cell as? DynamicTableViewStepCell else { return }
+										cell.configure(
+											text: AppStrings.ExposureSubmissionHotline.sectionDescription1,
+											attributedText: self.getAttributedStrings(),
+											image: UIImage(named: "Icons_Grey_1")
+										)
                         }),
 						.identifier(CustomCellReuseIdentifiers.stepCell, action: .none, configure: { _, cell, _ in
 							guard let cell = cell as? DynamicTableViewStepCell else { return }
@@ -84,6 +87,16 @@ class ExposureSubmissionHotlineViewController: DynamicTableViewController {
 					])
 			]
 		)
+	}
+
+	/// Comment me.
+	private func getAttributedStrings() -> [NSAttributedString] {
+		let font: UIFont = .preferredFont(forTextStyle: .body)
+		let boldFont: UIFont = UIFont.boldSystemFont(ofSize: font.pointSize)
+		let color: UIColor = .preferredColor(for: .tint)
+		let attr: [NSAttributedString.Key: Any] = [.font: boldFont, .foregroundColor: color]
+		let word = NSAttributedString(string: AppStrings.ExposureSubmissionHotline.phoneNumber, attributes: attr)
+		return [word]
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
@@ -89,7 +89,7 @@ class ExposureSubmissionHotlineViewController: DynamicTableViewController {
 		)
 	}
 
-	/// Comment me.
+	/// Gets the attributed string that makes the phone number blue and bold.
 	private func getAttributedStrings() -> [NSAttributedString] {
 		let font: UIFont = .preferredFont(forTextStyle: .body)
 		let boldFont: UIFont = UIFont.boldSystemFont(ofSize: font.pointSize)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
@@ -61,12 +61,12 @@ class ExposureSubmissionHotlineViewController: DynamicTableViewController {
 				.section(
 					header: .image(UIImage(named: "Illu_Submission_Kontakt")),
 					cells: [
-						.regular(text: AppStrings.ExposureSubmissionHotline.description)
+						.body(text: AppStrings.ExposureSubmissionHotline.description)
 					]
 				),
 				DynamicSection.section(
 					cells: [
-						.bigBold(text: AppStrings.ExposureSubmissionHotline.sectionTitle),
+						.title2(text: AppStrings.ExposureSubmissionHotline.sectionTitle),
 						.identifier(CustomCellReuseIdentifiers.stepCell,
 									action: .execute { _ in self.callHotline() },
 									configure: { _, cell, _ in

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionIntroViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionIntroViewController.swift
@@ -121,8 +121,8 @@ private extension DynamicTableViewModel {
 			header: .image(UIImage(named: "Illu_Submission_Funktion1"), height: 200),
 			separators: false,
 			cells: [
-				.bold(text: AppStrings.ExposureSubmissionIntroduction.usage01),
-				.regular(text: AppStrings.ExposureSubmissionIntroduction.usage02),
+				.headline(text: AppStrings.ExposureSubmissionIntroduction.usage01),
+				.body(text: AppStrings.ExposureSubmissionIntroduction.usage02),
 				.identifier(
 					ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell,
 					action: .none,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -235,7 +235,7 @@ private extension ExposureSubmissionOverviewViewController {
 				header: header,
 				separators: false,
 				cells: [
-					.regular(text: AppStrings.ExposureSubmissionDispatch.description)
+					.body(text: AppStrings.ExposureSubmissionDispatch.description)
 				]
 			)
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -269,7 +269,6 @@ private extension ExposureSubmissionOverviewViewController {
 			),
 			.identifier(
 				CustomCellReuseIdentifiers.imageCard,
-				// TODO: Add number.
 				action: .perform(segue: Segue.hotline),
 				configure: { _, cell, _ in
 					guard let cell = cell as? DynamicTableViewImageCardCell else { return }
@@ -286,7 +285,7 @@ private extension ExposureSubmissionOverviewViewController {
 		return data
 	}
 
-	/// Comment me.
+	/// Gets the attributed string that makes the "Positive" word bold.
 	private func getAttributedStrings() -> [NSAttributedString] {
 		let font: UIFont = .preferredFont(forTextStyle: .body)
 		let boldFont: UIFont = UIFont.boldSystemFont(ofSize: font.pointSize)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -269,19 +269,30 @@ private extension ExposureSubmissionOverviewViewController {
 			),
 			.identifier(
 				CustomCellReuseIdentifiers.imageCard,
+				// TODO: Add number.
 				action: .perform(segue: Segue.hotline),
 				configure: { _, cell, _ in
 					guard let cell = cell as? DynamicTableViewImageCardCell else { return }
 					cell.configure(
 						title: AppStrings.ExposureSubmissionDispatch.hotlineButtonTitle,
 						image: UIImage(named: "Illu_Submission_Anruf"),
-						body: AppStrings.ExposureSubmissionDispatch.hotlineButtonDescription
+						body: AppStrings.ExposureSubmissionDispatch.hotlineButtonDescription,
+						attributedStrings: self.getAttributedStrings()
 					)
 				}
 			)
 		]))
 
 		return data
+	}
+
+	/// Comment me.
+	private func getAttributedStrings() -> [NSAttributedString] {
+		let font: UIFont = .preferredFont(forTextStyle: .body)
+		let boldFont: UIFont = UIFont.boldSystemFont(ofSize: font.pointSize)
+		let attr: [NSAttributedString.Key: Any] = [.font: boldFont]
+		let word = NSAttributedString(string: AppStrings.ExposureSubmissionDispatch.positiveWord, attributes: attr)
+		return [word]
 	}
 
 	private func transitionToQRScanner(_: UIViewController) {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionSuccessViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionSuccessViewController.swift
@@ -55,8 +55,8 @@ private extension DynamicTableViewModel {
 			header: .image(UIImage(named: "Illu_Submission_VielenDank")),
 			separators: false,
 			cells: [
-				.regular(text: AppStrings.ExposureSubmissionSuccess.description),
-				.bigBold(text: AppStrings.ExposureSubmissionSuccess.listTitle),
+				.body(text: AppStrings.ExposureSubmissionSuccess.description),
+				.title2(text: AppStrings.ExposureSubmissionSuccess.listTitle),
 				.identifier(
 					ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell,
 					action: .none,
@@ -84,7 +84,7 @@ private extension DynamicTableViewModel {
 						)
 					}
 				),
-				.bigBold(text: AppStrings.ExposureSubmissionSuccess.subTitle),
+				.title2(text: AppStrings.ExposureSubmissionSuccess.subTitle),
 				.identifier(
 					ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell,
 					action: .none,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTestResultViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTestResultViewController.swift
@@ -227,7 +227,7 @@ private extension ExposureSubmissionTestResultViewController {
 			),
 			separators: false,
 			cells: [
-				.bigBold(text: AppStrings.ExposureSubmissionResult.procedure),
+				.title2(text: AppStrings.ExposureSubmissionResult.procedure),
 				.stepCellWith(
 					title: AppStrings.ExposureSubmissionResult.testAdded,
 					text: AppStrings.ExposureSubmissionResult.testAddedDesc,
@@ -258,7 +258,7 @@ private extension ExposureSubmissionTestResultViewController {
 			),
 			separators: false,
 			cells: [
-				.bigBold(text: AppStrings.ExposureSubmissionResult.procedure),
+				.title2(text: AppStrings.ExposureSubmissionResult.procedure),
 				.stepCellWith(
 					title: AppStrings.ExposureSubmissionResult.testAdded,
 					text: AppStrings.ExposureSubmissionResult.testAddedDesc,
@@ -276,7 +276,7 @@ private extension ExposureSubmissionTestResultViewController {
 					image: nil,
 					hasSeparators: false
 				),
-				.bigBold(text: AppStrings.ExposureSubmissionResult.furtherInfos_Title),
+				.title2(text: AppStrings.ExposureSubmissionResult.furtherInfos_Title),
 				.stepCellWith(
 					title: nil,
 					text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem1,
@@ -315,7 +315,7 @@ private extension ExposureSubmissionTestResultViewController {
 			),
 			separators: false,
 			cells: [
-				.bigBold(text: AppStrings.ExposureSubmissionResult.procedure),
+				.title2(text: AppStrings.ExposureSubmissionResult.procedure),
 				.stepCellWith(
 					title: AppStrings.ExposureSubmissionResult.testAdded,
 					text: AppStrings.ExposureSubmissionResult.testAddedDesc,
@@ -340,7 +340,7 @@ private extension ExposureSubmissionTestResultViewController {
 				}
 			),
 			cells: [
-				.bigBold(text: AppStrings.ExposureSubmissionResult.procedure),
+				.title2(text: AppStrings.ExposureSubmissionResult.procedure),
 				.stepCellWith(
 					title: AppStrings.ExposureSubmissionResult.testAdded,
 					text: AppStrings.ExposureSubmissionResult.testAddedDesc,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
@@ -110,9 +110,9 @@ private extension ExposureSubmissionWarnOthersViewController {
 				.section(
 					header: .image(UIImage(named: "Illu_Submission_AndereWarnen"), height: 250),
 					cells: [
-						.bigBold(text: AppStrings.ExposureSubmissionWarnOthers.sectionTitle),
-						.regular(text: AppStrings.ExposureSubmissionWarnOthers.description),
-						.regular(text: AppStrings.ExposureSubmissionWarnOthers.dataPrivacyDescription)
+						.title2(text: AppStrings.ExposureSubmissionWarnOthers.sectionTitle),
+						.body(text: AppStrings.ExposureSubmissionWarnOthers.description),
+						.body(text: AppStrings.ExposureSubmissionWarnOthers.dataPrivacyDescription)
 					]
 				)
 			)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -106,7 +106,6 @@ enum AppStrings {
 		static let tanButtonDescription = NSLocalizedString("ExposureSubmissionDispatch_TANButtonDescription", comment: "")
 		static let hotlineButtonTitle = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonTitle", comment: "")
 		static let hotlineButtonDescription = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonDescription", comment: "")
-		// TODO: add me to app strings.
 		static let positiveWord = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonPositiveWord", comment: "")
 	}
 

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -106,6 +106,8 @@ enum AppStrings {
 		static let tanButtonDescription = NSLocalizedString("ExposureSubmissionDispatch_TANButtonDescription", comment: "")
 		static let hotlineButtonTitle = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonTitle", comment: "")
 		static let hotlineButtonDescription = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonDescription", comment: "")
+		// TODO: add me to app strings.
+		static let positiveWord = NSLocalizedString("ExposureSubmissionDispatch_HotlineButtonPositiveWord", comment: "")
 	}
 
 	enum ExposureSubmissionHotline {
@@ -116,6 +118,7 @@ enum AppStrings {
 		static let sectionDescription2 = NSLocalizedString("ExposureSubmission_SectionDescription2", comment: "")
 		static let callButtonTitle = NSLocalizedString("ExposureSubmission_CallButtonTitle", comment: "")
 		static let tanInputButtonTitle = NSLocalizedString("ExposureSubmission_TANInputButtonTitle", comment: "")
+		static let phoneNumber = NSLocalizedString("ExposureSubmission_PhoneNumber", comment: "")
 	}
 
 	enum ExposureSubmissionWarnOthers {


### PR DESCRIPTION
## Description
I added support for attributed strings, because it was needed in some of the mockups. 
Example: 

![image](https://user-images.githubusercontent.com/15066374/83613258-d4efb700-a583-11ea-8a9a-04cd37fe90c6.png)
![image](https://user-images.githubusercontent.com/15066374/83613566-3fa0f280-a584-11ea-94e3-fb69fed16672.png)

