### PR TITLE
Disable Certificate Pinning for ENACommunity builds  (closes #358)

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -2394,6 +2394,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 					"SQLITE_HAS_CODEC=1",
+					"DISABLE_CERTIFICATE_PINNING=1",
 				);
 				INFOPLIST_FILE = ENA/Resources/Info.plist;
 				IPHONE_APP_CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/src/xcode/ENA/ENA/Source/Extensions/URLSession+Default.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/URLSession+Default.swift
@@ -19,10 +19,16 @@ import Foundation
 
 extension URLSession {
 	class func coronaWarnSession() -> URLSession {
-		URLSession(
+		#if DISABLE_CERTIFICATE_PINNING
+		let coronaWarnURLSessionDelegate = nil
+		#else
+		let coronaWarnURLSessionDelegate = CoronaWarnURLSessionDelegate()
+		#endif
+		return URLSession(
 			configuration: .coronaWarnSessionConfiguration(),
-			delegate: CoronaWarnURLSessionDelegate(),
+			delegate: coronaWarnURLSessionDelegate,
 			delegateQueue: .main
 		)
+		
 	}
 }


### PR DESCRIPTION
## Description
Closes #358:
"_We should find a way to still be able to disable pinning for development purposes since it make debugging the HTTP layer terribly inconvenient._"

This PR will disable certificate pinning for ENACommunity builds at compile time using macros. Production builds don't contain any code that would be able to disable certificate pinning.

## Changes
* Added DISABLE_CERTIFICATE_PINNING to the  ENACommunity scheme
* CoronaWarnURLSessionDelegate() is used if DISABLE_CERTIFICATE_PINNING isn't defined
