### PR TITLE
[Bug] Trait headers on risk legend

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewSection.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewSection.swift
@@ -49,6 +49,7 @@ extension DynamicSection {
 				cell.contentView.preservesSuperviewLayoutMargins = false
 				cell.contentView.layoutMargins = insets
 				cell.accessibilityIdentifier = accessibilityIdentifier
+				cell.accessibilityTraits = .header
 			}
 		])
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/RiskLegendViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/RiskLegendViewController+DynamicTableViewModel.swift
@@ -33,7 +33,7 @@ extension RiskLegendViewController {
 							   height: 200),
 				footer: .space(height: 32),
 				cells: [
-					.icon(UIImage(named: "Icons_Ueberblick_1"), text: AppStrings.RiskLegend.legend1Title, style: .title2),
+					.icon(UIImage(named: "Icons_Ueberblick_1"), text: AppStrings.RiskLegend.legend1Title, style: .title2) { _, cell, _ in cell.accessibilityTraits = .header },
 					.body(
 						text: AppStrings.RiskLegend.legend1Text,
 						accessibilityIdentifier: "AppStrings.RiskLegend.legend1Text")
@@ -42,7 +42,7 @@ extension RiskLegendViewController {
 			.section(
 				footer: .space(height: 32),
 				cells: [
-					.icon(UIImage(named: "Icons_Ueberblick_2"), text: AppStrings.RiskLegend.legend2Title, style: .title2),
+					.icon(UIImage(named: "Icons_Ueberblick_2"), text: AppStrings.RiskLegend.legend2Title, style: .title2) { _, cell, _ in cell.accessibilityTraits = .header },
 					.body(
 						text: AppStrings.RiskLegend.legend2Text,
 						accessibilityIdentifier: "AppStrings.RiskLegend.legend2Text"),
@@ -71,7 +71,7 @@ extension RiskLegendViewController {
 			.section(
 				footer: .separator(color: .enaColor(for: .hairline), insets: UIEdgeInsets(top: 32, left: 0, bottom: 32, right: 0)),
 				cells: [
-					.icon(UIImage(named: "Icons_Ueberblick_3"), text: AppStrings.RiskLegend.legend3Title, style: .title2),
+					.icon(UIImage(named: "Icons_Ueberblick_3"), text: AppStrings.RiskLegend.legend3Title, style: .title2) { _, cell, _ in cell.accessibilityTraits = .header },
 					.body(
 						text: AppStrings.RiskLegend.legend3Text,
 						accessibilityIdentifier: "AppStrings.RiskLegend.legend3Text")


### PR DESCRIPTION
This PR adds missing header trait on risk legend. Furthermore, the global navigation subtitle was changed to header.