### PR TITLE
[Lint] Fixes some trivial SwiftLint warnings

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -201,7 +201,9 @@ disabled_rules:
 
 # Included paths (disables --path option)
 included:
-  - ENA
+  - ENA/Source
+  - ENATests
+  - ENAUITests
 
 # Excluded paths (takes precedence over 'included')
 excluded: # paths to ignore during linting. Takes precedence over `included`.

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/SAPDownloadedPackageTests.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/SAPDownloadedPackageTests.swift
@@ -38,8 +38,9 @@ final class SAPDownloadedPackageTests: XCTestCase {
 		// Test the package signature verification process - rejecting when the signature does not match
 		let bytes = [0xA, 0xB, 0xC, 0xD]
 		// The bin and signature were  made for different data sets
-		let package = try makePackage(bin: Data(bytes: bytes, count: 4),
-									  signature: try makeSignature(data: Data(bytes: bytes, count: 3)).asList() //swiftlint:disable:this vertical_parameter_alignment_on_call
+		let package = try makePackage(
+			bin: Data(bytes: bytes, count: 4),
+			signature: try makeSignature(data: Data(bytes: bytes, count: 3)).asList()
 		)
 
 		XCTAssertFalse(package.verifySignature(with: MockKeyStore(keys: [defaultBundleId: publicKey])))

--- a/src/xcode/ENA/ENA/Source/Extensions/UIApplication+CoronaWarn.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UIApplication+CoronaWarn.swift
@@ -18,7 +18,9 @@
 import UIKit
 extension UIApplication {
 	class func coronaWarnDelegate() -> CoronaWarnAppDelegate {
-		// swiftlint:disable:next force_cast
-		shared.delegate as! CoronaWarnAppDelegate
+		guard let delegate = shared.delegate as? CoronaWarnAppDelegate else {
+			fatalError("shared.delegate is expected to be of type 'CoronaWarnAppDelegate'")
+		}
+		return delegate
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+DynamicTableViewModel.swift
@@ -77,7 +77,9 @@ private extension DynamicAction {
 }
 
 extension AppInformationViewController {
-	static let model: [Category: (text: String, accessibilityIdentifier: String?, action: DynamicAction)] = [
+	typealias CategoryModel = (text: String, accessibilityIdentifier: String?, action: DynamicAction)
+
+	static let model: [Category: CategoryModel] = [
 		.about: (
 			text: AppStrings.AppInformation.aboutNavigation,
 			accessibilityIdentifier: "AppStrings.AppInformation.aboutNavigation",

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+LegalModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+LegalModel.swift
@@ -31,19 +31,20 @@ private extension DynamicCell {
 	}
 }
 
-
-// swiftlint:disable line_length
 extension AppInformationViewController {
 	static let legalModel = DynamicTableViewModel([
 		.section(
-			header: .image(UIImage(named: "Illu_Appinfo_RechtlicheHinweise"),
-						   accessibilityLabel: AppStrings.AppInformation.legalImageDescription,
-						   accessibilityIdentifier: "AppStrings.AppInformation.legalImageDescription",
-						   height: 230),
+			header: .image(
+				UIImage(named: "Illu_Appinfo_RechtlicheHinweise"),
+				accessibilityLabel: AppStrings.AppInformation.legalImageDescription,
+				accessibilityIdentifier: "AppStrings.AppInformation.legalImageDescription",
+				height: 230
+			),
 			cells: legalCells
 		)
 	])
 
+	// swiftlint:disable line_length
 	private static let legalCells: [DynamicCell] = [
 		.legal(title: "ZIPFoundation", licensor: "Thomas Zoechling", fullLicense: """
 MIT License
@@ -160,5 +161,5 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """)
 	]
+	// swiftlint:enable line_length
 }
-// swiftlint:enable line_length

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -43,8 +43,8 @@ platform :ios do
 
     swiftlint(
       mode: :lint,
+      path: "ENA",
       output_file: "swiftlint.result.json",
-      config_file: "ENA/.swiftlint.yml",
       raise_if_swiftlint_error: true,
       reporter: "sonarqube"
     )


### PR DESCRIPTION
## Description
This is the first follow-up smaller PR to https://github.com/corona-warn-app/cwa-app-ios/pull/104. Together with the other PRs I will be posting, all SwiftLint warnings should be fixed to allow us to enable the `--strict` mode of SwiftLint on the CI to prevent any new warnings getting merged in the future.

## Related PRs
https://github.com/corona-warn-app/cwa-app-ios/pull/518, https://github.com/corona-warn-app/cwa-app-ios/pull/522, https://github.com/corona-warn-app/cwa-app-ios/pull/527, https://github.com/corona-warn-app/cwa-app-ios/pull/531, https://github.com/corona-warn-app/cwa-app-ios/pull/534.

_Note that all these PRs are completely independent and **can be merged in any order**._