### PR TITLE
Changed Notification Settings scrolling behaviour to: Bounce vertically

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/Settings.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/Settings.storyboard
@@ -382,7 +382,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0GH-Ib-DgS">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0GH-Ib-DgS">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HYJ-sA-5Ds">


### PR DESCRIPTION
Fixes https://github.com/corona-warn-app/cwa-app-ios/issues/327

Changed the scrolling behaviour of the scroll view to "always bounce vertically". No the scene behaves as expected.