### PR TITLE
[feature] Persist bool & timestamp for DPP (closes #440)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -210,6 +210,11 @@ final class OnboardingInfoViewController: UIViewController {
 			return
 		}
 
+		func persistForDPP(accepted: Bool) {
+			self.store.submitConsentAccept = accepted
+			self.store.submitConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
+		}
+
 		guard !exposureManagerActivated else {
 			completion?()
 			return
@@ -230,6 +235,7 @@ final class OnboardingInfoViewController: UIViewController {
 					return
 				}
 				self.showError(error, from: self, completion: completion)
+				persistForDPP(accepted: false)
 				completion?()
 			} else {
 				self.exposureManagerActivated = true
@@ -247,6 +253,9 @@ final class OnboardingInfoViewController: UIViewController {
 							// The error condition here should not really happen as we are inside the `enable()` completion block
 							completion?()
 						}
+						persistForDPP(accepted: false)
+					} else {
+						persistForDPP(accepted: true)
 					}
 					completion?()
 				}

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -211,8 +211,8 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 
 		func persistForDPP(accepted: Bool) {
-			self.store.submissionConsentAccept = accepted
-			self.store.submissionConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
+			self.store.exposureActivationConsentAccept = accepted
+			self.store.exposureActivationConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
 		}
 
 		guard !exposureManagerActivated else {

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -211,8 +211,8 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 
 		func persistForDPP(accepted: Bool) {
-			self.store.submitConsentAccept = accepted
-			self.store.submitConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
+			self.store.submissionConsentAccept = accepted
+			self.store.submissionConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
 		}
 
 		guard !exposureManagerActivated else {

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -31,9 +31,9 @@ class MockTestStore: Store {
 
 	var initialSubmitCompleted: Bool = false
 
-	var submissionConsentAcceptTimestamp: Int64?
+	var exposureActivationConsentAcceptTimestamp: Int64?
 
-	var submissionConsentAccept: Bool = false
+	var exposureActivationConsentAccept: Bool = false
 
 	var isOnboarded: Bool = false
 

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -31,9 +31,9 @@ class MockTestStore: Store {
 
 	var initialSubmitCompleted: Bool = false
 
-	var submitConsentAcceptTimestamp: Int64?
+	var submissionConsentAcceptTimestamp: Int64?
 
-	var submitConsentAccept: Bool = false
+	var submissionConsentAccept: Bool = false
 
 	var isOnboarded: Bool = false
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store.swift
@@ -59,11 +59,11 @@ protocol Store: AnyObject {
 
 	// An integer value representing the timestamp when the user
 	// accepted to submit his diagnosisKeys with the CWA submission service.
-	var submissionConsentAcceptTimestamp: Int64? { get set }
+	var exposureActivationConsentAcceptTimestamp: Int64? { get set }
 
 	// A boolean storing if the user has confirmed to submit
 	// his diagnosiskeys to the CWA submission service.
-	var submissionConsentAccept: Bool { get set }
+	var exposureActivationConsentAccept: Bool { get set }
 
 	func clearAll()
 	}
@@ -114,14 +114,14 @@ final class SecureStore: Store {
 		set { kvStore["initialSubmitCompleted"] = newValue }
 		}
 
-	var submissionConsentAcceptTimestamp: Int64? {
-		get { kvStore["submissionConsentAcceptTimestamp"] as Int64? ?? 0 }
-		set { kvStore["submissionConsentAcceptTimestamp"] = newValue }
+	var exposureActivationConsentAcceptTimestamp: Int64? {
+		get { kvStore["exposureActivationConsentAcceptTimestamp"] as Int64? ?? 0 }
+		set { kvStore["exposureActivationConsentAcceptTimestamp"] = newValue }
 	}
 
-	var submissionConsentAccept: Bool {
-		get { kvStore["submissionConsentAccept"] as Bool? ?? false }
-		set { kvStore["submissionConsentAccept"] = newValue }
+	var exposureActivationConsentAccept: Bool {
+		get { kvStore["exposureActivationConsentAccept"] as Bool? ?? false }
+		set { kvStore["exposureActivationConsentAccept"] = newValue }
 		}
 
 	var registrationToken: String? {

--- a/src/xcode/ENA/ENA/Source/Workers/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store.swift
@@ -59,11 +59,11 @@ protocol Store: AnyObject {
 
 	// An integer value representing the timestamp when the user
 	// accepted to submit his diagnosisKeys with the CWA submission service.
-	var submitConsentAcceptTimestamp: Int64? { get set }
+	var submissionConsentAcceptTimestamp: Int64? { get set }
 
 	// A boolean storing if the user has confirmed to submit
 	// his diagnosiskeys to the CWA submission service.
-	var submitConsentAccept: Bool { get set }
+	var submissionConsentAccept: Bool { get set }
 
 	func clearAll()
 	}
@@ -114,14 +114,14 @@ final class SecureStore: Store {
 		set { kvStore["initialSubmitCompleted"] = newValue }
 		}
 
-	var submitConsentAcceptTimestamp: Int64? {
-		get { kvStore["submitConsentAcceptTimestamp"] as Int64? ?? 0 }
-		set { kvStore["submitConsentAcceptTimestamp"] = newValue }
+	var submissionConsentAcceptTimestamp: Int64? {
+		get { kvStore["submissionConsentAcceptTimestamp"] as Int64? ?? 0 }
+		set { kvStore["submissionConsentAcceptTimestamp"] = newValue }
 	}
 
-	var submitConsentAccept: Bool {
-		get { kvStore["submitConsentAccept"] as Bool? ?? false }
-		set { kvStore["submitConsentAccept"] = newValue }
+	var submissionConsentAccept: Bool {
+		get { kvStore["submissionConsentAccept"] as Bool? ?? false }
+		set { kvStore["submissionConsentAccept"] = newValue }
 		}
 
 	var registrationToken: String? {


### PR DESCRIPTION
https://jira.itc.sap.com/browse/EXPOSUREAPP-440

Persist submitConsentAccept & submitConsentAcceptTimestamp in the store after exposureManager.activate() is called

