### PR TITLE
[Feature] differentiate different cases of ENStatus restricted by adding three …

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -462,6 +462,16 @@
 
 "ExposureNotificationSetting_Activate_OSENSetting_Description" = "Die Risiko-Ermittlung benötigt aktivierte COVID-19-Kontaktmitteilungen in den Systemeinstellungen, um Begegnungen zu protokollieren. Bitte aktivieren Sie COVID-19-Kontaktmitteilungen in Ihren Systemeinstellungen.";
 
+"ExposureNotificationSetting_ParentalControls_OSENSetting" = "Kindersicherung / Bildschirmzeit aktiviert";
+
+"ExposureNotificationSetting_ParentalControls_OSENSetting_Description" = "Die aktivierte Kindersicherung verhindert die Aktivierung der Risikoermittlung. Bitte deaktivieren Sie die Beschränkung dieser App unter Einstellungen -> Bildschirmzeit";
+
+"ExposureNotificationSetting_AuthorizationRequired_OSENSetting" = "Autorisierung erforderlich";
+
+"ExposureNotificationSetting_AuthorizationRequired_OSENSetting_Description" = "Bitte bestätigen Sie die Nutzung der COVID-19 Kontakt-Protokollierung.";
+
+"ExposureNotificationSetting_AuthorizationRequired_ActionTitle" = "Autorisieren";
+
 "ExposureNotificationSetting_AccLabel_Enabled" = "Drei Personen haben die Risiko-Erkennung auf ihren Smartphones aktiviert, ihre Begegnung wird daher aufgezeichnet.";
 "ExposureNotificationSetting_AccLabel_Disabled" = "Eine Person hat die Risiko-Erkennung auf ihrem Smartphone ausgeschaltet, eine Begegnung mit zwei weiteren Personen wird daher nicht aufgezeichnet.";
 "ExposureNotificationSetting_AccLabel_BluetoothOff" = "Eine Person hat Bluetooth auf ihrem Smartphone ausgeschaltet, eine Begegnung mit zwei weiteren Personen wird daher nicht aufgezeichnet.";

--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
@@ -137,7 +137,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="yp9-fh-bpb">
                                                             <rect key="frame" x="0.0" y="0.0" width="350" height="28"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jEQ-Jd-cnW" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title 2" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jEQ-Jd-cnW" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="278" height="28"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" name="ENA Text Primary 1 Color"/>
@@ -146,30 +146,45 @@
                                                                         <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="title2"/>
                                                                     </userDefinedRuntimeAttributes>
                                                                 </label>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pOD-cP-drw">
-                                                                    <rect key="frame" x="286" y="0.0" width="28" height="28"/>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aIT-yb-oLs">
+                                                                    <rect key="frame" x="266" y="-20" width="144" height="108"/>
+                                                                    <subviews>
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CwO-mS-B2t">
+                                                                            <rect key="frame" x="20" y="20" width="104" height="68"/>
+                                                                            <subviews>
+                                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pOD-cP-drw">
+                                                                                    <rect key="frame" x="20" y="20" width="28" height="28"/>
+                                                                                    <constraints>
+                                                                                        <constraint firstAttribute="width" constant="28" id="Sm8-j4-2bD"/>
+                                                                                        <constraint firstAttribute="height" constant="28" id="rtP-55-gA6"/>
+                                                                                    </constraints>
+                                                                                    <userDefinedRuntimeAttributes>
+                                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                            <integer key="value" value="6"/>
+                                                                                        </userDefinedRuntimeAttribute>
+                                                                                    </userDefinedRuntimeAttributes>
+                                                                                </imageView>
+                                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="F0p-QZ-aDD">
+                                                                                    <rect key="frame" x="56" y="20" width="28" height="28"/>
+                                                                                    <constraints>
+                                                                                        <constraint firstAttribute="height" constant="28" id="ffU-Rn-QwO"/>
+                                                                                        <constraint firstAttribute="width" constant="28" id="zi4-gr-Fwv"/>
+                                                                                    </constraints>
+                                                                                    <userDefinedRuntimeAttributes>
+                                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                                            <integer key="value" value="6"/>
+                                                                                        </userDefinedRuntimeAttribute>
+                                                                                    </userDefinedRuntimeAttributes>
+                                                                                </imageView>
+                                                                            </subviews>
+                                                                        </stackView>
+                                                                    </subviews>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="28" id="Sm8-j4-2bD"/>
-                                                                        <constraint firstAttribute="height" constant="28" id="rtP-55-gA6"/>
+                                                                        <constraint firstItem="CwO-mS-B2t" firstAttribute="leading" secondItem="aIT-yb-oLs" secondAttribute="leading" constant="20" id="Fp4-rf-W5Y"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="CwO-mS-B2t" secondAttribute="trailing" id="Qv9-12-WhZ"/>
+                                                                        <constraint firstItem="CwO-mS-B2t" firstAttribute="top" secondItem="aIT-yb-oLs" secondAttribute="top" id="hjC-BT-YWp"/>
                                                                     </constraints>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                            <integer key="value" value="6"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </imageView>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="F0p-QZ-aDD">
