### PR TITLE
[Spelling] FAST-TRACK: Fix spelling in Privacy Policy

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -675,7 +675,7 @@
 	ausschließlich auf Servern in Deutschland oder in einem anderem EU- oder
 	EWR-Mitgliedsstaat verarbeitet.</p>
 
-<h2>11. Wiederruf von Einwilligungen</h2>
+<h2>11. Widerruf von Einwilligungen</h2>
 
 <p>Ihnen steht das Recht zu, die in der App erteilten
 	Einwilligungen gegenüber dem RKI jederzeit mit Wirkung für die Zukunft zu widerrufen.

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -675,7 +675,7 @@
 	ausschließlich auf Servern in Deutschland oder in einem anderem EU- oder
 	EWR-Mitgliedsstaat verarbeitet.</p>
 
-<h2>11. Wiederruf von Einwilligungen</h2>
+<h2>11. Widerruf von Einwilligungen</h2>
 
 <p>Ihnen steht das Recht zu, die in der App erteilten
 	Einwilligungen gegenüber dem RKI jederzeit mit Wirkung für die Zukunft zu widerrufen.


### PR DESCRIPTION
This PR fixes an embarrassing spelling mistake in the German Privacy Policy.