### PR TITLE
[Bug] Fix risk legend line break with large text

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/RiskLegend.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/RiskLegend.storyboard
@@ -23,8 +23,8 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Body" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="onE-k3-TYh" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                            <rect key="frame" x="68" y="11" width="326" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Body" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="onE-k3-TYh" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
+                                            <rect key="frame" x="68" y="11" width="326" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" name="ENA Text Primary 1 Color"/>
                                             <nil key="highlightedColor"/>


### PR DESCRIPTION
This PR fix risk legend line break with large text.

<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84308316-96976080-ab5e-11ea-9794-d1ee035e7946.png">
