### PR TITLE
[Bug] iOS: Onboarding screen flow is wrong / regression (EXPOSUREAPP-1394)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Onboarding/OnboardingInfo.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Onboarding/OnboardingInfo.swift
@@ -62,11 +62,11 @@ extension OnboardingInfo {
 		)
 
 		let info3 = OnboardingInfo(
-			title: AppStrings.Onboarding.onboardingInfo_privacyPage_title,
-			imageName: "Illu_Onboarding_Datenschutz",
-			imageDescription: AppStrings.Onboarding.onboardingInfo_privacyPage_imageDescription,
-			boldText: AppStrings.Onboarding.onboardingInfo_privacyPage_boldText,
-			text: AppStrings.Onboarding.onboardingInfo_privacyPage_normalText,
+			title: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_title,
+			imageName: "Illu_Onboarding_Risikoerekennung",
+			imageDescription: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_imageDescription,
+			boldText: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_boldText,
+			text: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_normalText,
 			actionText: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_button,
 			ignoreText: AppStrings.Onboarding.onboardingDoNotActivate,
 			titleAccessibilityIdentifier: "AppStrings.Onboarding.onboardingInfo_privacyPage_title",


### PR DESCRIPTION
# What this PR does

Fixing the bug from the ticket EXPOSUREAPP-1394. Actually this issue  was not that the flow is wrong and a screen showing twice, but resources for some images and texts were doubled on two screens.