### PR TITLE
[Technical] Update handling when unable to create SecureStore

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -107,15 +107,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			if !fileManager.fileExists(atPath: directoryURL.path) {
 				try fileManager.createDirectory(atPath: directoryURL.path, withIntermediateDirectories: true, attributes: nil)
 				guard let key = KeychainHelper.generateDatabaseKey() else {
-					logError(message: "Creating the Database failed")
-					return SecureStore(at: nil, key: "")
+					fatalError("Creating the Database failed")
 				}
 				return SecureStore(at: directoryURL, key: key)
 			} else {
 				guard let keyData = KeychainHelper.loadFromKeychain(key: "secureStoreDatabaseKey") else {
 					guard let key = KeychainHelper.generateDatabaseKey() else {
-						logError(message: "Creating the Database failed")
-						return SecureStore(at: nil, key: "")
+						fatalError("Creating the Database failed")
 					}
 					return SecureStore(at: directoryURL, key: key)
 				}
@@ -123,8 +121,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 				return SecureStore(at: directoryURL, key: key)
 			}
 		} catch {
-			logError(message: "Creating the Database failed")
-			return SecureStore(at: nil, key: "")
+			fatalError("Creating the Database failed")
 		}
 	}()
 

--- a/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
@@ -28,12 +28,9 @@ class SQLiteKeyValueStore {
 	/// If the Database can't be accessed with the key the currentFile will be reset
 	init(with url: URL?, key: String) {
 		guard let url = url else {
-			self.directoryURL = URL(string: ":memory:")!
-			let fileURL = directoryURL
-			databaseQueue = FMDatabaseQueue(url: fileURL)
-			initDatabase(key, retry: false)
-			return
+			fatalError("Creating the Database failed")
 		}
+
 		self.directoryURL = url
 		let fileURL = directoryURL.appendingPathComponent("secureStore.sqlite")
 		databaseQueue = FMDatabaseQueue(url: fileURL)


### PR DESCRIPTION
## Description
When the SecureStore can't be created at the start of the app we used to default to a in memory database which would lead to dataloss

Therfore we are no throwing a fatal error if the SecureStore can't be created and exit the app.

## How to test
Disrupt the initialization of the store by for example entering a nil value as key during the guard statement and see if the fatalError is thrown.