### PR TITLE
[Feature] Persist previousSummary & timestamp (closes EXPOSUREAPP-484)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -165,6 +165,8 @@ extension RiskProvider: RiskProviding {
 		for consumer in consumers.allObjects {
 			_provideRisk(risk, to: consumer)
 		}
+		store.previousSummary = summary
+		store.previousSummaryDate = Date()
 	}
 
 	private func _provideRisk(_ risk: Risk, to consumer: RiskConsumer?) {

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -45,6 +45,7 @@ class MockTestStore: Store {
 	var registrationToken: String?
 	var allowRiskChangesNotification: Bool = true
 	var allowTestsStatusNotification: Bool = true
+	var previousSummaryDate: Date? = Date()
 	var previousSummary: ENExposureDetectionSummaryContainer? = ENExposureDetectionSummaryContainer(
 		daysSinceLastExposure: 0,
 		matchedKeyCount: 0,
@@ -52,6 +53,5 @@ class MockTestStore: Store {
 		attenuationDurations: [],
 		maximumRiskScoreFullRange: 0
 	)
-	var previousSummaryDate: Date? = Date()
 	var hourlyFetchingEnabled: Bool = true
 }

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -52,5 +52,6 @@ class MockTestStore: Store {
 		attenuationDurations: [],
 		maximumRiskScoreFullRange: 0
 	)
+	var previousSummaryDate: Date? = Date()
 	var hourlyFetchingEnabled: Bool = true
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store.swift
@@ -40,6 +40,7 @@ protocol Store: AnyObject {
 	var allowTestsStatusNotification: Bool { get set }
 
 	var previousSummary: ENExposureDetectionSummaryContainer? { get set }
+	var previousSummaryDate: Date? { get set }
 
 	var registrationToken: String? { get set }
 	var hasSeenSubmissionExposureTutorial: Bool { get set }
@@ -227,6 +228,11 @@ final class SecureStore: Store {
 	var previousSummary: ENExposureDetectionSummaryContainer? {
 		get { kvStore["previousSummary"] as ENExposureDetectionSummaryContainer? ?? nil }
 		set { kvStore["previousSummary"] = newValue }
+	}
+
+	var previousSummaryDate: Date? {
+		get { kvStore["previousSummaryDate"] as Date? ?? nil }
+		set { kvStore["previousSummaryDate"] = newValue }
 	}
 
 	var hourlyFetchingEnabled: Bool {


### PR DESCRIPTION
https://jira.itc.sap.com/browse/EXPOSUREAPP-484

Persist the previousSummary & previousSummaryDate in RiskProvider _requestRiskLevel() function

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
