### PR TITLE
[Bug] Change navigation appearance to solid white

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/App/AppNavigationController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/App/AppNavigationController.swift
@@ -58,10 +58,12 @@ extension AppNavigationController: UINavigationControllerDelegate {
 
 		var navigationBackgroundAlpha: CGFloat = 1.0
 		var largeTitleBlurEffect: UIBlurEffect.Style?
+		var largeTitleBackgroundColor: UIColor?
 
 		if let opacityDelegate = viewController as? NavigationBarOpacityDelegate {
 			navigationBackgroundAlpha = opacityDelegate.backgroundAlpha
 			largeTitleBlurEffect = opacityDelegate.preferredLargeTitleBlurEffect
+			largeTitleBackgroundColor = opacityDelegate.preferredLargeTitleBackgroundColor
 
 			if let scrollView = viewController.view as? UIScrollView ?? viewController.view.subviews.first(ofType: UIScrollView.self) {
 				scrollViewObserver = scrollView.observe(\.contentOffset) { [weak self] _, _ in
@@ -74,10 +76,14 @@ extension AppNavigationController: UINavigationControllerDelegate {
 
 		let previousNavigationBackgroundAlpha = navigationBar.backgroundAlpha
 		let previousScrollEdgeAppearance = navigationBar.scrollEdgeAppearance
+
 		transitionCoordinator?.animate(alongsideTransition: { _ in
 			self.navigationBar.backgroundAlpha = navigationBackgroundAlpha
 
-			if let largeTitleBlurEffect = largeTitleBlurEffect {
+			if let largeTitleBackgroundColor = largeTitleBackgroundColor {
+				self.navigationBar.scrollEdgeAppearance = UINavigationBarAppearance()
+				self.navigationBar.scrollEdgeAppearance?.backgroundColor = largeTitleBackgroundColor
+			} else if let largeTitleBlurEffect = largeTitleBlurEffect {
 				self.navigationBar.scrollEdgeAppearance = UINavigationBarAppearance()
 				self.navigationBar.scrollEdgeAppearance?.backgroundEffect = UIBlurEffect(style: largeTitleBlurEffect)
 			} else {
@@ -120,10 +126,12 @@ private extension Array {
 protocol NavigationBarOpacityDelegate: class {
 	var preferredNavigationBarOpacity: CGFloat { get }
 	var preferredLargeTitleBlurEffect: UIBlurEffect.Style? { get }
+	var preferredLargeTitleBackgroundColor: UIColor? { get }
 }
 
 extension NavigationBarOpacityDelegate {
 	var preferredNavigationBarOpacity: CGFloat { 1.0 }
 	var preferredLargeTitleBlurEffect: UIBlurEffect.Style? { nil }
+	var preferredLargeTitleBackgroundColor: UIColor? { nil }
 	fileprivate var backgroundAlpha: CGFloat { max(0, min(preferredNavigationBarOpacity, 1)) }
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController.swift
@@ -105,5 +105,5 @@ extension AppInformationViewController {
 }
 
 extension AppInformationViewController: NavigationBarOpacityDelegate {
-	var preferredLargeTitleBlurEffect: UIBlurEffect.Style? { .systemChromeMaterial }
+	var preferredLargeTitleBackgroundColor: UIColor? { .enaColor(for: .background) }
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -299,5 +299,5 @@ extension SettingsViewController: ENStateHandlerUpdating {
 }
 
 extension SettingsViewController: NavigationBarOpacityDelegate {
-	var preferredLargeTitleBlurEffect: UIBlurEffect.Style? { .systemChromeMaterial }
+	var preferredLargeTitleBackgroundColor: UIColor? { .enaColor(for: .background) }
 }


### PR DESCRIPTION
This PR changes the large title navigation bar appearance for app information and settings to solid white.

This is a rather minor color change:
|Before|After|
|:--|:--|
|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84278225-c6317300-ab34-11ea-8f0c-9a7c0980e679.png">|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84278148-aef28580-ab34-11ea-8064-eef41e471209.png">|

