### PR TITLE
[Bug] Fix switch appearance on notification settings screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureNotificationSetting.storyboard
@@ -87,7 +87,6 @@
                                                                     </connections>
                                                                 </switch>
                                                             </subviews>
-                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="ttn-a7-w0H" secondAttribute="trailing" id="CNv-eR-5X6"/>
                                                                 <constraint firstItem="ttn-a7-w0H" firstAttribute="leading" secondItem="yn0-sa-eIJ" secondAttribute="leading" id="HmR-Ls-yth"/>


### PR DESCRIPTION
This PR fixed the switch appearance on the notification settings screen.

|Before|After|
|:--|:--|
|<img width="767" alt="Bildschirmfoto 2020-06-11 um 12 41 50" src="https://user-images.githubusercontent.com/64848654/84376239-16fea580-abe1-11ea-9240-8307c8ffdc4d.png">|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84376309-3ac1eb80-abe1-11ea-838c-cc6aa2df346f.png">|

