### PR TITLE
Bugfix for rescheduling fetchTestResults

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -367,10 +367,9 @@ extension AppDelegate: ENATaskExecutionDelegate {
 	func executeFetchTestResults(task: BGTask) {
 		func complete(success: Bool) {
 			task.setTaskCompleted(success: success)
-			taskScheduler.scheduleBackgroundTask(for: .detectExposures)
+			taskScheduler.scheduleBackgroundTask(for: .fetchTestResults)
 		}
 
-		
 		self.exposureSubmissionService = ENAExposureSubmissionService(diagnosiskeyRetrieval: exposureManager, client: client, store: store)
 
 		if store.registrationToken != nil && store.testResultReceivedTimeStamp == nil {


### PR DESCRIPTION
Rescheduling fetchTestResults was incorrectly rescheduling the detectExposures task, now fixed.