### PR TITLE
[Bug/Missing Implementation] ENACommunity: MockExposureManager doesn't mock requestUserNotificationsPermission right

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
@@ -77,6 +77,7 @@ extension MockExposureManager: ExposureManager {
 	func alertForBluetoothOff(completion: @escaping () -> Void) -> UIAlertController? { return nil }
 
 	func requestUserNotificationsPermissions(completionHandler: @escaping (() -> Void)) {
+		#if COMMUNITY
 		let options: UNAuthorizationOptions = [.alert, .sound, .badge]
 		let notificationCenter = UNUserNotificationCenter.current()
 		notificationCenter.requestAuthorization(options: options) { _, error in
@@ -88,5 +89,8 @@ extension MockExposureManager: ExposureManager {
 				completionHandler()
 			}
 		}
+		#else
+		completionHandler()
+		#endif
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
@@ -77,6 +77,16 @@ extension MockExposureManager: ExposureManager {
 	func alertForBluetoothOff(completion: @escaping () -> Void) -> UIAlertController? { return nil }
 
 	func requestUserNotificationsPermissions(completionHandler: @escaping (() -> Void)) {
-		completionHandler()
+		let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+		let notificationCenter = UNUserNotificationCenter.current()
+		notificationCenter.requestAuthorization(options: options) { _, error in
+			if let error = error {
+				// handle error
+				log(message: "Notification authorization request error: \(error.localizedDescription)", level: .error)
+			}
+			DispatchQueue.main.async {
+				completionHandler()
+			}
+		}
 	}
 }


### PR DESCRIPTION
* [X] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [X] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [X] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
When using the schema ENACommunity, in requestUserNotificationsPermission of MockExposureManager the iOS notifications are not initialized at all. This causes trouble later. For example notifications aren't registered with the iOS settings and calls to UNUserNotificationCenter' requestAuthorization() or getNotificationSettings() won't behave like in the production app, i.e. generating an unexpected popup or not returning the expected values.

## Fix in this pull request
When using the schema ENACommunity, UNUserNotificationCenter is initialized like in the production app.

