### PR TITLE
Risk Level Interval Cell Dynamic Color

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.swift
@@ -61,7 +61,7 @@ final class RiskLevelCollectionViewCell: HomeCardCollectionViewCell {
 		detectionIntervalLabelContainer.layer.masksToBounds = true
 		detectionIntervalLabelContainer.layoutMargins = .init(top: 9.0, left: 16.0, bottom: 9.0, right: 16.0)
 		detectionIntervalLabelContainer.backgroundColor = UIColor.black.withAlphaComponent(0.12)
-		detectionIntervalLabel.textColor = .systemGray6
+		detectionIntervalLabel.textColor = .enaColor(for: .textContrast)
 	}
 
 	// Ignore touches on the button when it's disabled


### PR DESCRIPTION
In risk level collection view cell, the detection interval uses the wrong dynamic color. Instead of using the text contrast color, it uses a system gray. That's why the label's color doesn't match other label's colors in dark mode:

|Current|Expected|
|---|---|
|![Current](https://user-images.githubusercontent.com/37324823/84171196-d8e77180-aa7a-11ea-813b-90ee49e056ed.png)|![Expected](https://user-images.githubusercontent.com/37324823/84171228-e13fac80-aa7a-11ea-9fa8-ebd0647ae4ec.png)|