### PR TITLE
[Technical] Exclude vendored code from project language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Exclude vendored code from project language stats
+sqlite3.h linguist-vendored
+sqlite3.c linguist-vendored


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
With the merge of PR #85, the language stats of this repository changed to 91.4% C code, which causes the repository to be labeled as a C repository (see screenshot). This PR excludes the vendored `sqlite3` files from being considered in the language stats, so that GitHub correctly labels this project as a Swift project.

|Label|Before|After|
|---|---|---|
|![Screen Shot 2020-06-03 at 17 17 19](https://user-images.githubusercontent.com/7734806/83655287-88759d00-a5be-11ea-9a44-db3fcfcbe2d7.png)|![Screen Shot 2020-06-03 at 17 09 14](https://user-images.githubusercontent.com/7734806/83655146-56643b00-a5be-11ea-8e67-00c94911f240.png)|![Screen Shot 2020-06-03 at 17 04 48](https://user-images.githubusercontent.com/7734806/83655172-5e23df80-a5be-11ea-8759-4093f5072ca9.png)|