-                                                                    <rect key="frame" x="322" y="0.0" width="28" height="28"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="28" id="ffU-Rn-QwO"/>
-                                                                        <constraint firstAttribute="width" constant="28" id="zi4-gr-Fwv"/>
-                                                                    </constraints>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                            <integer key="value" value="6"/>
-                                                                        </userDefinedRuntimeAttribute>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </imageView>
+                                                                </view>
                                                             </subviews>
                                                         </stackView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VLW-S5-gsb" customClass="ENALabel" customModule="ENA" customModuleProvider="target">

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ENStateTests.swift
@@ -130,7 +130,19 @@ final class ENStateTests: XCTestCase {
 	func testRestrictedState() {
 		exposureManagerState = ExposureManagerState(authorized: false, enabled: false, status: .restricted)
 		stateHandler.updateExposureState(exposureManagerState)
-		XCTAssert(stateHandler.state == .restricted)
+		switch ENManager.authorizationStatus {
+		case .notAuthorized:
+			XCTAssert(stateHandler.state == .notAuthorized)
+		case .restricted:
+			XCTAssert(stateHandler.state == .restricted)
+		case .unknown:
+			XCTAssert(stateHandler.state == .unknown)
+		case .authorized:
+			XCTAssert(stateHandler.state == .disabled)
+		@unknown default:
+			fatalError("Not all cases handled by Test cases of ENStateHandler")
+		}
+
 	}
 
 	func testUnknownState() {

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeActivateCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeActivateCellConfigurator.swift
@@ -38,7 +38,7 @@ final class HomeActivateCellConfigurator: CollectionViewCellConfigurator {
 			iconImage = UIImage(named: "Icons_Risikoermittlung")
 			cell.titleTextView.text = AppStrings.Home.activateCardOnTitle
 			cell.iconImageView.tintColor = UIColor.preferredColor(for: .tint)
-		case .disabled, .restricted:
+		case .disabled, .restricted, .notAuthorized, .unknown:
 			iconImage = UIImage(named: "Icons_Risikoermittlung_gestoppt")
 			cell.iconImageView.tintColor = UIColor.preferredColor(for: .negativeRisk)
 			cell.titleTextView.text = AppStrings.Home.activateCardOffTitle

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -331,6 +331,7 @@ extension SceneDelegate: ENAExposureManagerObserver {
 		Authorized: \(newState.authorized)
 		enabled: \(newState.enabled)
 		status: \(newState.status)
+		authorizationStatus: \(ENManager.authorizationStatus)
 		"""
 		log(message: message)
 

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -142,6 +142,16 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 
 	// MARK: Helper
 
+	func requestUpdatedExposureState() {
+		let state = exposureManager.preconditions()
+		let newState = ExposureManagerState(
+				authorized: ENManager.authorizationStatus == .authorized,
+				enabled: state.enabled,
+				status: state.status
+		)
+		updateExposureState(newState)
+	}
+
 	private func setupUI() {
 		setupNavigationBarAppearance()
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
@@ -16,6 +16,7 @@
 // under the License.
 
 import Foundation
+import ExposureNotification
 
 protocol ENStateHandlerUpdating: AnyObject {
 	func updateEnState(_ state: ENStateHandler.State)
@@ -33,10 +34,12 @@ final class ENStateHandler {
 		case bluetoothOff
 		/// Internet is off.
 		case internetOff
-		/// Restricted Mode.
+		/// Restricted Mode due to parental controls.
 		case restricted
-		//FIXME: NOT YET DONE.
-		//case notAuthorized
+		///Not authorized. The user declined consent in onboarding.
+		case notAuthorized
+		///The user was never asked the consent before, thats why unknown.
+		case unknown
 	}
 
 	private var currentState: State! {
@@ -76,7 +79,7 @@ final class ENStateHandler {
 		}
 
 		switch currentState {
-		case .disabled, .bluetoothOff, .restricted:
+		case .disabled, .bluetoothOff, .restricted, .notAuthorized, .unknown:
 			return
 		case .enabled:
 			if !isReachable {
@@ -112,10 +115,23 @@ final class ENStateHandler {
 		case .disabled:
 			return .disabled
 		case .restricted:
-			return .restricted
+			return differentiateRestrictedCase()
 		case .unknown:
 			return .disabled
 		@unknown default:
+			fatalError("New state was added that is not being covered by ENStateHandler")
+		}
+	}
+
+	private func differentiateRestrictedCase() -> State {
+		switch ENManager.authorizationStatus {
+		case .notAuthorized:
+			return .notAuthorized
+		case .restricted:
+			return .restricted
+		case .unknown:
+			return .unknown
+		default:
 			fatalError("New state was added that is not being covered by ENStateHandler")
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
@@ -131,7 +131,9 @@ final class ENStateHandler {
 			return .restricted
 		case .unknown:
 			return .unknown
-		default:
+		case .authorized:
+			return .disabled
+		@unknown default:
 			fatalError("New state was added that is not being covered by ENStateHandler")
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -107,6 +107,9 @@ extension ExposureNotificationSettingViewController {
 			// This error should not happen as we toggle the enabled status on off - we can not enable without disabling first
 			alertError(message: "ExposureNotification is already enabled", title: "Note")
 		}
+		if let mySceneDelegate = self.view.window?.windowScene?.delegate as? SceneDelegate {
+			mySceneDelegate.requestUpdatedExposureState()
+		}
 		tableView.reloadData()
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -183,7 +183,7 @@ extension ExposureNotificationSettingViewController {
 						)
 						return tracingCell
 					}
-				case .bluetoothOff, .internetOff, .restricted:
+				case .bluetoothOff, .internetOff, .restricted, .notAuthorized, .unknown:
 					cell.configure(for: enState)
 				}
 			case .descriptionCell:

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -204,7 +204,9 @@ extension ExposureNotificationSettingViewController {
 						return tracingCell
 					}
 				case .bluetoothOff, .internetOff, .restricted, .notAuthorized, .unknown:
-					cell.configure(for: enState)
+					if let cell = cell as? ActionCell {
+						cell.configure(for: enState, delegate: self)
+					}
 				}
 			case .descriptionCell:
 				cell.configure(for: enState)

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -197,6 +197,17 @@ extension ExposureNotificationSettingViewController {
 }
 
 extension ExposureNotificationSettingViewController: ActionTableViewCellDelegate {
+	func performAction(action: SettingAction) {
+		switch action {
+		case .enable(true):
+			setExposureManagerEnabled(true, then: handleErrorIfNeed)
+		case .enable(false):
+			setExposureManagerEnabled(false, then: handleErrorIfNeed)
+		case .askConsent:
+			setExposureManagerEnabled(true, then: handleErrorIfNeed)
+		}
+	}
+
 	func performAction(enable: Bool) {
 		setExposureManagerEnabled(enable, then: handleErrorIfNeed)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -77,12 +77,12 @@ final class ExposureNotificationSettingViewController: UITableViewController {
 
 	private func setExposureManagerEnabled(
 		_ enabled: Bool,
-		then _: ExposureNotificationSettingViewControllerDelegate.Completion
+		then completion: @escaping ExposureNotificationSettingViewControllerDelegate.Completion
 	) {
 		delegate?.exposureNotificationSettingViewController(
 			self,
 			setExposureManagerEnabled: enabled,
-			then: handleErrorIfNeed
+			then: completion
 		)
 	}
 }
@@ -92,20 +92,29 @@ extension ExposureNotificationSettingViewController {
 		title = AppStrings.ExposureNotificationSetting.title
 	}
 
-	private func handleEnableError(_ error: ExposureNotificationError) {
+	private func handleEnableError(_ error: ExposureNotificationError, alert: Bool) {
 		switch error {
 		case .exposureNotificationAuthorization:
 			logError(message: "Failed to enable exposureNotificationAuthorization")
-			alertError(message: "Failed to enable: exposureNotificationAuthorization", title: "Error")
+			if alert {
+				alertError(message: "Failed to enable: exposureNotificationAuthorization", title: "Error")
+			}
 		case .exposureNotificationRequired:
 			logError(message: "Failed to enable")
-			alertError(message: "exposureNotificationAuthorization", title: "Error")
+			if alert {
+				alertError(message: "exposureNotificationAuthorization", title: "Error")
+			}
 		case .exposureNotificationUnavailable:
 			logError(message: "Failed to enable")
-			alertError(message: "ExposureNotification is not availabe due to the sytem policy", title: "Error")
+			if alert {
+				alertError(message: "ExposureNotification is not availabe due to the sytem policy", title: "Error")
+			}
 		case .apiMisuse:
+			logError(message: "APIMisuse")
 			// This error should not happen as we toggle the enabled status on off - we can not enable without disabling first
-			alertError(message: "ExposureNotification is already enabled", title: "Note")
+			if alert {
+				alertError(message: "ExposureNotification is already enabled", title: "Note")
+			}
 		}
 		if let mySceneDelegate = self.view.window?.windowScene?.delegate as? SceneDelegate {
 			mySceneDelegate.requestUpdatedExposureState()
@@ -115,7 +124,15 @@ extension ExposureNotificationSettingViewController {
 
 	private func handleErrorIfNeed(_ error: ExposureNotificationError?) {
 		if let error = error {
-			handleEnableError(error)
+			handleEnableError(error, alert: true)
+		} else {
+			tableView.reloadData()
+		}
+	}
+
+	private func silentErrorIfNeed(_ error: ExposureNotificationError?) {
+		if let error = error {
+			handleEnableError(error, alert: false)
 		} else {
 			tableView.reloadData()
 		}
@@ -207,12 +224,8 @@ extension ExposureNotificationSettingViewController: ActionTableViewCellDelegate
 		case .enable(false):
 			setExposureManagerEnabled(false, then: handleErrorIfNeed)
 		case .askConsent:
-			setExposureManagerEnabled(true, then: handleErrorIfNeed)
+			setExposureManagerEnabled(true, then: silentErrorIfNeed)
 		}
-	}
-
-	func performAction(enable: Bool) {
-		setExposureManagerEnabled(enable, then: handleErrorIfNeed)
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import UserNotifications
+import ExposureNotification
 
 enum OnboardingPageType: Int, CaseIterable {
 	case togetherAgainstCoronaPage = 0
@@ -211,6 +212,7 @@ final class OnboardingInfoViewController: UIViewController {
 				log(message: "Encourage the user to consider enabling Exposure Notifications.", level: .warning)
 			case .exposureNotificationAuthorization:
 				log(message: "Encourage the user to authorize this application", level: .warning)
+				print("Encourage the user to authorize this application: \(ENManager.authorizationStatus)")
 			case .exposureNotificationUnavailable:
 				log(message: "Tell the user that Exposure Notifications is currently not available.", level: .warning)
 			case .apiMisuse:

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -314,6 +314,11 @@ enum AppStrings {
 		static let tracingHistoryDescription = NSLocalizedString("ENSetting_Tracing_History", comment: "")
 		static let activateOSENSetting = NSLocalizedString("ExposureNotificationSetting_Activate_OSENSetting", comment: "")
 		static let activateOSENSettingDescription = NSLocalizedString("ExposureNotificationSetting_Activate_OSENSetting_Description", comment: "")
+		static let activateParentalControlENSetting = NSLocalizedString("ExposureNotificationSetting_ParentalControls_OSENSetting", comment: "")
+		static let activateParentalControlENSettingDescription = NSLocalizedString("ExposureNotificationSetting_ParentalControls_OSENSetting_Description", comment: "")
+		static let authorizationRequiredENSetting = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_OSENSetting", comment: "")
+		static let authorizationRequiredENSettingDescription = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_OSENSetting_Description", comment: "")
+		static let authorizationButtonTitle = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_ActionTitle", comment: "")
 
 		static let accLabelEnabled = NSLocalizedString("ExposureNotificationSetting_AccLabel_Enabled", comment: "")
 		static let accLabelDisabled = NSLocalizedString("ExposureNotificationSetting_AccLabel_Disabled", comment: "")

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
@@ -52,8 +52,16 @@ class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 			descriptionLabel.text = AppStrings.ExposureNotificationSetting.internetDescription
 			iconImageView2.isHidden = false
 		case .restricted:
+			actionTitleLabel.text = "Kindersicherung aktiv"
+			descriptionLabel.text = "Bitte deaktivieren Sie Einschränkungen durch die Kindersicherung, um die Risikoermittlung zu nutzen"
+			iconImageView2.isHidden = true
+		case .notAuthorized:
 			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.activateOSENSetting
 			descriptionLabel.text = AppStrings.ExposureNotificationSetting.activateOSENSettingDescription
+			iconImageView2.isHidden = true
+		case .unknown:
+			actionTitleLabel.text = "Autorisierung erforderlich"
+			descriptionLabel.text = "Bitte bestätigen Sie die Nutzung der COVID-19 Kontakt-Protokollierung"
 			iconImageView2.isHidden = true
 		}
 	}
@@ -66,7 +74,7 @@ class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 			return (UIImage(named: "Icons_Bluetooth"), nil)
 		case .internetOff:
 			return (UIImage(named: "Icons_MobileDaten"), UIImage(named: "Icons_iOS_Wifi"))
-		case .restricted:
+		case .restricted, .notAuthorized, .unknown:
 			return (UIImage(named: "Icons_iOS_Settings"), nil)
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
@@ -18,20 +18,25 @@
 import Foundation
 import UIKit
 
-class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
+class ActionDetailTableViewCell: UITableViewCell, ActionCell {
+
 	@IBOutlet var iconImageView1: UIImageView!
 	@IBOutlet var iconImageView2: UIImageView!
 	@IBOutlet weak var actionTitleLabel: ENALabel!
 	@IBOutlet var descriptionLabel: UILabel!
 	@IBOutlet var actionButton: ENAButton!
 
-	@IBAction func actionButtonTapped(_: Any) {
-		guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
-			return
-		}
+	weak var delegate: ActionTableViewCellDelegate?
+	var state: ENStateHandler.State?
 
-		if UIApplication.shared.canOpenURL(settingsUrl) {
-			UIApplication.shared.open(settingsUrl, completionHandler: nil)
+	@IBAction func actionButtonTapped(_: Any) {
+		if let state = self.state, state == .unknown {
+			delegate?.performAction(action: .askConsent)
+		} else {
+			if let settingsUrl = URL(string: UIApplication.openSettingsURLString),
+				UIApplication.shared.canOpenURL(settingsUrl) {
+				UIApplication.shared.open(settingsUrl, completionHandler: nil)
+			}
 		}
 	}
 
@@ -62,8 +67,15 @@ class ActionDetailTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 		case .unknown:
 			actionTitleLabel.text = "Autorisierung erforderlich"
 			descriptionLabel.text = "Bitte bestätigen Sie die Nutzung der COVID-19 Kontakt-Protokollierung"
+			actionButton.setTitle("Autorisieren", for: .normal)
 			iconImageView2.isHidden = true
 		}
+	}
+
+	func configure(for state: ENStateHandler.State, delegate: ActionTableViewCellDelegate) {
+		self.delegate = delegate
+		self.state = state
+		configure(for: state)
 	}
 
 	private func images(for state: ENStateHandler.State) -> (UIImage?, UIImage?) {

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionDetailTableViewCell.swift
@@ -57,17 +57,17 @@ class ActionDetailTableViewCell: UITableViewCell, ActionCell {
 			descriptionLabel.text = AppStrings.ExposureNotificationSetting.internetDescription
 			iconImageView2.isHidden = false
 		case .restricted:
-			actionTitleLabel.text = "Kindersicherung aktiv"
-			descriptionLabel.text = "Bitte deaktivieren Sie Einschränkungen durch die Kindersicherung, um die Risikoermittlung zu nutzen"
+			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.activateParentalControlENSetting
+			descriptionLabel.text = AppStrings.ExposureNotificationSetting.activateParentalControlENSettingDescription
 			iconImageView2.isHidden = true
 		case .notAuthorized:
 			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.activateOSENSetting
 			descriptionLabel.text = AppStrings.ExposureNotificationSetting.activateOSENSettingDescription
 			iconImageView2.isHidden = true
 		case .unknown:
-			actionTitleLabel.text = "Autorisierung erforderlich"
-			descriptionLabel.text = "Bitte bestätigen Sie die Nutzung der COVID-19 Kontakt-Protokollierung"
-			actionButton.setTitle("Autorisieren", for: .normal)
+			actionTitleLabel.text = AppStrings.ExposureNotificationSetting.authorizationRequiredENSetting
+			descriptionLabel.text = AppStrings.ExposureNotificationSetting.authorizationRequiredENSettingDescription
+			actionButton.setTitle(AppStrings.ExposureNotificationSetting.authorizationButtonTitle, for: .normal)
 			iconImageView2.isHidden = true
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
@@ -42,8 +42,9 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 	@IBAction func switchValueDidChange(_: Any) {
 		if askForConsent {
 			delegate?.performAction(action: .askConsent)
+		} else {
+			delegate?.performAction(action: .enable(self.actionSwitch.isOn))
 		}
-		delegate?.performAction(action: .enable(self.actionSwitch.isOn))
 	}
 
 	func turnSwitch(to on: Bool) {

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
@@ -32,8 +32,13 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 	@IBOutlet var detailLabel: UILabel!
 
 	weak var delegate: ActionTableViewCellDelegate?
+	private var askForConsent = false
 
 	@IBAction func switchValueDidChange(_: Any) {
+		if askForConsent {
+			//FIXME
+			//Show Consent
+		}
 		delegate?.performAction(enable: self.actionSwitch.isOn)
 	}
 
@@ -42,6 +47,7 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 	}
 
 	func configure(for state: ENStateHandler.State) {
+		askForConsent = false
 		actionTitleLabel.text = AppStrings.ExposureNotificationSetting.enableTracing
 		detailLabel.text = AppStrings.ExposureNotificationSetting.limitedTracing
 		turnSwitch(to: state == .enabled)
@@ -53,10 +59,14 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 		case .bluetoothOff, .internetOff:
 			detailLabel.isHidden = false
 			actionSwitch.isHidden = true
-		case .restricted:
+		case .restricted, .notAuthorized:
 			detailLabel.isHidden = false
 			actionSwitch.isHidden = true
 			detailLabel.text = AppStrings.ExposureNotificationSetting.deactivatedTracing
+		case .unknown:
+			askForConsent = true
+			detailLabel.isHidden = true
+			actionSwitch.isHidden = false
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ActionTableViewCell.swift
@@ -23,7 +23,12 @@ protocol ActionCell: ConfigurableENSettingCell {
 }
 
 protocol ActionTableViewCellDelegate: AnyObject {
-	func performAction(enable: Bool)
+	func performAction(action: SettingAction)
+}
+
+enum SettingAction {
+	case enable(Bool)
+	case askConsent
 }
 
 class ActionTableViewCell: UITableViewCell, ActionCell {
@@ -36,10 +41,9 @@ class ActionTableViewCell: UITableViewCell, ActionCell {
 
 	@IBAction func switchValueDidChange(_: Any) {
 		if askForConsent {
-			//FIXME
-			//Show Consent
+			delegate?.performAction(action: .askConsent)
 		}
-		delegate?.performAction(enable: self.actionSwitch.isOn)
+		delegate?.performAction(action: .enable(self.actionSwitch.isOn))
 	}
 
 	func turnSwitch(to on: Bool) {

--- a/src/xcode/ENA/ENA/Source/Views/ENSetting/ImageTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ENSetting/ImageTableViewCell.swift
@@ -41,9 +41,7 @@ class ImageTableViewCell: UITableViewCell, ConfigurableENSettingCell {
 		switch state {
 		case .enabled:
 			return (UIImage(named: "Illu_Risikoermittlung_On"), AppStrings.ExposureNotificationSetting.accLabelEnabled)
-		case .disabled:
-			return (UIImage(named: "Illu_Risikoermittlung_Off"), AppStrings.ExposureNotificationSetting.accLabelDisabled)
-		case .restricted:
+		case .disabled, .restricted, .notAuthorized, .unknown:
 			return (UIImage(named: "Illu_Risikoermittlung_Off"), AppStrings.ExposureNotificationSetting.accLabelDisabled)
 		case .bluetoothOff:
 			return (UIImage(named: "Illu_Bluetooth_Off"), AppStrings.ExposureNotificationSetting.accLabelBluetoothOff)


### PR DESCRIPTION
Three new states are covered now by this PR that occur when ENStatus equals restricted. AuthorizationStatus of ENManager can become unknown (when authorization consent was not shown to the user), notAuthorized (user declined consent during onboarding), restricted(due to parental controls).
How to test ENStateHandler: 
- Reinstall app and click not activate everywhere (if a consent for EN shows up you did something wrong)-> unknown case
- Reinstall app let the consent show up and decline it -> not authorized case
- if you find out how to make restricted case happen using parental controls you deserve an award (please tell me how to make this happen)