### PR TITLE
[Bug] Notifications state on Settings screen (#1008)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -149,7 +149,7 @@ final class SettingsViewController: UITableViewController {
 				return
 			}
 
-			if granted, self.store.allowRiskChangesNotification, self.store.allowTestsStatusNotification {
+			if granted && (self.store.allowRiskChangesNotification || self.store.allowTestsStatusNotification) {
 				self.settingsViewModel.notifications.setState(state: true)
 			} else {
 				self.settingsViewModel.notifications.setState(state: false)


### PR DESCRIPTION
This is a very simple change that allows showing Notifications state in Settings screen as On/An, when any of two types of notifications are on. 