### PR TITLE
[Bug] Onboarding: Screen pushed twice

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -273,9 +273,11 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 
 	@IBAction func didTapNextButton(_: Any) {
+		nextButton.isUserInteractionEnabled = false
 		runActionForPageType(
-			completion: {
-				self.gotoNextScreen()
+			completion: { [weak self] in
+				self?.gotoNextScreen()
+				self?.nextButton.isUserInteractionEnabled = true
 			}
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -215,7 +215,6 @@ final class OnboardingInfoViewController: UIViewController {
 				log(message: "Tell the user that Exposure Notifications is currently not available.", level: .warning)
 			case .apiMisuse:
 				// User already enabled notifications, but went back to the previous screen. Just ignore error and proceed
-				completion?()
 				return false
 			default:
 				break


### PR DESCRIPTION
There is a bug with onboarding screen "Falls Sie positiv getested werden..." being pushed twice after the reset. The cause was that after ```apiMisuse``` error, there was a double completion. That is removed now.

Also, while testing this, I managed to double-tap on the next button at some point, also causing the next screen to be pushed twice. I wasn't able to reproduce it again, but since it happened on 11 Pro, I believe it's better to be safe, since we are supporting 6s/SE. To fix this, I've added a prevention - disabled the button after the tap and enabled it again on the callback.