### PR TITLE
[Bug] Fix Risk Level Storing Logic

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -16,12 +16,12 @@
 		01DC23252462DFD0001B727C /* ExposureSubmission.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD99A39C245B22EE00BF12AF /* ExposureSubmission.storyboard */; };
 		01F5F7222487B9C000229720 /* AppInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F5F7212487B9C000229720 /* AppInformationViewController.swift */; };
 		0D5611B4247F852C00B5B094 /* SQLiteKeyValueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5611B3247F852C00B5B094 /* SQLiteKeyValueStore.swift */; };
+		0DD260FF248D549B007C3B2C /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD260FE248D549B007C3B2C /* KeychainHelper.swift */; };
 		0DF6BB97248AD616007E8B0C /* AppUpdateCheckHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF6BB96248AD616007E8B0C /* AppUpdateCheckHelper.swift */; };
 		0DF6BB9D248AE232007E8B0C /* AppUpdateCheckerHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF6BB9C248AE232007E8B0C /* AppUpdateCheckerHelperTests.swift */; };
 		0DF6BBB5248C04CF007E8B0C /* app_config_attenuation_duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF6BBB2248C04CF007E8B0C /* app_config_attenuation_duration.pb.swift */; };
 		0DF6BBB6248C04CF007E8B0C /* app_config_app_version_config.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF6BBB3248C04CF007E8B0C /* app_config_app_version_config.pb.swift */; };
 		0DF6BBB7248C04CF007E8B0C /* app_config.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF6BBB4248C04CF007E8B0C /* app_config.pb.swift */; };
-		0DD260FF248D549B007C3B2C /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD260FE248D549B007C3B2C /* KeychainHelper.swift */; };
 		0DFCC2722484DC8400E2811D /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 0DFCC2702484DC8400E2811D /* sqlite3.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		1309194F247972C40066E329 /* PrivacyProtectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1309194E247972C40066E329 /* PrivacyProtectionViewController.swift */; };
 		130CB19C246D92F800ADE602 /* ENAUITestsOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CB19B246D92F800ADE602 /* ENAUITestsOnboarding.swift */; };
@@ -190,7 +190,6 @@
 		A3284259248E7672006B1F09 /* MockExposureSubmissionQRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284258248E7672006B1F09 /* MockExposureSubmissionQRScannerViewController.swift */; };
 		A328425D248E82BC006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328425B248E82B5006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift */; };
 		A328425F248E943D006B1F09 /* ExposureSubmissionTanInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328425E248E943D006B1F09 /* ExposureSubmissionTanInputViewControllerTests.swift */; };
-		A36D07B72486AD0100E46F96 /* HomeTestResultCellConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36D07B62486AD0100E46F96 /* HomeTestResultCellConfigurator.swift */; };
 		A36D07B92486D61C00E46F96 /* HomeCardCellButtonDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36D07B82486D61C00E46F96 /* HomeCardCellButtonDelegate.swift */; };
 		A3C4F96024812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */; };
 		A3E5E71A247D4FFB00237116 /* ExposureSubmissionViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */; };
