### PR TITLE
[Feature] Alert user with consent before activating the tracing the first time

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -498,6 +498,8 @@ Sie können Ihre Einwilligung jederzeit widerrufen, indem Sie die App löschen. 
 
 "ExposureNotificationSetting_AccLabel_InternetOff" = "Eine Person hat die Internetverbindung ihres Smartphones ausgeschaltet, eine Bestimmung der letzten Begegnungen kann dadurch nicht ausgeführt werden.";
 
+"ExposureNotificationSetting_Activate_Action" = "Akzeptieren";
+"ExposureNotificationSetting_Dismiss_Action" = "Abbrechen";
 /* Home Navigation Bar */
 "Home_LeftBarButton_description" = "Corona Warn App Logo";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -145,8 +145,8 @@ extension ExposureNotificationSettingViewController {
 				fatalError("Not all cases of actions covered when handling the bluetooth")
 			}
 		}
-		alert.addAction(UIAlertAction(title: "Aktivieren", style: .default, handler: { action in completionHandler(action) }))
-		alert.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: { action in completionHandler(action) }))
+		alert.addAction(UIAlertAction(title: AppStrings.ExposureNotificationSetting.privacyConsentActivateAction, style: .default, handler: { action in completionHandler(action) }))
+		alert.addAction(UIAlertAction(title: AppStrings.ExposureNotificationSetting.privacyConsentDismissAction, style: .cancel, handler: { action in completionHandler(action) }))
 		self.present(alert, animated: true, completion: nil)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -59,16 +59,6 @@ final class ExposureNotificationSettingViewController: UITableViewController {
 		tableView.sectionFooterHeight = 0.0
 
 	}
-//
-//	private func tryEnManager() {
-//		let enManager = ENManager()
-//		enManager.activate { error in
-//			if let error = error {
-//				print("Cannot activate the enmanager.")
-//				return
-//			}
-//		}
-//	}
 
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
@@ -136,6 +126,28 @@ extension ExposureNotificationSettingViewController {
 		} else {
 			tableView.reloadData()
 		}
+	}
+
+	private func askConsentToUser() {
+		let alert = UIAlertController(
+			title: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_panelTitle,
+			message: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_panelBody,
+			preferredStyle: .alert
+		)
+		let completionHandler: (UIAlertAction) -> Void = { action in
+			switch action.style {
+			case .default:
+				self.setExposureManagerEnabled(true, then: self.silentErrorIfNeed)
+			case .cancel, .destructive:
+				self.lastActionCell?.configure(for: self.enState, delegate: self)
+				self.tableView.reloadData()
+			@unknown default:
+				fatalError("Not all cases of actions covered when handling the bluetooth")
+			}
+		}
+		alert.addAction(UIAlertAction(title: "Aktivieren", style: .default, handler: { action in completionHandler(action) }))
+		alert.addAction(UIAlertAction(title: "Abbrechen", style: .cancel, handler: { action in completionHandler(action) }))
+		self.present(alert, animated: true, completion: nil)
 	}
 }
 
@@ -226,7 +238,7 @@ extension ExposureNotificationSettingViewController: ActionTableViewCellDelegate
 		case .enable(false):
 			setExposureManagerEnabled(false, then: handleErrorIfNeed)
 		case .askConsent:
-			setExposureManagerEnabled(true, then: silentErrorIfNeed)
+			askConsentToUser()
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -322,6 +322,8 @@ enum AppStrings {
 		static let authorizationRequiredENSetting = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_OSENSetting", comment: "")
 		static let authorizationRequiredENSettingDescription = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_OSENSetting_Description", comment: "")
 		static let authorizationButtonTitle = NSLocalizedString("ExposureNotificationSetting_AuthorizationRequired_ActionTitle", comment: "")
+		static let privacyConsentActivateAction = NSLocalizedString("ExposureNotificationSetting_Activate_Action", comment: "")
+		static let privacyConsentDismissAction = NSLocalizedString("ExposureNotificationSetting_Dismiss_Action", comment: "")
 
 		static let accLabelEnabled = NSLocalizedString("ExposureNotificationSetting_AccLabel_Enabled", comment: "")
 		static let accLabelDisabled = NSLocalizedString("ExposureNotificationSetting_AccLabel_Disabled", comment: "")


### PR DESCRIPTION
consent needs to be shown when user has clicked on not activate during onboarding