### PR TITLE
[Feature] Set tint color for SFSafariViewController

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/WebPageHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/WebPageHelper.swift
@@ -28,6 +28,7 @@ enum WebPageHelper {
 			config.barCollapsingEnabled = true
 
 			let vc = SFSafariViewController(url: url, configuration: config)
+			vc.preferredControlTintColor = .enaColor(for: .tint)
 			viewController.present(vc, animated: true)
 		} else {
 			let error = "\(AppStrings.SafariView.targetURL) is no valid URL"


### PR DESCRIPTION
This PR sets the tint color for the `SFSafariViewController`.

Please limit your review to this screen (take a look at the top and bottom bar tint color):
<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/83884402-1f6c6180-a745-11ea-969a-c1ba1c2293d7.png">
<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/83884434-2abf8d00-a745-11ea-802c-c0bc52872d52.png">
