### PR TITLE
[Bug] Fix crash on App reset

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/DownloadedPackagesSQLLiteStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/DownloadedPackagesSQLLiteStore.swift
@@ -250,9 +250,8 @@ extension DownloadedPackagesSQLLiteStore: DownloadedPackagesStore {
 					DROP TABLE Z_DOWNLOADED_PACKAGE;
 				"""
 			)
-			self.close()
 		}
-
+		self.close()
 	}
 }
 


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
Minor change to fix the crash in DownloadedPackagesSQLLiteStore when the app is reset. It was just a small queueing issue where one call had to be moved out of the queue.

## How to test
Try to reset the app on your device. There shouldn't be a crash anymore 👍 
