### PR TITLE
fix: Reload Test Result cell unless it is positive

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -382,7 +382,7 @@ extension HomeInteractor {
 extension HomeInteractor {
 	func updateTestResults() {
 		// Avoid unnecessary loading.
-		guard testResult == nil || testResult == .pending else { return }
+		guard testResult == nil || testResult != .positive else { return }
 		guard store.registrationToken != nil else { return }
 
 


### PR DESCRIPTION
This fix removes the error where the user would still have a negative result in their homescreen after scanning a new positive qr code, because it would not reload correctly.