### PR TITLE
[Bug] Privacy protection screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -112,13 +112,13 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 		updateExposureState(state)
 	}
 
+	func sceneDidEnterBackground(_ scene: UIScene) {
+		showPrivacyProtectionWindow()
+	}
+
 	func sceneDidBecomeActive(_: UIScene) {
 		hidePrivacyProtectionWindow()
 		UIApplication.shared.applicationIconBadgeNumber = 0
-	}
-
-	func sceneWillResignActive(_: UIScene) {
-		showPrivacyProtectionWindow()
 	}
 
 	// MARK: Helper
@@ -276,6 +276,7 @@ extension SceneDelegate {
 			else {
 				return
 		}
+
 		let privacyProtectionViewController = PrivacyProtectionViewController()
 		privacyProtectionWindow = UIWindow(windowScene: windowScene)
 		privacyProtectionWindow?.rootViewController = privacyProtectionViewController

--- a/src/xcode/ENA/ENA/Source/Scenes/PrivacyProtectionViewController/PrivacyProtectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/PrivacyProtectionViewController/PrivacyProtectionViewController.swift
@@ -36,13 +36,13 @@ class PrivacyProtectionViewController: UIViewController {
 	}
 	
 	func show() {
-		UIView.animate(withDuration: 0.2, animations: {
+		UIView.animate(withDuration: CATransaction.animationDuration(), animations: {
 			self.view.alpha = 1.0
 		})
 	}
 	
 	func hide(completion: (() -> Void)? = nil) {
-		UIView.animate(withDuration: 0.1, animations: {
+		UIView.animate(withDuration: CATransaction.animationDuration(), animations: {
 			self.view.alpha = 0.0
 		}, completion: { _ in
 			completion?()


### PR DESCRIPTION
This PR addresses the issue of the privacy protection screen appearing, when interrupted by system dialogs such as phone call prompts as show below.

|Before|After|
|:--|:--|
|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84204261-28de2c80-aaab-11ea-8868-c14e4a5ba699.png">|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84204323-4612fb00-aaab-11ea-97e3-9130a2d21aa7.png">|
