### PR TITLE
Risk cell chevron icon tint color

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
@@ -24,10 +24,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="627" height="376"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6sx-gi-fDy" userLabel="Top Container">
-                                        <rect key="frame" x="0.0" y="0.0" width="627" height="90"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="627" height="93.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gno-nj-MZX" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                <rect key="frame" x="8" y="52" width="571" height="30"/>
+                                                <rect key="frame" x="8" y="52" width="571" height="33.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <color key="textColor" name="ENA Text Primary 1 Color"/>
                                                 <nil key="highlightedColor"/>
@@ -37,7 +37,7 @@
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="255" verticalHuggingPriority="251" horizontalCompressionResistancePriority="755" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="nJl-O5-rry">
                                                 <rect key="frame" x="587" y="54" width="32" height="28.5"/>
-                                                <color key="tintColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="gv6-c3-YX2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="pm1-Pr-Fe4"/>
@@ -54,7 +54,7 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" text="Body Body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Sq-Fu-7Ci" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="105" width="627" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="108.5" width="627" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -63,13 +63,13 @@
                                         </userDefinedRuntimeAttributes>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1VM-pd-4gu">
-                                        <rect key="frame" x="0.0" y="140.5" width="627" height="137"/>
+                                        <rect key="frame" x="0.0" y="144" width="627" height="137"/>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eyD-er-ora" userLabel="Label Container">
-                                        <rect key="frame" x="0.0" y="292.5" width="627" height="35.5"/>
+                                        <rect key="frame" x="0.0" y="296" width="627" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" verticalCompressionResistancePriority="755" text="Aktualisierung in 51:08 Minuten" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NNo-PQ-bh2" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                <rect key="frame" x="8" y="8" width="611" height="19.5"/>
+                                                <rect key="frame" x="8" y="8" width="611" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
@@ -37,7 +37,7 @@
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="255" verticalHuggingPriority="251" horizontalCompressionResistancePriority="755" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="nJl-O5-rry">
                                                 <rect key="frame" x="587" y="54" width="32" height="28.5"/>
-                                                <color key="tintColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="gv6-c3-YX2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="pm1-Pr-Fe4"/>

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
@@ -24,10 +24,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="627" height="376"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6sx-gi-fDy" userLabel="Top Container">
-                                        <rect key="frame" x="0.0" y="0.0" width="627" height="93.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="627" height="90"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gno-nj-MZX" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                <rect key="frame" x="8" y="52" width="571" height="33.5"/>
+                                                <rect key="frame" x="8" y="52" width="571" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <color key="textColor" name="ENA Text Primary 1 Color"/>
                                                 <nil key="highlightedColor"/>
@@ -37,7 +37,7 @@
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="255" verticalHuggingPriority="251" horizontalCompressionResistancePriority="755" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="nJl-O5-rry">
                                                 <rect key="frame" x="587" y="54" width="32" height="28.5"/>
-                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="gv6-c3-YX2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="pm1-Pr-Fe4"/>
@@ -54,7 +54,7 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" text="Body Body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Sq-Fu-7Ci" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="108.5" width="627" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="105" width="627" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -63,13 +63,13 @@
                                         </userDefinedRuntimeAttributes>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1VM-pd-4gu">
-                                        <rect key="frame" x="0.0" y="144" width="627" height="137"/>
+                                        <rect key="frame" x="0.0" y="140.5" width="627" height="137"/>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eyD-er-ora" userLabel="Label Container">
-                                        <rect key="frame" x="0.0" y="296" width="627" height="32"/>
+                                        <rect key="frame" x="0.0" y="292.5" width="627" height="35.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" verticalCompressionResistancePriority="755" text="Aktualisierung in 51:08 Minuten" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NNo-PQ-bh2" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                <rect key="frame" x="8" y="8" width="611" height="16"/>
+                                                <rect key="frame" x="8" y="8" width="611" height="19.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/Risk/RiskLevelCollectionViewCell.xib
@@ -37,7 +37,7 @@
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="255" verticalHuggingPriority="251" horizontalCompressionResistancePriority="755" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="nJl-O5-rry">
                                                 <rect key="frame" x="587" y="54" width="32" height="28.5"/>
-                                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="tintColor" name="ENA Text Contrast Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="gv6-c3-YX2"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="pm1-Pr-Fe4"/>


### PR DESCRIPTION
I changed the tint color of the risk cell. The previous tint color did not contrast enough with the background color of the cell.

The tint color now is ENA Text Contrast Color. It's basically just white but to make the icon automatically adapt to any future color scheme changes.

Before:
<img src="https://user-images.githubusercontent.com/24317813/84239173-64551700-aafc-11ea-896a-032de8c9c702.png" width=280x></img>

After:
<img src="https://user-images.githubusercontent.com/24317813/84239167-61f2bd00-aafc-11ea-9549-457c56d555c9.png" width=280x></img>
