### PR TITLE
[Lint] Reintroduce rule identifier_name & fix warnings

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -196,7 +196,6 @@ opt_in_rules:
 # Disable rules which are in the default set
 disabled_rules:
   - type_name
-  - identifier_name
   - redundant_string_enum_value # disabled because it conflicts with explicit_enum_raw_value
 
 # Included paths (disables --path option)
@@ -214,6 +213,15 @@ reporter: "xcode"
 
 
 ### Rule specific configuration
+
+identifier_name:
+  max_length: 60
+  excluded:
+    - db
+    - id
+    - ok
+    - on
+    - to
 
 line_length:
   warning: 500

--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -200,7 +200,9 @@ disabled_rules:
 
 # Included paths (disables --path option)
 included:
-  - ENA
+  - ENA/Source
+  - ENATests
+  - ENAUITests
 
 # Excluded paths (takes precedence over 'included')
 excluded: # paths to ignore during linting. Takes precedence over `included`.

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
@@ -61,13 +61,13 @@ final class DMDeveloperMenu {
 
 	@objc
 	func showDeveloperMenu(_: UITapGestureRecognizer) {
-		let vc = DMViewController(
+		let viewCtrl = DMViewController(
 			client: client,
 			store: store,
 			exposureManager: exposureManager
 		)
 		let navigationController = UINavigationController(
-			rootViewController: vc
+			rootViewController: viewCtrl
 		)
 		presentingViewController.present(
 			navigationController,

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
@@ -166,7 +166,7 @@ final class DMViewController: UITableViewController {
 	// For now we simply submit automatically.
 	@objc
 	private func generateTestKeys() {
-		exposureManager.getTestDiagnosisKeys { [weak self] keys, error in
+		exposureManager.getTestDiagnosisKeys { [weak self] keysOptional, error in
 			guard let self = self else {
 				return
 			}
@@ -174,17 +174,17 @@ final class DMViewController: UITableViewController {
 				logError(message: "Failed to generate test keys due to: \(error)")
 				return
 			}
-			let _keys = keys ?? []
+			let keys = keysOptional ?? []
 			// The tan is hardcoded and should work on int. It you get a HTTP 403 response
 			// it may be required to change the tan to something else.
 			self.client.submit(
-				keys: _keys,
+				keys: keys,
 				tan: "235b56ff-fd57-465a-8203-31456e58f06f"
 			) { submitError in
 				print("submitError: \(submitError?.localizedDescription ?? "")")
 				return
 			}
-			log(message: "Got diagnosis keys: \(_keys)", level: .info)
+			log(message: "Got diagnosis keys: \(keys)", level: .info)
 			self.resetAndFetchKeys()
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Models/Converting Keys/__tests__/ConvertingKeysTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Converting Keys/__tests__/ConvertingKeysTests.swift
@@ -36,6 +36,7 @@ final class ConvertingKeysTests: XCTestCase {
 	}
 }
 
+// swiftlint:disable identifier_name
 private final class TemporaryExposureKeyMock: ENTemporaryExposureKey {
 	init(
 		keyData: Data,

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -193,7 +193,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 			fatalError("It should not happen.")
 		}
 
-		let vc = AppStoryboard.home.initiate(viewControllerType: HomeViewController.self) { [unowned self] coder in
+		let viewCtrl = AppStoryboard.home.initiate(viewControllerType: HomeViewController.self) { [unowned self] coder in
 			HomeViewController(
 				coder: coder,
 				delegate: self,
@@ -204,12 +204,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 			)
 		}
 
-		homeController = vc // strong ref needed
+		homeController = viewCtrl // strong ref needed
 		UIView.transition(with: navigationController.view, duration: CATransaction.animationDuration(), options: [.transitionCrossDissolve], animations: {
-			self.navigationController.setViewControllers([vc], animated: false)
+			self.navigationController.setViewControllers([viewCtrl], animated: false)
 		})
 		#if !RELEASE
-		enableDeveloperMenuIfAllowed(in: vc)
+		enableDeveloperMenuIfAllowed(in: viewCtrl)
 		#endif
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
@@ -108,15 +108,15 @@ class ExposureSubmissionNavigationController: UINavigationController, UINavigati
 
 		// We got a test result and can jump straight into the test result view controller.
 		if let service = exposureSubmissionService, testResult != nil, service.hasRegistrationToken() {
-			let vc = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionTestResultViewController.self)
-			vc.exposureSubmissionService = service
-			vc.testResult = testResult
-			return vc
+			let viewCtrl = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionTestResultViewController.self)
+			viewCtrl.exposureSubmissionService = service
+			viewCtrl.testResult = testResult
+			return viewCtrl
 		}
 
 		// By default, we show the intro view.
-		let vc = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionIntroViewController.self)
-		return vc
+		let viewCtrl = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionIntroViewController.self)
+		return viewCtrl
 	}
 
 	override func viewDidLoad() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -67,17 +67,17 @@ class ExposureSubmissionOverviewViewController: DynamicTableViewController, Spin
 		let destination = segue.destination
 		switch Segue(segue) {
 		case .tanInput:
-			let vc = destination as? ExposureSubmissionTanInputViewController
-			vc?.initialTan = sender as? String
-			vc?.exposureSubmissionService = service
+			let viewCtrl = destination as? ExposureSubmissionTanInputViewController
+			viewCtrl?.initialTan = sender as? String
+			viewCtrl?.exposureSubmissionService = service
 		case .qrScanner:
-			let vc = destination as? ExposureSubmissionQRScannerNavigationController
-			vc?.scannerViewController?.delegate = self
-			vc?.exposureSubmissionService = service
+			let viewCtrl = destination as? ExposureSubmissionQRScannerNavigationController
+			viewCtrl?.scannerViewController?.delegate = self
+			viewCtrl?.exposureSubmissionService = service
 		case .labResult:
-			let vc = destination as? ExposureSubmissionTestResultViewController
-			vc?.exposureSubmissionService = service
-			vc?.testResult = sender as? TestResult
+			let viewCtrl = destination as? ExposureSubmissionTestResultViewController
+			viewCtrl?.exposureSubmissionService = service
+			viewCtrl?.testResult = sender as? TestResult
 		default:
 			break
 		}
@@ -159,25 +159,25 @@ extension ExposureSubmissionOverviewViewController: ExposureSubmissionQRScannerD
 		}
 	}
 
-	func qrScanner(_ vc: QRScannerViewController, didScan code: String) {
+	func qrScanner(_ viewCtrl: QRScannerViewController, didScan code: String) {
 		guard let guid = sanitizeAndExtractGuid(code) else {
-			vc.delegate = nil
+			viewCtrl.delegate = nil
 			let alert = ExposureSubmissionViewUtils.setupAlert(
 				title: AppStrings.ExposureSubmissionQRScanner.alertCodeNotFoundTitle,
 				message: AppStrings.ExposureSubmissionQRScanner.alertCodeNotFoundText,
 				okTitle: AppStrings.Common.alertActionCancel,
 				retry: true,
 				action: {
-					self.dismissQRCodeScannerView(vc, completion: nil)
+					self.dismissQRCodeScannerView(viewCtrl, completion: nil)
 				},
-				retryActionHandler: { vc.delegate = self }
+				retryActionHandler: { viewCtrl.delegate = self }
 			)
-			vc.present(alert, animated: true, completion: nil)
+			viewCtrl.present(alert, animated: true, completion: nil)
 			return
 		}
 
 		// Found QR Code, deactivate scanning.
-		dismissQRCodeScannerView(vc, completion: {
+		dismissQRCodeScannerView(viewCtrl, completion: {
 			self.startSpinner()
 			self.getRegistrationToken(forKey: .guid(guid))
 		})
@@ -232,9 +232,9 @@ extension ExposureSubmissionOverviewViewController: ExposureSubmissionQRScannerD
 		return candidate
 	}
 
-	private func dismissQRCodeScannerView(_ vc: QRScannerViewController, completion: (() -> Void)?) {
-		vc.delegate = nil
-		vc.dismiss(animated: true, completion: completion)
+	private func dismissQRCodeScannerView(_ viewCtrl: QRScannerViewController, completion: (() -> Void)?) {
+		viewCtrl.delegate = nil
+		viewCtrl.dismiss(animated: true, completion: completion)
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionTanInputViewController.swift
@@ -48,9 +48,9 @@ class ExposureSubmissionTanInputViewController: UIViewController, SpinnerInjecta
 
 	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 		if segue.identifier == Segue.labResultsSegue.rawValue,
-			let vc = segue.destination as? ExposureSubmissionTestResultViewController {
-			vc.exposureSubmissionService = exposureSubmissionService
-			vc.testResult = .positive
+			let viewCtrl = segue.destination as? ExposureSubmissionTestResultViewController {
+			viewCtrl.exposureSubmissionService = exposureSubmissionService
+			viewCtrl.testResult = .positive
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionHotlineViewControllerTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionHotlineViewControllerTest.swift
@@ -23,11 +23,11 @@ import XCTest
 class ExposureSubmissionHotlineViewControllerTest: XCTestCase {
 
 	func testSetupView() {
-		let vc = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionHotlineViewController.self)
-		_ = vc.view
-		XCTAssertNotNil(vc.tableView)
-		XCTAssertEqual(vc.tableView.numberOfSections, 2)
-		XCTAssertEqual(vc.tableView(vc.tableView, numberOfRowsInSection: 1), 5)
+		let viewCtrl = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionHotlineViewController.self)
+		_ = viewCtrl.view
+		XCTAssertNotNil(viewCtrl.tableView)
+		XCTAssertEqual(viewCtrl.tableView.numberOfSections, 2)
+		XCTAssertEqual(viewCtrl.tableView(viewCtrl.tableView, numberOfRowsInSection: 1), 5)
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionNavigationControllerTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionNavigationControllerTest.swift
@@ -34,58 +34,58 @@ class ExposureSubmissionNavigationControllerTest: XCTestCase {
 	}
 
 	func testSetupSecondaryButton() {
-		let vc = createVC()
-		_ = vc.view
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
 		let title = "Second Button Test"
-		vc.setSecondaryButtonTitle(title: title)
-		vc.showSecondaryButton()
+		viewCtrl.setSecondaryButtonTitle(title: title)
+		viewCtrl.showSecondaryButton()
 
-		XCTAssert(!vc.secondaryButton.isHidden)
-		XCTAssertEqual(vc.secondaryButton.currentTitle, title)
-		XCTAssertEqual(vc.secondaryButton.state, UIButton.State.normal)
+		XCTAssert(!viewCtrl.secondaryButton.isHidden)
+		XCTAssertEqual(viewCtrl.secondaryButton.currentTitle, title)
+		XCTAssertEqual(viewCtrl.secondaryButton.state, UIButton.State.normal)
 	}
 
 	func testHideSecondaryButton() {
-		let vc = createVC()
-		_ = vc.view
-		vc.showSecondaryButton()
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
+		viewCtrl.showSecondaryButton()
 
-		XCTAssert(!vc.secondaryButton.isHidden)
-		vc.hideSecondaryButton()
-		XCTAssert(vc.secondaryButton.isHidden)
+		XCTAssert(!viewCtrl.secondaryButton.isHidden)
+		viewCtrl.hideSecondaryButton()
+		XCTAssert(viewCtrl.secondaryButton.isHidden)
 	}
 
 	func testSecondaryButtonAction() {
-		let vc = createVC()
-		_ = vc.view
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
 
 		let child = MockExposureSubmissionNavigationControllerChild()
 		let expectation = self.expectation(description: "Button action executed.")
 		child.didTapSecondButtonCallback = { expectation.fulfill() }
 
-		vc.pushViewController(child, animated: false)
-		vc.secondaryButton.sendActions(for: .touchUpInside)
+		viewCtrl.pushViewController(child, animated: false)
+		viewCtrl.secondaryButton.sendActions(for: .touchUpInside)
 
 		waitForExpectations(timeout: .short)
 	}
 
 	func testButtonAction() {
-		let vc = createVC()
-		_ = vc.view
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
 
 		let child = MockExposureSubmissionNavigationControllerChild()
 		let expectation = self.expectation(description: "Button action executed.")
 		child.didTapButtonCallback = { expectation.fulfill() }
 
-		vc.pushViewController(child, animated: false)
-		vc.button.sendActions(for: .touchUpInside)
+		viewCtrl.pushViewController(child, animated: false)
+		viewCtrl.button.sendActions(for: .touchUpInside)
 
 		waitForExpectations(timeout: .short)
 	}
 
 	func testExposureSubmissionService() {
-		let vc = createVC()
-		XCTAssertNotNil(vc.getExposureSubmissionService())
+		let viewCtrl = createVC()
+		XCTAssertNotNil(viewCtrl.getExposureSubmissionService())
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionOverviewViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionOverviewViewControllerTests.swift
@@ -38,8 +38,8 @@ class ExposureSubmissionOverviewViewControllerTests: XCTestCase {
 	}
 
 	func testQRCodeScanSuccess() {
-		let vc = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionOverviewViewController.self)
-		vc.service = service
+		let viewCtrl = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionOverviewViewController.self)
+		viewCtrl.service = service
 
 		let expectation = self.expectation(description: "Call getRegistration service method.")
 		service.getRegistrationTokenCallback = { deviceRegistrationKey, completion in
@@ -50,44 +50,44 @@ class ExposureSubmissionOverviewViewControllerTests: XCTestCase {
 		qrScannerViewController.dismissCallback = { _, callback in callback?() }
 
 		let scanResult = "https://example.org/?50C707FB-2DC4-4252-9C21-7B0DF0F30ED5"
-		vc.qrScanner(qrScannerViewController, didScan: scanResult)
+		viewCtrl.qrScanner(qrScannerViewController, didScan: scanResult)
 		waitForExpectations(timeout: .short)
 	}
 
 	func testQRCodeSanitization() {
-		let vc = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionOverviewViewController.self)
+		let viewCtrl = AppStoryboard.exposureSubmission.initiate(viewControllerType: ExposureSubmissionOverviewViewController.self)
 
 		// Empty.
-		var result = vc.sanitizeAndExtractGuid("")
+		var result = viewCtrl.sanitizeAndExtractGuid("")
 		XCTAssertNil(result)
 
 		// Input Length exceeded.
-		result = vc.sanitizeAndExtractGuid(String(repeating: "x", count: 150))
+		result = viewCtrl.sanitizeAndExtractGuid(String(repeating: "x", count: 150))
 		XCTAssertNil(result)
 
 		// Missing ?.
 		let guid = "61d4e0f7-a910-4b82-8b9b-39fdc76837a0"
-		result = vc.sanitizeAndExtractGuid("https://abc.com/\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("https://abc.com/\(guid)")
 		XCTAssertNil(result)
 
 		// Additional space after ?
-		result = vc.sanitizeAndExtractGuid("? \(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("? \(guid)")
 		XCTAssertNil(result)
 
 		// GUID Length exceeded.
-		result = vc.sanitizeAndExtractGuid("https://abc.com/\(guid)\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("https://abc.com/\(guid)\(guid)")
 		XCTAssertNil(result)
 
 		// Success.
-		result = vc.sanitizeAndExtractGuid("https://abc.com?\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("https://abc.com?\(guid)")
 		XCTAssertEqual(result, guid)
-		result = vc.sanitizeAndExtractGuid("?\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("?\(guid)")
 		XCTAssertEqual(result, guid)
-		result = vc.sanitizeAndExtractGuid(" ?\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid(" ?\(guid)")
 		XCTAssertEqual(result, guid)
-		result = vc.sanitizeAndExtractGuid("some-string?\(guid)")
+		result = viewCtrl.sanitizeAndExtractGuid("some-string?\(guid)")
 		XCTAssertEqual(result, guid)
-		result = vc.sanitizeAndExtractGuid("https://abc.com?\(guid.uppercased())")
+		result = viewCtrl.sanitizeAndExtractGuid("https://abc.com?\(guid.uppercased())")
 		XCTAssertEqual(result, guid.uppercased())
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionSuccessViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionSuccessViewControllerTests.swift
@@ -34,12 +34,12 @@ class ExposureSubmissionSuccessViewControllerTests: XCTestCase {
 	}
 
 	func testViewLoading() {
-		let vc = createVC()
-		_ = vc.view
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
 
-		XCTAssertEqual(vc.navigationItem.title, AppStrings.ExposureSubmissionSuccess.title)
-		XCTAssertTrue(vc.navigationItem.hidesBackButton)
-		XCTAssertEqual(vc.tableView.numberOfSections, 1)
-		XCTAssertEqual(vc.tableView.numberOfRows(inSection: 0), 9)
+		XCTAssertEqual(viewCtrl.navigationItem.title, AppStrings.ExposureSubmissionSuccess.title)
+		XCTAssertTrue(viewCtrl.navigationItem.hidesBackButton)
+		XCTAssertEqual(viewCtrl.tableView.numberOfSections, 1)
+		XCTAssertEqual(viewCtrl.tableView.numberOfRows(inSection: 0), 9)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTanInputViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTanInputViewControllerTests.swift
@@ -34,9 +34,9 @@ class ExposureSubmissionTanInputViewControllerTests: XCTestCase {
 	}
 
 	func testTanInputSuccess() {
-		let vc = createVC()
-		_ = vc.view
-		vc.exposureSubmissionService = service
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
+		viewCtrl.exposureSubmissionService = service
 
 		let expectation = self.expectation(description: "Call getRegistration service method.")
 		service.getRegistrationTokenCallback = { deviceRegistrationKey, completion in
@@ -44,9 +44,9 @@ class ExposureSubmissionTanInputViewControllerTests: XCTestCase {
 			completion(.success(""))
 		}
 
-		vc.tanInput.insertText("234567893D")
-		if vc.tanInput.isEnabled {
-			vc.didTapButton()
+		viewCtrl.tanInput.insertText("234567893D")
+		if viewCtrl.tanInput.isEnabled {
+			viewCtrl.didTapButton()
 		}
 		
 		waitForExpectations(timeout: .short)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTestResultViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTestResultViewControllerTests.swift
@@ -28,15 +28,15 @@ class ExposureSubmissionViewControllerTests: XCTestCase {
 	}
 
 	func testPositiveState() {
-		let vc = createVC()
-		vc.testResult = .positive
-		_ = vc.view
-		XCTAssertEqual(vc.dynamicTableViewModel.numberOfSection, 1)
+		let viewCtrl = createVC()
+		viewCtrl.testResult = .positive
+		_ = viewCtrl.view
+		XCTAssertEqual(viewCtrl.dynamicTableViewModel.numberOfSection, 1)
 
-		let header = vc.tableView(vc.tableView, viewForHeaderInSection: 0) as? ExposureSubmissionTestResultHeaderView
+		let header = viewCtrl.tableView(viewCtrl.tableView, viewForHeaderInSection: 0) as? ExposureSubmissionTestResultHeaderView
 		XCTAssertNotNil(header)
 
-		let cell = vc.tableView(vc.tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? DynamicTypeTableViewCell
+		let cell = viewCtrl.tableView(viewCtrl.tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as? DynamicTypeTableViewCell
 		XCTAssertNotNil(cell)
 		XCTAssertEqual(cell?.textLabel?.text, AppStrings.ExposureSubmissionResult.procedure)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionWarnOthersViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionWarnOthersViewControllerTests.swift
@@ -37,9 +37,9 @@ class ExposureSubmissionWarnOthersViewControllerTests: XCTestCase {
 	}
 
 	func testSuccessfulSubmit() {
-		let vc = createVC()
-		_ = vc.view
-		vc.exposureSubmissionService = service
+		let viewCtrl = createVC()
+		_ = viewCtrl.view
+		viewCtrl.exposureSubmissionService = service
 
 		let expectTANSubmission = self.expectation(description: "Call getTANForExposureSubmit")
 		let exampleTAN = "asdf123456"
@@ -63,7 +63,7 @@ class ExposureSubmissionWarnOthersViewControllerTests: XCTestCase {
 		}
 
 		// Trigger submission process.
-		vc.didTapButton()
+		viewCtrl.didTapButton()
 		waitForExpectations(timeout: .short)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionQRScannerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionQRScannerViewController.swift
@@ -35,7 +35,7 @@ class MockExposureSubmissionQRScannerViewController: QRScannerViewController {
 		dismissCallback?(animated, completion)
 	}
 
-	func present(_ vc: UIViewController, animated: Bool, completion: (() -> Void)?) {
-		presentCallback?(vc, animated, completion)
+	func present(_ viewCtrl: UIViewController, animated: Bool, completion: (() -> Void)?) {
+		presentCallback?(viewCtrl, animated, completion)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -168,7 +168,7 @@ final class HomeViewController: UIViewController {
 
 	func showExposureNotificationSetting() {
 		let storyboard = AppStoryboard.exposureNotificationSetting.instance
-		let vc = storyboard.instantiateViewController(identifier: "ExposureNotificationSettingViewController") { coder in
+		let viewCtrl = storyboard.instantiateViewController(identifier: "ExposureNotificationSettingViewController") { coder in
 			ExposureNotificationSettingViewController(
 					coder: coder,
 					initialEnState: self.homeInteractor.state.enState,
@@ -176,14 +176,14 @@ final class HomeViewController: UIViewController {
 					delegate: self
 			)
 		}
-		addToUpdatingSetIfNeeded(vc)
-		notificationSettingsController = vc
-		navigationController?.pushViewController(vc, animated: true)
+		addToUpdatingSetIfNeeded(viewCtrl)
+		notificationSettingsController = viewCtrl
+		navigationController?.pushViewController(viewCtrl, animated: true)
 	}
 
 	func showSetting() {
 		let storyboard = AppStoryboard.settings.instance
-		let vc = storyboard.instantiateViewController(identifier: "SettingsViewController") { coder in
+		let viewCtrl = storyboard.instantiateViewController(identifier: "SettingsViewController") { coder in
 			SettingsViewController(
 				coder: coder,
 				store: self.homeInteractor.store,
@@ -191,9 +191,9 @@ final class HomeViewController: UIViewController {
 				delegate: self
 			)
 		}
-		addToUpdatingSetIfNeeded(vc)
-		settingsController = vc
-		navigationController?.pushViewController(vc, animated: true)
+		addToUpdatingSetIfNeeded(viewCtrl)
+		settingsController = viewCtrl
+		navigationController?.pushViewController(viewCtrl, animated: true)
 	}
 
 	func showExposureDetection() {
@@ -203,16 +203,16 @@ final class HomeViewController: UIViewController {
 			isLoading: homeInteractor.isRequestRiskRunning,
 			risk: homeInteractor.state.risk
 		)
-		let vc = AppStoryboard.exposureDetection.initiateInitial { coder in
+		let viewCtrl = AppStoryboard.exposureDetection.initiateInitial { coder in
 			ExposureDetectionViewController(
 				coder: coder,
 				state: state,
 				delegate: self
 			)
 		}
-//		addToUpdatingSetIfNeeded(vc)
-		exposureDetectionController = vc as? ExposureDetectionViewController
-		present(vc, animated: true)
+//		addToUpdatingSetIfNeeded(viewCtrl)
+		exposureDetectionController = viewCtrl as? ExposureDetectionViewController
+		present(viewCtrl, animated: true)
 	}
 
 	func showAppInformation() {

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -81,21 +81,21 @@ final class SettingsViewController: UITableViewController {
 	}
 
 	override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
-		if segue.identifier == resetSegue, let nc = segue.destination as? UINavigationController, let vc = nc.topViewController as? ResetViewController {
-			vc.delegate = self
+		if segue.identifier == resetSegue, let navCtrl = segue.destination as? UINavigationController, let viewCtrl = navCtrl.topViewController as? ResetViewController {
+			viewCtrl.delegate = self
 		}
 	}
 
 	@IBSegueAction
 	func createExposureNotificationSettingViewController(coder: NSCoder) -> ExposureNotificationSettingViewController? {
-		let vc = ExposureNotificationSettingViewController(
+		let navCtrl = ExposureNotificationSettingViewController(
 				coder: coder,
 				initialEnState: enState,
 				store: store,
 				delegate: self
 		)
-		notificationSettingsController = vc
-		return vc
+		notificationSettingsController = navCtrl
+		return navCtrl
 	}
 
 	@IBSegueAction

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/AppleFilesWriterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/AppleFilesWriterTests.swift
@@ -23,10 +23,10 @@ import XCTest
 final class AppleFilesWriterTests: XCTestCase {
 
 	private class func createRootDir() throws -> URL {
-		let fm = FileManager()
-		let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let fileManager = FileManager()
+		let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
 
-		try fm.createDirectory(
+		try fileManager.createDirectory(
 			atPath: tempDir.path,
 			withIntermediateDirectories: true,
 			attributes: nil

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
@@ -213,11 +213,11 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 			}
 			
 			let startIndex = 0
-			for i in startIndex...keys.count - 1 {
-				if i + 1 <= transmissionRiskDefaultVector.count - 1 {
-					keys[i].transmissionRiskLevel = UInt8(transmissionRiskDefaultVector[i + 1])
+			for index in startIndex...keys.count - 1 {
+				if index + 1 <= transmissionRiskDefaultVector.count - 1 {
+					keys[index].transmissionRiskLevel = UInt8(transmissionRiskDefaultVector[index + 1])
 				} else {
-					keys[i].transmissionRiskLevel = UInt8(1)
+					keys[index].transmissionRiskLevel = UInt8(1)
 				}
 			}
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/__tests__/RiskCalculationTests.swift
@@ -513,6 +513,7 @@ private extension RiskCalculationTests {
 		}
 	}
 
+	// swiftlint:disable identifier_name
 	private func makeExposureSummaryContainer(
 		maxRiskScoreFullRange: Int,
 		ad_low: Double,
@@ -565,6 +566,7 @@ private extension RiskCalculationTests {
 
 		return config
 	}
+	// swiftlint:enable identifier_name
 }
 
 private extension TimeInterval {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -168,10 +168,10 @@ extension RiskProvider: RiskProviding {
 			group.leave()
 		}
 
-		var appConfiguration: SAP_ApplicationConfiguration?
+		var appConfigurationOptional: SAP_ApplicationConfiguration?
 		group.enter()
 		appConfigurationProvider.appConfiguration { configuration in
-			appConfiguration = configuration
+			appConfigurationOptional = configuration
 			group.leave()
 		}
 
@@ -186,7 +186,7 @@ extension RiskProvider: RiskProviding {
 			return
 		}
 
-		guard let _appConfiguration = appConfiguration else {
+		guard let appConfiguration = appConfigurationOptional else {
 			completeOnTargetQueue(risk: nil)
 			return
 		}
@@ -197,7 +197,7 @@ extension RiskProvider: RiskProviding {
 		guard
 			let risk = RiskCalculation.risk(
 				summary: summaries?.current?.summary,
-				configuration: _appConfiguration,
+				configuration: appConfiguration,
 				dateLastExposureDetection: summaries?.current?.date,
 				numberOfTracingActiveHours: numberOfEnabledHours,
 				preconditions: exposureManagerState,

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStoryboard.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStoryboard.swift
@@ -35,21 +35,21 @@ enum AppStoryboard: String {
 	func initiate<T: UIViewController>(viewControllerType: T.Type, creator: ((NSCoder) -> UIViewController?)? = nil) -> T {
 		let storyboard = UIStoryboard(name: rawValue, bundle: nil)
 		let viewControllerIdentifier = viewControllerType.stringName()
-		guard let vc = storyboard.instantiateViewController(identifier: viewControllerIdentifier, creator: creator) as? T else {
+		guard let viewCtrl = storyboard.instantiateViewController(identifier: viewControllerIdentifier, creator: creator) as? T else {
 			let error = "Can't initiate \(viewControllerIdentifier) for \(rawValue) storyboard"
 			logError(message: error)
 			fatalError(error)
 		}
-		return vc
+		return viewCtrl
 	}
 
 	func initiateInitial<T: UIViewController>(creator: ((NSCoder) -> UIViewController?)? = nil) -> T {
 		let storyboard = UIStoryboard(name: rawValue, bundle: nil)
-		guard let vc = storyboard.instantiateInitialViewController(creator: creator) as? T else {
+		guard let viewCtrl = storyboard.instantiateInitialViewController(creator: creator) as? T else {
 			let error = "Can't initiate start UIViewController for \(rawValue) storyboard"
 			logError(message: error)
 			fatalError(error)
 		}
-		return vc
+		return viewCtrl
 	}
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -17,7 +17,7 @@
 
 import UIKit
 
-// swiftlint:disable:next type_body_length
+// swiftlint:disable type_body_length identifier_name
 enum AppStrings {
 	enum Common {
 		static let alertTitleGeneral = NSLocalizedString("Alert_TitleGeneral", comment: "")

--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
@@ -388,7 +388,7 @@ private extension ENATanInput {
 		switch hash.first?.uppercased() {
 		case "0": return "G"
 		case "1": return "H"
-		case .some(let c): return Character(c)
+		case .some(let char): return Character(char)
 		default: return nil
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
@@ -66,9 +66,9 @@ extension Array where Element == TracingStatusEntry {
 
 		// Iterate from end of array until we find a date older than threshold
 		var firstStaleIndex: Int?
-		for (i, element) in enumerated().reversed() {
+		for (index, element) in enumerated().reversed() {
 			if now.timeIntervalSince(element.date) > threshold {
-				firstStaleIndex = i
+				firstStaleIndex = index
 				break
 			}
 		}

--- a/src/xcode/ENA/ENA/Source/Workers/Update Checker/AppUpdateCheckHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Update Checker/AppUpdateCheckHelper.swift
@@ -44,7 +44,7 @@ final class AppUpdateCheckHelper {
 		removeObserver()
 	}
 
-	func checkAppVersionDialog(for vc: UIViewController?) {
+	func checkAppVersionDialog(for viewCtrl: UIViewController?) {
 		client.appConfiguration { result in
 			guard let versionInfo: SAP_ApplicationVersionConfiguration = result?.appVersion else {
 				return
@@ -59,19 +59,19 @@ final class AppUpdateCheckHelper {
 				latestVersion: versionInfo.ios.latest
 			)
 
-			guard let alert = self.createAlert(alertType, vc: vc) else { return }
-			vc?.present(alert, animated: true, completion: nil)
+			guard let alert = self.createAlert(alertType, viewCtrl: viewCtrl) else { return }
+			viewCtrl?.present(alert, animated: true, completion: nil)
 		}
 	}
 
-	private func setObserver(vc: UIViewController?, alertType: UpdateAlertType) {
+	private func setObserver(viewCtrl: UIViewController?, alertType: UpdateAlertType) {
 		guard self.applicationDidBecomeActiveObserver == nil else { return }
 		self.applicationDidBecomeActiveObserver = NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
 			guard let self = self else { return }
-			guard let alert = self.createAlert(alertType, vc: vc) else {
+			guard let alert = self.createAlert(alertType, viewCtrl: viewCtrl) else {
 				return
 			}
-			vc?.present(alert, animated: true, completion: nil)
+			viewCtrl?.present(alert, animated: true, completion: nil)
 		}
 	}
 
@@ -80,7 +80,7 @@ final class AppUpdateCheckHelper {
 		applicationDidBecomeActiveObserver = nil
 	}
 
-	func createAlert(_ type: UpdateAlertType, vc: UIViewController?) -> UIAlertController? {
+	func createAlert(_ type: UpdateAlertType, viewCtrl: UIViewController?) -> UIAlertController? {
 		let alert = UIAlertController(title: AppStrings.UpdateMessage.title, message: AppStrings.UpdateMessage.text, preferredStyle: .alert)
 		alert.addAction(UIAlertAction(title: NSLocalizedString(AppStrings.UpdateMessage.actionUpdate, comment: ""), style: .cancel, handler: { _ in
 			guard let url: URL = URL(string: "itms-apps://itunes.apple.com/app/apple-store/") else {
@@ -95,7 +95,7 @@ final class AppUpdateCheckHelper {
 			}))
 		case .forceUpdate:
 			alert.message = AppStrings.UpdateMessage.textForce
-			self.setObserver(vc: vc, alertType: type)
+			self.setObserver(viewCtrl: viewCtrl, alertType: type)
 		case .none:
 			return nil
 		}

--- a/src/xcode/ENA/ENA/Source/Workers/Update Checker/__tests__/AppUpdateCheckerHelperTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Update Checker/__tests__/AppUpdateCheckerHelperTests.swift
@@ -82,18 +82,18 @@ final class AppUpdateCheckerHelperTests: XCTestCase {
 	}
 
 	func testAlert_none() {
-		let alert = sut.createAlert(.none, vc: nil)
+		let alert = sut.createAlert(.none, viewCtrl: nil)
 		XCTAssertNil(alert)
 	}
 
 	func testAlert_update() {
-		let alert = sut.createAlert(.update, vc: nil)
+		let alert = sut.createAlert(.update, viewCtrl: nil)
 		XCTAssertNotNil(alert)
 		XCTAssertEqual(alert?.actions.count, 2)
 	}
 
 	func testAlert_forceUpdate() {
-		let alert = sut.createAlert(.forceUpdate, vc: nil)
+		let alert = sut.createAlert(.forceUpdate, viewCtrl: nil)
 		XCTAssertNotNil(alert)
 		XCTAssertEqual(alert?.actions.count, 1)
 	}

--- a/src/xcode/ENA/ENA/Source/Workers/WebPageHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/WebPageHelper.swift
@@ -27,9 +27,9 @@ enum WebPageHelper {
 			config.entersReaderIfAvailable = true
 			config.barCollapsingEnabled = true
 
-			let vc = SFSafariViewController(url: url, configuration: config)
-			vc.preferredControlTintColor = .enaColor(for: .tint)
-			viewController.present(vc, animated: true)
+			let viewCtrl = SFSafariViewController(url: url, configuration: config)
+			viewCtrl.preferredControlTintColor = .enaColor(for: .tint)
+			viewController.present(viewCtrl, animated: true)
 		} else {
 			let error = "\(AppStrings.SafariView.targetURL) is no valid URL"
 			logError(message: error)
@@ -42,9 +42,9 @@ enum WebPageHelper {
 		config.entersReaderIfAvailable = true
 		config.barCollapsingEnabled = true
 
-		let vc = SFSafariViewController(url: url, configuration: config)
-		vc.preferredControlTintColor = .enaColor(for: .tint)
+		let viewCtrl = SFSafariViewController(url: url, configuration: config)
+		viewCtrl.preferredControlTintColor = .enaColor(for: .tint)
 
-		viewController.present(vc, animated: true)
+		viewController.present(viewCtrl, animated: true)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
@@ -147,15 +147,15 @@ final class SQLiteKeyValueStoreTests: XCTestCase {
 	}
 
 	func testThreadSafety() {
-		for i in 0...1000 {
+		for index in 0...1000 {
 			group.enter()
 
 			DispatchQueue.global().async {
 				let sleepVal = UInt32.random(in: 0...1000)
 				usleep(sleepVal)
-				self.kvStore["key\(i)"] = Data("value\(i)".utf8)
-				if i.isMultiple(of: 2) {
-					self.kvStore["key\(i)"] = nil
+				self.kvStore["key\(index)"] = Data("value\(index)".utf8)
+				if index.isMultiple(of: 2) {
+					self.kvStore["key\(index)"] = nil
 				}
 				self.group.leave()
 			}
@@ -163,11 +163,11 @@ final class SQLiteKeyValueStoreTests: XCTestCase {
 
 		let result = group.wait(timeout: .now() + 15)
 		XCTAssert(result == .success)
-		for j in 0...1000 {
-			if j.isMultiple(of: 2) {
-				XCTAssertNil(self.kvStore["key\(j)"])
+		for index in 0...1000 {
+			if index.isMultiple(of: 2) {
+				XCTAssertNil(self.kvStore["key\(index)"])
 			} else {
-				XCTAssertEqual(self.kvStore["key\(j)"], Data("value\(j)".utf8))
+				XCTAssertEqual(self.kvStore["key\(index)"], Data("value\(index)".utf8))
 			}
 		}
 	}

--- a/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
@@ -17,6 +17,7 @@
 
 import XCTest
 
+// swiftlint:disable identifier_name
 enum SizeCategory: String {
 	case XS
 	case S
@@ -26,6 +27,7 @@ enum SizeCategory: String {
 	case XXL
 	case XXXL
 }
+// swiftlint:enable identifier_name
 
 enum SizeCategoryAccessibility: String {
 	case accessibility = "Accessibility"

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -43,8 +43,8 @@ platform :ios do
 
     swiftlint(
       mode: :lint,
+      path: "ENA",
       output_file: "swiftlint.result.json",
-      config_file: "ENA/.swiftlint.yml",
       raise_if_swiftlint_error: true,
       reporter: "sonarqube"
     )


### PR DESCRIPTION
## Description
This is the third follow-up smaller PR to https://github.com/corona-warn-app/cwa-app-ios/pull/104. Together with the other PRs I will be posting, all SwiftLint warnings should be fixed to allow us to enable the `--strict` mode of SwiftLint on the CI to prevent any new warnings getting merged in the future.

In this specific PR, I've turned on the `identifier_name` rule which is enabled by default in SwiftLint for a reason (and was turned off for some reason) and the many cases where it was violated show really nicely why the rule is a good rule that should be kept turned on. Many variables were not really speaking and too short, this rule will prevent that in the future.

I've added a few exceptions for the common 2-character English words in development within the configuration (like `id` and `db`) but the many appearances of `vc`, `nc`, `i` and other too short and not very concise names were fixed.

Note also that I fixed variable names where for example `keys` was used for an Optional and `_keys` for the strong typed variable. I used speaking names in such cases like `keysOptional` and `keys`, removing the need for the leading underscore, which is not very Swifty (more Obj-C like).

## Related PRs
https://github.com/corona-warn-app/cwa-app-ios/pull/516, https://github.com/corona-warn-app/cwa-app-ios/pull/518, https://github.com/corona-warn-app/cwa-app-ios/pull/527, https://github.com/corona-warn-app/cwa-app-ios/pull/531, https://github.com/corona-warn-app/cwa-app-ios/pull/534.

_Note that all these PRs are completely independent and **can be merged in any order**._