### PR TITLE
[Bug] Fix ExposureSubmissionImageCardCell accessibility not reading attributed strings

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionImageCardCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionImageCardCell.swift
@@ -77,7 +77,7 @@ class ExposureSubmissionImageCardCell: UITableViewCell {
 			descriptionLabel.attributedText = attributedText
 		}
 
-		cardView.accessibilityLabel = "\(title)\n\n\(description)"
+		cardView.accessibilityLabel = "\(title)\n\n\(description) \(attributedDescription?.string ?? "")"
 		cardView.accessibilityIdentifier = accessibilityIdentifier
 	}
 


### PR DESCRIPTION
This PR fixes ExposureSubmissionImageCardCell accessibility not reading attributed strings.

<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84432701-797d9300-ac2d-11ea-8095-b0a63d4da240.png">
