### PR TITLE
Bug/fixed notification for detectexposure

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER).detect-exposures.exposure-notification</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).exposure-notification</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).fetch-test-results</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -345,9 +345,9 @@ extension AppDelegate: ENATaskExecutionDelegate {
 					RiskLevel(riskScore: newSummary.maximumRiskScore) == .increased {
 					// present a notification if the risk score has increased
 					self.taskScheduler.notificationManager.presentNotification(
-						title: AppStrings.LocalNotifications.testResultsTitle,
-						body: AppStrings.LocalNotifications.testResultsBody,
-						identifier: ENATaskIdentifier.fetchTestResults.rawValue)
+						title: AppStrings.LocalNotifications.detectExposureTitle,
+						body: AppStrings.LocalNotifications.detectExposureBody,
+						identifier: ENATaskIdentifier.detectExposures.rawValue)
 				}
 
 				// persist the previous risk score to the store

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -21,7 +21,7 @@ import UIKit
 
 enum ENATaskIdentifier: String, CaseIterable {
 	// only one task identifier is allowed have the .exposure-notification suffix
-	case detectExposures = "detect-exposures.exposure-notification"
+	case detectExposures = "exposure-notification" // detect-exposures.exposure-notification"
 	case fetchTestResults = "fetch-test-results"
 
 	var backgroundTaskScheduleInterval: TimeInterval {


### PR DESCRIPTION
The .detectExposures notification was incorrectly presenting the content for the fetchTestResults notification.
Also, changed the bgtask identifier to 
$(PRODUCT_BUNDLE_IDENTIFIER).detect-exposures.exposure-notification
after discussing with Alberto from Apple.