@@ -356,6 +355,7 @@
 		016146902487A43E00660992 /* WebPageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageHelper.swift; sourceTree = "<group>"; };
 		01F5F7212487B9C000229720 /* AppInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationViewController.swift; sourceTree = "<group>"; };
 		0D5611B3247F852C00B5B094 /* SQLiteKeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteKeyValueStore.swift; sourceTree = "<group>"; };
+		0DD260FE248D549B007C3B2C /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		0DF6BB92248AD3EB007E8B0C /* app_config_attenuation_duration.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = app_config_attenuation_duration.pb.swift; path = ../../../gen/output/app_config_attenuation_duration.pb.swift; sourceTree = "<group>"; };
 		0DF6BB93248AD3EB007E8B0C /* app_config_app_version_config.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = app_config_app_version_config.pb.swift; path = ../../../gen/output/app_config_app_version_config.pb.swift; sourceTree = "<group>"; };
 		0DF6BB96248AD616007E8B0C /* AppUpdateCheckHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateCheckHelper.swift; sourceTree = "<group>"; };
@@ -364,7 +364,6 @@
 		0DF6BBB2248C04CF007E8B0C /* app_config_attenuation_duration.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = app_config_attenuation_duration.pb.swift; path = ../../../gen/output/app_config_attenuation_duration.pb.swift; sourceTree = "<group>"; };
 		0DF6BBB3248C04CF007E8B0C /* app_config_app_version_config.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = app_config_app_version_config.pb.swift; path = ../../../gen/output/app_config_app_version_config.pb.swift; sourceTree = "<group>"; };
 		0DF6BBB4248C04CF007E8B0C /* app_config.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = app_config.pb.swift; path = ../../../gen/output/app_config.pb.swift; sourceTree = "<group>"; };
-		0DD260FE248D549B007C3B2C /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		0DFCC2692484D7A700E2811D /* ENA-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ENA-Bridging-Header.h"; sourceTree = "<group>"; };
 		0DFCC26F2484DC8200E2811D /* ENATests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ENATests-Bridging-Header.h"; sourceTree = "<group>"; };
 		0DFCC2702484DC8400E2811D /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
@@ -520,7 +519,7 @@
 		8539874E2467094E00D28B62 /* AppIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcon.xcassets; sourceTree = "<group>"; };
 		853D987924694A8700490DBA /* ENAButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAButton.swift; sourceTree = "<group>"; };
 		853D98822469DC5000490DBA /* ExposureNotificationSetting.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ExposureNotificationSetting.storyboard; sourceTree = "<group>"; };
-		853D98842469DC8100490DBA /* ExposureNotificationSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureNotificationSettingViewController.swift; sourceTree = "<group>"; };
+		853D98842469DC8100490DBA /* ExposureNotificationSettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ExposureNotificationSettingViewController.swift; sourceTree = "<group>"; };
 		85790F2E245C6B72003D47E1 /* ENA.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = ENA.entitlements; sourceTree = "<group>"; };
 		858F6F6D245A103C009FFD33 /* ExposureNotification.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExposureNotification.framework; path = System/Library/Frameworks/ExposureNotification.framework; sourceTree = SDKROOT; };
 		8595BF5E246032D90056EA27 /* ENASwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENASwitch.swift; sourceTree = "<group>"; };
@@ -556,7 +555,6 @@
 		A3284258248E7672006B1F09 /* MockExposureSubmissionQRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExposureSubmissionQRScannerViewController.swift; sourceTree = "<group>"; };
 		A328425B248E82B5006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionTestResultViewControllerTests.swift; sourceTree = "<group>"; };
 		A328425E248E943D006B1F09 /* ExposureSubmissionTanInputViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionTanInputViewControllerTests.swift; sourceTree = "<group>"; };
-		A36D07B62486AD0100E46F96 /* HomeTestResultCellConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTestResultCellConfigurator.swift; sourceTree = "<group>"; };
 		A36D07B82486D61C00E46F96 /* HomeCardCellButtonDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCardCellButtonDelegate.swift; sourceTree = "<group>"; };
 		A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionWarnOthersViewController.swift; sourceTree = "<group>"; };
 		A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionViewUtils.swift; sourceTree = "<group>"; };

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
@@ -176,7 +176,7 @@ enum RiskCalculation {
 		numberOfTracingActiveHours: Int,
 		preconditions: ExposureManagerState,
 		currentDate: Date = Date(),
-		store: Store
+		previousRiskLevel: EitherLowOrIncreasedRiskLevel?
 	) -> Risk? {
 		switch riskLevel(
 			summary: summary,
@@ -202,7 +202,7 @@ enum RiskCalculation {
 
 			var riskLevelHasChanged = false
 			if
-				let previousRiskLevel = store.previousRiskLevel,
+				let previousRiskLevel = previousRiskLevel,
 				let newRiskLevel = EitherLowOrIncreasedRiskLevel(with: level),
 				previousRiskLevel != newRiskLevel {
 				// If the newly calculated risk level is different than the stored level, set the flag to true.

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
@@ -176,7 +176,7 @@ enum RiskCalculation {
 		numberOfTracingActiveHours: Int,
 		preconditions: ExposureManagerState,
 		currentDate: Date = Date(),
-		previousSummary: CodableExposureDetectionSummary?
+		store: Store
 	) -> Risk? {
 		switch riskLevel(
 			summary: summary,
@@ -192,21 +192,22 @@ enum RiskCalculation {
 				exposureDetectionDate: dateLastExposureDetection ?? Date()
 			)
 
-			var riskLevelHasChanged = false
-			if
-				let summary = summary,
-				let previousSummary = previousSummary,
-				(RiskLevel(riskScore: summary.maximumRiskScore) == .low || RiskLevel(riskScore: summary.maximumRiskScore) == .increased),
-				RiskLevel(riskScore: summary.maximumRiskScore) != RiskLevel(riskScore: previousSummary.maximumRiskScore) {
-				riskLevelHasChanged = true
-			}
-
 			DispatchQueue.main.async {
 				// TODO: Remove
 				let appDelegate = UIApplication.shared.delegate as? AppDelegate
 				appDelegate?.lastRiskCalculation.append("\n ===== Risk =====\n")
 				appDelegate?.lastRiskCalculation.append("details: \(details)\n")
 				appDelegate?.lastRiskCalculation.append("summary: \(String(describing: summary?.description))\n")
+			}
+
+			var riskLevelHasChanged = false
+			if
+				let previousRiskLevel = store.previousRiskLevel,
+				let newRiskLevel = EitherLowOrIncreasedRiskLevel(with: level),
+				previousRiskLevel != newRiskLevel {
+				// If the newly calculated risk level is different than the stored level, set the flag to true.
+				// Note that we ignore all levels aside from low or increased risk
+				riskLevelHasChanged = true
 			}
 			
 			return Risk(

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
@@ -55,7 +55,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date(),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.invalid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .inactive)
@@ -76,7 +76,7 @@ final class RiskCalculationTests: XCTestCase {
 				dateLastExposureDetection: Date(),
 				numberOfTracingActiveHours: 0,
 				preconditions: preconditions(.valid),
-				store: store
+				previousRiskLevel: nil
 			)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
@@ -88,7 +88,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date(),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
@@ -104,7 +104,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .unknownOutdated)
@@ -119,7 +119,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .low)
@@ -134,7 +134,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .increased)
@@ -153,7 +153,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertNil(risk)
@@ -170,7 +170,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertNil(risk)
@@ -187,7 +187,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertNil(risk)
@@ -206,7 +206,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .increased)
@@ -220,7 +220,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
@@ -231,7 +231,7 @@ final class RiskCalculationTests: XCTestCase {
 	func testCalculateRisk_RiskChanged_WithPreviousRisk() {
 		// Test the case where we have an old risk level in the store,
 		// and the new risk level has changed
-		store.previousRiskLevel = .low
+		let previousRiskLevel = EitherLowOrIncreasedRiskLevel.low
 
 		// Will produce increased risk
 		let risk = RiskCalculation.risk(
@@ -241,7 +241,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: previousRiskLevel
 		)
 
 		XCTAssertTrue(risk?.riskLevelHasChanged ?? false)
@@ -250,7 +250,6 @@ final class RiskCalculationTests: XCTestCase {
 	func testCalculateRisk_RiskChanged_NoPreviousRisk() {
 		// Test the case where we do not have an old risk level in the store,
 		// and the new risk level has changed
-		store.previousRiskLevel = nil
 
 		// Will produce high risk
 		let risk = RiskCalculation.risk(
@@ -260,7 +259,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: nil
 		)
 		// Going from unknown -> increased or low risk does not produce a change
 		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
@@ -269,7 +268,7 @@ final class RiskCalculationTests: XCTestCase {
 	func testCalculateRisk_RiskNotChanged() {
 		// Test the case where we have an old risk level in the store,
 		// and the new risk level has not changed
-		store.previousRiskLevel = .low
+		let previousRiskLevel = EitherLowOrIncreasedRiskLevel.low
 
 		let risk = RiskCalculation.risk(
 			summary: summaryLow,
@@ -278,7 +277,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: previousRiskLevel
 		)
 
 		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
@@ -287,7 +286,7 @@ final class RiskCalculationTests: XCTestCase {
 	func testCalculateRisk_LowToUnknown() {
 		// Test the case where we have low risk level in the store,
 		// and the new risk calculation returns unknown
-		store.previousRiskLevel = .low
+		let previousRiskLevel = EitherLowOrIncreasedRiskLevel.low
 
 		// Produces unknown risk
 		let risk = RiskCalculation.risk(
@@ -296,7 +295,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: previousRiskLevel
 		)
 		// The risk level did not change - we only care about changes between low and increased
 		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
@@ -305,7 +304,7 @@ final class RiskCalculationTests: XCTestCase {
 	func testCalculateRisk_IncreasedToUnknown() {
 		// Test the case where we have low risk level in the store,
 		// and the new risk calculation returns unknown
-		store.previousRiskLevel = .increased
+		let previousRiskLevel = EitherLowOrIncreasedRiskLevel.increased
 
 		// Produces unknown risk
 		let risk = RiskCalculation.risk(
@@ -314,7 +313,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			store: store
+			previousRiskLevel: previousRiskLevel
 		)
 		// The risk level did not change - we only care about changes between low and increased
 		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
@@ -23,6 +23,8 @@ import XCTest
 
 final class RiskCalculationTests: XCTestCase {
 
+	private let store = MockTestStore()
+
 	// MARK: - Tests for calculating raw risk score
 
 	func testCalculateRawRiskScore_Zero() throws {
@@ -53,7 +55,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date(),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.invalid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .inactive)
@@ -74,7 +76,7 @@ final class RiskCalculationTests: XCTestCase {
 				dateLastExposureDetection: Date(),
 				numberOfTracingActiveHours: 0,
 				preconditions: preconditions(.valid),
-				previousSummary: nil
+				store: store
 			)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
@@ -86,7 +88,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date(),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
@@ -102,7 +104,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .unknownOutdated)
@@ -117,7 +119,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .low)
@@ -132,7 +134,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .increased)
@@ -151,7 +153,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertNil(risk)
@@ -168,7 +170,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertNil(risk)
@@ -185,7 +187,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(-3600),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertNil(risk)
@@ -204,7 +206,7 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .increased)
@@ -218,10 +220,104 @@ final class RiskCalculationTests: XCTestCase {
 			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
 			numberOfTracingActiveHours: 48,
 			preconditions: preconditions(.valid),
-			previousSummary: nil
+			store: store
 		)
 
 		XCTAssertEqual(risk?.level, .unknownInitial)
+	}
+
+	// MARK: - RiskLevel changed tests
+
+	func testCalculateRisk_RiskChanged_WithPreviousRisk() {
+		// Test the case where we have an old risk level in the store,
+		// and the new risk level has changed
+		store.previousRiskLevel = .low
+
+		// Will produce increased risk
+		let risk = RiskCalculation.risk(
+			summary: summaryHigh,
+			configuration: appConfig,
+			// arbitrary, but within limit
+			dateLastExposureDetection: Date().addingTimeInterval(-3600),
+			numberOfTracingActiveHours: 48,
+			preconditions: preconditions(.valid),
+			store: store
+		)
+
+		XCTAssertTrue(risk?.riskLevelHasChanged ?? false)
+	}
+
+	func testCalculateRisk_RiskChanged_NoPreviousRisk() {
+		// Test the case where we do not have an old risk level in the store,
+		// and the new risk level has changed
+		store.previousRiskLevel = nil
+
+		// Will produce high risk
+		let risk = RiskCalculation.risk(
+			summary: summaryHigh,
+			configuration: appConfig,
+			// arbitrary, but within limit
+			dateLastExposureDetection: Date().addingTimeInterval(-3600),
+			numberOfTracingActiveHours: 48,
+			preconditions: preconditions(.valid),
+			store: store
+		)
+		// Going from unknown -> increased or low risk does not produce a change
+		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
+	}
+
+	func testCalculateRisk_RiskNotChanged() {
+		// Test the case where we have an old risk level in the store,
+		// and the new risk level has not changed
+		store.previousRiskLevel = .low
+
+		let risk = RiskCalculation.risk(
+			summary: summaryLow,
+			configuration: appConfig,
+			// arbitrary, but within limit
+			dateLastExposureDetection: Date().addingTimeInterval(-3600),
+			numberOfTracingActiveHours: 48,
+			preconditions: preconditions(.valid),
+			store: store
+		)
+
+		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
+	}
+
+	func testCalculateRisk_LowToUnknown() {
+		// Test the case where we have low risk level in the store,
+		// and the new risk calculation returns unknown
+		store.previousRiskLevel = .low
+
+		// Produces unknown risk
+		let risk = RiskCalculation.risk(
+			summary: summaryLow,
+			configuration: appConfig,
+			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
+			numberOfTracingActiveHours: 48,
+			preconditions: preconditions(.valid),
+			store: store
+		)
+		// The risk level did not change - we only care about changes between low and increased
+		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
+	}
+
+	func testCalculateRisk_IncreasedToUnknown() {
+		// Test the case where we have low risk level in the store,
+		// and the new risk calculation returns unknown
+		store.previousRiskLevel = .increased
+
+		// Produces unknown risk
+		let risk = RiskCalculation.risk(
+			summary: summaryLow,
+			configuration: appConfig,
+			dateLastExposureDetection: Date().addingTimeInterval(.init(days: -2)),
+			numberOfTracingActiveHours: 48,
+			preconditions: preconditions(.valid),
+			store: store
+		)
+		// The risk level did not change - we only care about changes between low and increased
+		XCTAssertFalse(risk?.riskLevelHasChanged ?? true)
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -202,7 +202,7 @@ extension RiskProvider: RiskProviding {
 				numberOfTracingActiveHours: numberOfEnabledHours,
 				preconditions: exposureManagerState,
 				currentDate: Date(),
-				previousSummary: summaries?.previous?.summary
+				store: store
 			) else {
 				logError(message: "Serious error during risk calculation")
 				completeOnTargetQueue(risk: nil)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -202,7 +202,7 @@ extension RiskProvider: RiskProviding {
 				numberOfTracingActiveHours: numberOfEnabledHours,
 				preconditions: exposureManagerState,
 				currentDate: Date(),
-				store: store
+				previousRiskLevel: store.previousRiskLevel
 			) else {
 				logError(message: "Serious error during risk calculation")
 				completeOnTargetQueue(risk: nil)

--- a/src/xcode/ENA/ENA/Source/Workers/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store.swift
@@ -23,6 +23,19 @@ enum EitherLowOrIncreasedRiskLevel: Int {
 	case increased = 1_000 // so that increased > low + we have enough reserved values
 }
 
+extension EitherLowOrIncreasedRiskLevel {
+	init?(with risk: RiskLevel) {
+		switch risk {
+		case .low:
+			self = .low
+		case .increased:
+			self = .increased
+		default:
+			return nil
+		}
+	}
+}
+
 protocol Store: AnyObject {
 	var isOnboarded: Bool { get set }
 	var dateOfAcceptedPrivacyNotice: Date? { get set }


### PR DESCRIPTION
## Summary

Previous risk level is now **not** calculated from the previous exposure
detection summary, but from the previous `EitherLowOrIncreasedRiskLevel` in the `Store`

<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

