### PR TITLE
[Feature] submission check for framework

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -298,6 +298,8 @@ Da nur unpersönliche Zufallscodes übertragen werden, bleibt Ihre Identität un
 "ExposureSubmissionError_other" = "Fehler: ";
 "ExposureSubmissionError_unknown" = "Unbekannter Fehler";
 "ExposureSubmissionError_defaultError" = "Allgemeinier Exposure Submission Fehler";
+"ExposureSubmissionError_EnNotEnabledForWarnOthersTitle" = "Fehler";
+"ExposureSubmissionError_EnNotEnabledForWarnOthersDescription" = "Bitte aktivieren Sie die Risiko-Ermittlung um andere zu warnen.";
 
 /* Tracing Enable/Disable Settings */
 "ExposureNotificationSetting_TracingSettingTitle" = "Risiko-Ermittlung";

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
@@ -74,6 +74,20 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, Sp
 		exposureSubmissionService?.submitExposure(with: tan, completionHandler: { error in
 			self.stopSpinner()
 			if let error = error {
+				print(error.localizedDescription)
+				// This error case needs a specialized description (which is not
+				// its default localizedDescription) that is only interesting
+				// for this particular screen.
+				if case .enNotEnabled = error {
+					logError(message: "error: \(error.localizedDescription)", level: .error)
+					let alert = ExposureSubmissionViewUtils.setupAlert(
+						title: AppStrings.ExposureSubmissionWarnOthers.errorNotEnabledTitle,
+						message: AppStrings.ExposureSubmissionWarnOthers.errorNotEnabledDescription,
+						retry: false
+					)
+					self.present(alert, animated: true, completion: nil)
+					return
+				}
 				logError(message: "error: \(error.localizedDescription)", level: .error)
 				let alert = ExposureSubmissionViewUtils.setupErrorAlert(error)
 				self.present(alert, animated: true, completion: nil)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -140,6 +140,8 @@ enum AppStrings {
 		static let sectionTitle = NSLocalizedString("ExposureSubmissionWarnOthers_sectionTitle", comment: "")
 		static let description = NSLocalizedString("ExposureSubmissionWarnOthers_description", comment: "")
 		static let dataPrivacyDescription = NSLocalizedString("ExposureSubmissionWarnOthers_dataPrivacyDescription", comment: "")
+		static let errorNotEnabledTitle = NSLocalizedString("ExposureSubmissionError_EnNotEnabledForWarnOthersTitle", comment: "")
+		static let errorNotEnabledDescription = NSLocalizedString("ExposureSubmissionError_EnNotEnabledForWarnOthersDescription", comment: "")
 	}
 
 	enum ExposureSubmissionSuccess {


### PR DESCRIPTION
As described in issue 1064, I have added a custom description for the error case in which the user has to enable rights in order to warn others.