### PR TITLE
[Lint] Turn off unnecessary rules in test code

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -201,7 +201,9 @@ disabled_rules:
 
 # Included paths (disables --path option)
 included:
-  - ENA
+  - ENA/Source
+  - ENATests
+  - ENAUITests
 
 # Excluded paths (takes precedence over 'included')
 excluded: # paths to ignore during linting. Takes precedence over `included`.

--- a/src/xcode/ENA/ENA/Backend/__tests__/Sap_FilebucketTests.swift
+++ b/src/xcode/ENA/ENA/Backend/__tests__/Sap_FilebucketTests.swift
@@ -26,7 +26,6 @@ final class SapFileBucketTests: XCTestCase {
 		let fixtureUrl = bundle.url(
 			forResource: "api-response-day-2020-05-16",
 			withExtension: nil
-			// swiftlint:disable:next force_unwrapping
 		)!
 
 		let fixtureData = try Data(contentsOf: fixtureUrl)

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/HTTPClientTests.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/HTTPClientTests.swift
@@ -19,7 +19,6 @@
 import ExposureNotification
 import XCTest
 
-// swiftlint:disable:next type_body_length
 final class HTTPClientTests: XCTestCase {
 	let binFileSize = 501
 	let sigFileSize = 144
@@ -221,7 +220,6 @@ final class HTTPClientTests: XCTestCase {
 	}
 
 	func testFetchHour_Success() throws {
-		// swiftlint:disable:next force_unwrapping
 		let url = Bundle(for: type(of: self)).url(forResource: "api-response-day-2020-05-16", withExtension: nil)!
 		let responseData = try Data(contentsOf: url)
 
@@ -262,7 +260,6 @@ final class HTTPClientTests: XCTestCase {
 	}
 
 	func testFetchDay_Success() throws {
-		// swiftlint:disable:next force_unwrapping
 		let url = Bundle(for: type(of: self)).url(forResource: "api-response-day-2020-05-16", withExtension: nil)!
 		let responseData = try Data(contentsOf: url)
 
@@ -467,7 +464,6 @@ final class HTTPClientTests: XCTestCase {
 
 	// TODO: Enable once we figured our how to get this running with production server
 //	func testValidExposureConfigurationResponseData() throws {
-//		// swiftlint:disable:next force_unwrapping
 //		let url = Bundle(for: type(of: self)).url(forResource: "de-config", withExtension: nil)!
 //		let responseData = try Data(contentsOf: url)
 //
@@ -485,7 +481,6 @@ final class HTTPClientTests: XCTestCase {
 //	}
 
 	func testValidExposureConfigurationDataBut404Response() throws {
-		// swiftlint:disable:next force_unwrapping
 		let url = Bundle(for: type(of: self)).url(forResource: "de-config", withExtension: nil)!
 		let responseData = try Data(contentsOf: url)
 

--- a/src/xcode/ENA/ENA/Source/Client/Security/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Client/Security/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Client/Security/__tests__/CoronaWarnURLSessionDelegateTests.swift
+++ b/src/xcode/ENA/ENA/Source/Client/Security/__tests__/CoronaWarnURLSessionDelegateTests.swift
@@ -19,7 +19,6 @@
 import XCTest
 
 class CoronaWarnURLSessionDelegateTests: XCTestCase {
-	//swiftlint:disable:next weak_delegate
 	private let delegate = CoronaWarnURLSessionDelegate()
 
 	// MARK: - Whitelist testing

--- a/src/xcode/ENA/ENA/Source/Client/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Extensions/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Extensions/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Models/Converting Keys/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Models/Converting Keys/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
@@ -21,7 +21,6 @@ import XCTest
 @testable import ENA
 import ExposureNotification
 final class ExposureDetectionTransactionTests: XCTestCase {
-	// swiftlint:disable:next function_body_length
     func testGivenThatEveryNeedIsSatisfiedTheDetectionFinishes() throws {
 		let delegate = ExposureDetectionDelegateMock()
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
@@ -21,8 +21,6 @@
 import ExposureNotification
 import XCTest
 
-// swiftlint:disable file_length
-// swiftlint:disable:next type_body_length
 final class RiskCalculationTests: XCTestCase {
 
 	private let store = MockTestStore()

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -32,7 +32,6 @@ private final class ExposureSummaryProviderMock: ExposureSummaryProvider {
 }
 
 final class RiskProviderTests: XCTestCase {
-	// swiftlint:disable:next function_body_length
 	func testExposureDetectionIsExecutedIfLastDetectionIsToOldAndModeIsAutomatic() throws {
 		var duration = DateComponents()
 		duration.day = 1
@@ -55,7 +54,6 @@ final class RiskProviderTests: XCTestCase {
 				attenuationDurations: [],
 				maximumRiskScoreFullRange: 0
 			),
-			// swiftlint:disable:next force_unwrapping
 			date: lastExposureDetectionDate!
 		)
 
@@ -111,7 +109,6 @@ final class RiskProviderTests: XCTestCase {
 			value: -12,
 			to: Date(),
 			wrappingComponents: false
-			// swiftlint:disable:next force_unwrapping
 		)!
 
 		let store = MockTestStore()
@@ -156,7 +153,6 @@ final class RiskProviderTests: XCTestCase {
 //		XCTAssertTrue(calendar.isDate(sut.nextExposureDetectionDate(), equalTo: expectedDate, toGranularity: .hour))
 
 		consumer.nextExposureDetectionDateDidChange = { nextDetectionDate in
-			// swiftlint:disable:next force_unwrapping
 //			let expectedDate = calendar.date(byAdding: .hour, value: 12, to: Date(), wrappingComponents: false)
 //			print("expected: \(expectedDate)")
 //			print("nextDetectionDate: \(nextDetectionDate)")

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Workers/Update Checker/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Workers/Update Checker/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/.swiftlint.yml
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENATests/.swiftlint.yml
+++ b/src/xcode/ENA/ENATests/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/ENA/ENATests/Helper/URL+Helper.swift
+++ b/src/xcode/ENA/ENATests/Helper/URL+Helper.swift
@@ -19,7 +19,6 @@ import Foundation
 
 extension URL {
 	init(staticString: StaticString) {
-		// swiftlint:disable:next force_unwrapping
 		self.init(string: "\(staticString)")!
 	}
 }

--- a/src/xcode/ENA/ENAUITests/.swiftlint.yml
+++ b/src/xcode/ENA/ENAUITests/.swiftlint.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - file_length
+  - force_cast
+  - force_try
+  - force_unwrapping
+  - function_body_length
+  - type_body_length
+  - weak_delegate

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -43,8 +43,8 @@ platform :ios do
 
     swiftlint(
       mode: :lint,
+      path: "ENA",
       output_file: "swiftlint.result.json",
-      config_file: "ENA/.swiftlint.yml",
       raise_if_swiftlint_error: true,
       reporter: "sonarqube"
     )


### PR DESCRIPTION
## Description
This is the second follow-up smaller PR to https://github.com/corona-warn-app/cwa-app-ios/pull/104. Together with the other PRs I will be posting, all SwiftLint warnings should be fixed to allow us to enable the `--strict` mode of SwiftLint on the CI to prevent any new warnings getting merged in the future.

## Related PRs
https://github.com/corona-warn-app/cwa-app-ios/pull/516, https://github.com/corona-warn-app/cwa-app-ios/pull/522, https://github.com/corona-warn-app/cwa-app-ios/pull/527, https://github.com/corona-warn-app/cwa-app-ios/pull/531, https://github.com/corona-warn-app/cwa-app-ios/pull/534.

_Note that all these PRs are completely independent and **can be merged in any order**._