### PR TITLE
[Lint] Reconfigure rule line_length & fix warnings

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -215,11 +215,7 @@ reporter: "xcode"
 
 ### Rule specific configuration
 
-line_length:
-  warning: 500
-  error: 1000
-  ignores_function_declarations: true
-  ignores_comments: true
+line_length: 160
 
 trailing_whitespace:
   ignores_empty_lines: true

--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -201,7 +201,9 @@ disabled_rules:
 
 # Included paths (disables --path option)
 included:
-  - ENA
+  - ENA/Source
+  - ENATests
+  - ENAUITests
 
 # Excluded paths (takes precedence over 'included')
 excluded: # paths to ignore during linting. Takes precedence over `included`.

--- a/src/xcode/ENA/ENA/Source/Client/Client.swift
+++ b/src/xcode/ENA/ENA/Source/Client/Client.swift
@@ -84,12 +84,12 @@ protocol Client {
 
 	/// Gets the remove exposure configuration. See `ENExposureConfiguration` for more details
 	/// Parameters:
-	/// - completion: Will be called with the remove configuration or an error if something went wrong. The completion handler will always be called on the main thread.
+	/// - completion: Called with the remove configuration or an error if something went wrong. Completion handler will always be called on the main thread.
 	func exposureConfiguration(
 		completion: @escaping ExposureConfigurationCompletionHandler
 	)
 
-	/// Submits exposure keys to the backend. This makes the local information available to the world so that the risk of others can be calculated on their local devices.
+	/// Submits exposure keys to the backend. Makes the local information available to the world so the risk of others can be calculated on their local devices.
 	/// Parameters:
 	/// - keys: An array of `ENTemporaryExposureKey`s  to submit to the backend.
 	/// - tan: A transaction number

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
@@ -49,7 +49,9 @@ final class DMDeveloperMenu {
 
 	/// Enables the developer menu if it is currently allowed to do so.
 	///
-	/// Whether or not the developer menu is allowed is determined at build time by looking at the active build configuration. It is only allowed for `RELEASE` and `DEBUG` builds. Builds that target the app store (configuration `APP_STORE`) are built without support for a developer menu.
+	/// Whether or not the developer menu is allowed is determined at build time by looking at the active build configuration.
+	/// It is only allowed for `RELEASE` and `DEBUG` builds.
+	/// Builds that target the app store (configuration `APP_STORE`) are built without support for a developer menu.
 	func enableIfAllowed() {
 		guard isAllowed() else {
 			return

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
@@ -86,7 +86,7 @@ private extension CIFilter {
 
 	var bigOutputCGImage: CGImage {
 		let extent = existingOutputImage.extent
-		// swiftlint:disable:next force_unwrapping
+
 		return DMQRCodeViewController.context.createCGImage(
 			bigOutputImage,
 			from: CGRect(
@@ -94,6 +94,7 @@ private extension CIFilter {
 				size: CGSize(width: extent.width * scaleFactor, height: extent.height * scaleFactor)
 			)
 		)!
+		// swiftlint:disable:previous force_unwrapping
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
@@ -87,7 +87,13 @@ private extension CIFilter {
 	var bigOutputCGImage: CGImage {
 		let extent = existingOutputImage.extent
 		// swiftlint:disable:next force_unwrapping
-		return DMQRCodeViewController.context.createCGImage(bigOutputImage, from: CGRect(origin: .zero, size: CGSize(width: extent.width * scaleFactor, height: extent.height * scaleFactor)))!
+		return DMQRCodeViewController.context.createCGImage(
+			bigOutputImage,
+			from: CGRect(
+				origin: .zero,
+				size: CGSize(width: extent.width * scaleFactor, height: extent.height * scaleFactor)
+			)
+		)!
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Extensions/UICollectionView/UICollectionView+Dequeue.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UICollectionView/UICollectionView+Dequeue.swift
@@ -35,9 +35,18 @@ extension UICollectionView {
 	///   - reusableViewType: Concreate reusable view type.
 	///   - kind: The kind of reusable view to dequeue.
 	///   - indexPath: IndexPath of the cell.
-	func dequeueReusableSupplementaryView<ReusableView: UICollectionReusableView>(reusableViewType: ReusableView.Type, kind: String, for indexPath: IndexPath) -> ReusableView {
+	func dequeueReusableSupplementaryView<ReusableView: UICollectionReusableView>(
+		reusableViewType: ReusableView.Type,
+		kind: String,
+		for indexPath: IndexPath
+	) -> ReusableView {
 		let identifier = reusableViewType.reusableViewIdentifier
-		guard let view = dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: identifier, for: indexPath) as? ReusableView else { fatalError("\(identifier) isn't registered") }
+		guard let view = dequeueReusableSupplementaryView(
+			ofKind: kind,
+			withReuseIdentifier: identifier,
+			for: indexPath
+		) as? ReusableView else { fatalError("\(identifier) isn't registered") }
+
 		return view
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -355,8 +355,19 @@ extension ENAExposureManager {
 					fatalError("Not all cases of actions covered when handling the bluetooth")
 				}
 			}
-			alert.addAction(UIAlertAction(title: AppStrings.Common.alertActionOpenSettings, style: .default, handler: { action in completionHandler(action, completion) }))
-			alert.addAction(UIAlertAction(title: AppStrings.Common.alertActionLater, style: .cancel, handler: { action in completionHandler(action, completion) }))
+			alert.addAction(
+				UIAlertAction(
+					title: AppStrings.Common.alertActionOpenSettings,
+					style: .default,
+					handler: { action in completionHandler(action, completion) }
+				)
+			)
+			alert.addAction(
+				UIAlertAction(
+					title: AppStrings.Common.alertActionLater,
+					style: .cancel, handler: { action in completionHandler(action, completion) }
+				)
+			)
 			return alert
 		}
 		return nil

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
@@ -66,7 +66,11 @@ extension MockExposureManager: ExposureManager {
 		ExposureManagerState(authorized: true, enabled: true, status: .active)
 	}
 
-	func detectExposures(configuration _: ENExposureConfiguration, diagnosisKeyURLs _: [URL], completionHandler _: @escaping ENDetectExposuresHandler) -> Progress {
+	func detectExposures(
+		configuration _: ENExposureConfiguration,
+		diagnosisKeyURLs _: [URL],
+		completionHandler _: @escaping ENDetectExposuresHandler
+	) -> Progress {
 		Progress()
 	}
 

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/RiskLevel.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/RiskLevel.swift
@@ -53,7 +53,7 @@ enum RiskLevel: Int, CaseIterable {
 }
 
 extension RiskLevel: Comparable {
-	/// - attention: Might not produce valid results when sorting Collections  of RiskLevels, because of the exception case which overrides the normal rawValue compare!
+	/// - attention: Might not produce valid results when sorting Collections of RiskLevels cause of the exception case overriding the normal rawValue compare!
 	static func < (lhs: RiskLevel, rhs: RiskLevel) -> Bool {
 		// Generally we compare the raw values, but there is one exception:
 		// .increased should override .unknownOutdated

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeFindingPositiveRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeFindingPositiveRiskCellConfigurator.swift
@@ -45,15 +45,36 @@ final class HomeFindingPositiveRiskCellConfigurator: HomeRiskCellConfigurator {
 
 		let iconColor: UIColor = .enaColor(for: .riskHigh)
 		let phoneTitle = AppStrings.Home.findingPositivePhoneItemTitle
-		let phoneItem = HomeRiskImageItemViewConfigurator(title: phoneTitle, titleColor: titleColor, iconImageName: "Icons - Hotline", iconTintColor: iconColor, color: .clear, separatorColor: .clear)
+		let phoneItem = HomeRiskImageItemViewConfigurator(
+			title: phoneTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons - Hotline",
+			iconTintColor: iconColor,
+			color: .clear,
+			separatorColor: .clear
+		)
 		phoneItem.containerInsets = .init(top: 10.0, left: 0.0, bottom: 10.0, right: 0)
 
 		let homeTitle = AppStrings.Home.findingPositiveHomeItemTitle
-		let homeItem = HomeRiskImageItemViewConfigurator(title: homeTitle, titleColor: titleColor, iconImageName: "Icons - Home", iconTintColor: iconColor, color: .clear, separatorColor: .clear)
+		let homeItem = HomeRiskImageItemViewConfigurator(
+			title: homeTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons - Home",
+			iconTintColor: iconColor,
+			color: .clear,
+			separatorColor: .clear
+		)
 		homeItem.containerInsets = .init(top: 10.0, left: 0.0, bottom: 10.0, right: 0)
 
 		let shareTitle = AppStrings.Home.findingPositiveShareItemTitle
-		let shareItem = HomeRiskImageItemViewConfigurator(title: shareTitle, titleColor: titleColor, iconImageName: "Icons - Warnen", iconTintColor: iconColor, color: .clear, separatorColor: .clear)
+		let shareItem = HomeRiskImageItemViewConfigurator(
+			title: shareTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons - Warnen",
+			iconTintColor: iconColor,
+			color: .clear,
+			separatorColor: .clear
+		)
 		shareItem.containerInsets = .init(top: 10.0, left: 0.0, bottom: 10.0, right: 0)
 
 		cell.configureNotesRiskViews(cellConfigurators: [phoneItem, homeItem, shareItem])

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeHighRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeHighRiskCellConfigurator.swift
@@ -58,16 +58,43 @@ final class HomeHighRiskCellConfigurator: HomeRiskLevelCellConfigurator {
 		let separatorColor: UIColor = .enaColor(for: .hairlineContrast)
 		var itemCellConfigurators: [HomeRiskViewConfiguratorAny] = []
 		if isLoading {
-			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(title: AppStrings.Home.riskCardStatusCheckBody, titleColor: titleColor, isLoading: true, color: color, separatorColor: separatorColor)
+			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(
+				title: AppStrings.Home.riskCardStatusCheckBody,
+				titleColor: titleColor,
+				isLoading: true,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(isLoadingItem)
 		} else {
 			let numberOfDaysSinceLastExposure = daysSinceLastExposure ?? 0
 			let numberContactsTitle = String(format: AppStrings.Home.riskCardNumberContactsItemTitle, numberRiskContacts)
-			let item1 = HomeRiskImageItemViewConfigurator(title: numberContactsTitle, titleColor: titleColor, iconImageName: "Icons_RisikoBegegnung", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item1 = HomeRiskImageItemViewConfigurator(
+				title: numberContactsTitle,
+				titleColor: titleColor,
+				iconImageName: "Icons_RisikoBegegnung",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			let lastContactTitle = String(format: AppStrings.Home.riskCardLastContactItemTitle, numberOfDaysSinceLastExposure)
-			let item2 = HomeRiskImageItemViewConfigurator(title: lastContactTitle, titleColor: titleColor, iconImageName: "Icons_Calendar", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item2 = HomeRiskImageItemViewConfigurator(
+				title: lastContactTitle,
+				titleColor: titleColor,
+				iconImageName: "Icons_Calendar",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			let dateTitle = String(format: AppStrings.Home.riskCardDateItemTitle, lastUpdateDateString)
-			let item3 = HomeRiskImageItemViewConfigurator(title: dateTitle, titleColor: titleColor, iconImageName: "Icons_Aktualisiert", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item3 = HomeRiskImageItemViewConfigurator(
+				title: dateTitle,
+				titleColor: titleColor,
+				iconImageName: "Icons_Aktualisiert",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(contentsOf: [item1, item2, item3])
 		}
 		cell.configureRiskViews(cellConfigurators: itemCellConfigurators)

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeInactiveRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeInactiveRiskCellConfigurator.swift
@@ -66,11 +66,15 @@ final class HomeInactiveRiskCellConfigurator: HomeRiskCellConfigurator {
 	func configure(cell: RiskInactiveCollectionViewCell) {
 		cell.delegate = self
 
-		let title: String = incativeType == .noCalculationPossible ? AppStrings.Home.riskCardInactiveNoCalculationPossibleTitle : AppStrings.Home.riskCardInactiveOutdatedResultsTitle
+		let title: String = incativeType == .noCalculationPossible ?
+				AppStrings.Home.riskCardInactiveNoCalculationPossibleTitle :
+				AppStrings.Home.riskCardInactiveOutdatedResultsTitle
 		let titleColor: UIColor = .enaColor(for: .textPrimary1)
 		cell.configureTitle(title: title, titleColor: titleColor)
 
-		let bodyText: String = incativeType == .noCalculationPossible ? AppStrings.Home.riskCardInactiveNoCalculationPossibleBody : AppStrings.Home.riskCardInactiveOutdatedResultsBody
+		let bodyText: String = incativeType == .noCalculationPossible ?
+			AppStrings.Home.riskCardInactiveNoCalculationPossibleBody :
+			AppStrings.Home.riskCardInactiveOutdatedResultsBody
 		cell.configureBody(text: bodyText, bodyColor: titleColor)
 
 		let color: UIColor = .enaColor(for: .background)
@@ -89,15 +93,31 @@ final class HomeInactiveRiskCellConfigurator: HomeRiskCellConfigurator {
 
 		let activateItemTitle = String(format: AppStrings.Home.riskCardInactiveActivateItemTitle, previousRiskTitle)
 		let iconTintColor: UIColor = .enaColor(for: .riskNeutral)
-		let item1 = HomeRiskImageItemViewConfigurator(title: activateItemTitle, titleColor: titleColor, iconImageName: "Icons_LetzteErmittlung-Light", iconTintColor: iconTintColor, color: color, separatorColor: separatorColor)
+		let item1 = HomeRiskImageItemViewConfigurator(
+			title: activateItemTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons_LetzteErmittlung-Light",
+			iconTintColor: iconTintColor,
+			color: color,
+			separatorColor: separatorColor
+		)
 		let dateTitle = String(format: AppStrings.Home.riskCardDateItemTitle, lastUpdateDateString)
-		let item2 = HomeRiskImageItemViewConfigurator(title: dateTitle, titleColor: titleColor, iconImageName: "Icons_Aktualisiert", iconTintColor: iconTintColor, color: color, separatorColor: separatorColor)
+		let item2 = HomeRiskImageItemViewConfigurator(
+			title: dateTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons_Aktualisiert",
+			iconTintColor: iconTintColor,
+			color: color,
+			separatorColor: separatorColor
+		)
 		itemCellConfigurators.append(contentsOf: [item1, item2])
 
 		cell.configureRiskViews(cellConfigurators: itemCellConfigurators)
 		cell.configureBackgroundColor(color: color)
 
-		let buttonTitle: String = incativeType == .noCalculationPossible ? AppStrings.Home.riskCardInactiveNoCalculationPossibleButton : AppStrings.Home.riskCardInactiveOutdatedResultsButton
+		let buttonTitle: String = incativeType == .noCalculationPossible ?
+			AppStrings.Home.riskCardInactiveNoCalculationPossibleButton :
+			AppStrings.Home.riskCardInactiveOutdatedResultsButton
 
 		cell.configureActiveButton(title: buttonTitle)
 

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeLowRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeLowRiskCellConfigurator.swift
@@ -62,17 +62,44 @@ final class HomeLowRiskCellConfigurator: HomeRiskLevelCellConfigurator {
 		let separatorColor: UIColor = .enaColor(for: .hairlineContrast)
 		var itemCellConfigurators: [HomeRiskViewConfiguratorAny] = []
 		if isLoading {
-			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(title: AppStrings.Home.riskCardStatusCheckBody, titleColor: titleColor, isLoading: true, color: color, separatorColor: separatorColor)
+			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(
+				title: AppStrings.Home.riskCardStatusCheckBody,
+				titleColor: titleColor,
+				isLoading: true,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(isLoadingItem)
 		} else {
 			let numberContactsTitle = String(format: AppStrings.Home.riskCardNumberContactsItemTitle, numberRiskContacts)
-			let item1 = HomeRiskImageItemViewConfigurator(title: numberContactsTitle, titleColor: titleColor, iconImageName: "Icons_KeineRisikoBegegnung", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item1 = HomeRiskImageItemViewConfigurator(
+				title: numberContactsTitle,
+				titleColor: titleColor,
+				iconImageName: "Icons_KeineRisikoBegegnung",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			let numberDaysString = String(numberDays)
 			let totalDaysString = String(totalDays)
 			let saveDays = String(format: AppStrings.Home.riskCardLowSaveDaysItemTitle, numberDaysString, totalDaysString)
-			let item2 = HomeRiskImageItemViewConfigurator(title: saveDays, titleColor: titleColor, iconImageName: "Icons_TracingCircleFull - Dark", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item2 = HomeRiskImageItemViewConfigurator(
+				title: saveDays,
+				titleColor: titleColor,
+				iconImageName: "Icons_TracingCircleFull - Dark",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			let dateTitle = String(format: AppStrings.Home.riskCardDateItemTitle, lastUpdateDateString)
-			let item3 = HomeRiskImageItemViewConfigurator(title: dateTitle, titleColor: titleColor, iconImageName: "Icons_Aktualisiert", iconTintColor: titleColor, color: color, separatorColor: separatorColor)
+			let item3 = HomeRiskImageItemViewConfigurator(
+				title: dateTitle,
+				titleColor: titleColor,
+				iconImageName: "Icons_Aktualisiert",
+				iconTintColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(item1)
 			itemCellConfigurators.append(item2)
 			itemCellConfigurators.append(item3)

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeThankYouRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeThankYouRiskCellConfigurator.swift
@@ -42,11 +42,25 @@ final class HomeThankYouRiskCellConfigurator: HomeRiskCellConfigurator {
 
 		let iconColor: UIColor = .enaColor(for: .riskHigh)
 		let phoneTitle = AppStrings.Home.thankYouCardPhoneItemTitle
-		let phoneItem = HomeRiskImageItemViewConfigurator(title: phoneTitle, titleColor: titleColor, iconImageName: "Icons - Hotline", iconTintColor: iconColor, color: .clear, separatorColor: .clear)
+		let phoneItem = HomeRiskImageItemViewConfigurator(
+			title: phoneTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons - Hotline",
+			iconTintColor: iconColor,
+			color: .clear,
+			separatorColor: .clear
+		)
 		phoneItem.containerInsets = .init(top: 10.0, left: 0.0, bottom: 10.0, right: 0)
 
 		let homeTitle = AppStrings.Home.thankYouCardHomeItemTitle
-		let homeItem = HomeRiskImageItemViewConfigurator(title: homeTitle, titleColor: titleColor, iconImageName: "Icons - Home", iconTintColor: iconColor, color: .clear, separatorColor: .clear)
+		let homeItem = HomeRiskImageItemViewConfigurator(
+			title: homeTitle,
+			titleColor: titleColor,
+			iconImageName: "Icons - Home",
+			iconTintColor: iconColor,
+			color: .clear,
+			separatorColor: .clear
+		)
 		homeItem.containerInsets = .init(top: 10.0, left: 0.0, bottom: 10.0, right: 0)
 		cell.configureNoteRiskViews(cellConfigurators: [phoneItem, homeItem])
 

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeUnknownRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/HomeRiskCellConfigurators/HomeUnknownRiskCellConfigurator.swift
@@ -54,10 +54,21 @@ final class HomeUnknownRiskCellConfigurator: HomeRiskLevelCellConfigurator {
 		let separatorColor: UIColor = .enaColor(for: .hairlineContrast)
 		var itemCellConfigurators: [HomeRiskViewConfiguratorAny] = []
 		if isLoading {
-			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(title: AppStrings.Home.riskCardStatusCheckBody, titleColor: titleColor, isLoading: true, color: color, separatorColor: separatorColor)
+			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(
+				title: AppStrings.Home.riskCardStatusCheckBody,
+				titleColor: titleColor,
+				isLoading: true,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(isLoadingItem)
 		} else {
-			let item = HomeRiskTextItemViewConfigurator(title: AppStrings.Home.riskCardUnknownItemTitle, titleColor: titleColor, color: color, separatorColor: separatorColor)
+			let item = HomeRiskTextItemViewConfigurator(
+				title: AppStrings.Home.riskCardUnknownItemTitle,
+				titleColor: titleColor,
+				color: color,
+				separatorColor: separatorColor
+			)
 			itemCellConfigurators.append(item)
 		}
 		cell.configureRiskViews(cellConfigurators: itemCellConfigurators)

--- a/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/group/HomeInactiveRiskCellConfigurator.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Home/HomeRiskCellConfigurator/group/HomeInactiveRiskCellConfigurator.swift
@@ -26,7 +26,15 @@ final class HomeInactiveRiskCellConfigurator: HomeRiskCellConfigurator {
 	init(isLoading: Bool, isButtonEnabled: Bool, lastInvestigation: String, lastUpdateDate: Date?) {
 		self.lastUpdateDate = lastUpdateDate
 		self.lastInvestigation = lastInvestigation
-		super.init(isLoading: isLoading, isButtonEnabled: isButtonEnabled, isButtonHidden: false, isCounterLabelHidden: true, startDate: nil, releaseDate: nil, lastUpdateDate: lastUpdateDate)
+		super.init(
+            isLoading: isLoading,
+            isButtonEnabled: isButtonEnabled,
+            isButtonHidden: false,
+            isCounterLabelHidden: true,
+            startDate: nil,
+            releaseDate: nil,
+            lastUpdateDate: lastUpdateDate
+        )
 	}
 
 	// MARK: Configuration
@@ -47,15 +55,35 @@ final class HomeInactiveRiskCellConfigurator: HomeRiskCellConfigurator {
 		let separatorColor = UIColor.systemGray5
 		var itemCellConfigurators: [HomeRiskViewConfiguratorAny] = []
 		if isLoading {
-			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(title: AppStrings.Home.riskCardStatusCheckBody, titleColor: titleColor, isLoading: true, color: color, separatorColor: separatorColor)
+			let isLoadingItem = HomeRiskLoadingItemViewConfigurator(
+                title: AppStrings.Home.riskCardStatusCheckBody,
+                titleColor: titleColor,
+                isLoading: true,
+                color: color,
+                separatorColor: separatorColor
+            )
 			itemCellConfigurators.append(isLoadingItem)
 		} else {
 			let lastInvestigationTitle = String(format: AppStrings.Home.riskCardInactiveActivateItemTitle, lastInvestigation)
 			let iconTintColor = UIColor(red: 93.0 / 255.0, green: 111.0 / 255.0, blue: 128.0 / 255.0, alpha: 1.0)
-			let item1 = HomeRiskImageItemViewConfigurator(title: lastInvestigationTitle, titleColor: titleColor, iconImageName: "exposure-detection-last-risk-level-contrast", iconTintColor: iconTintColor, color: color, separatorColor: separatorColor)
+			let item1 = HomeRiskImageItemViewConfigurator(
+                title: lastInvestigationTitle,
+                titleColor: titleColor,
+                iconImageName: "exposure-detection-last-risk-level-contrast",
+                iconTintColor: iconTintColor,
+                color: color,
+                separatorColor: separatorColor
+            )
 
 			let dateTitle = String(format: AppStrings.Home.riskCardInactiveDateItemTitle, lastUpdateDateString)
-			let item2 = HomeRiskImageItemViewConfigurator(title: dateTitle, titleColor: titleColor, iconImageName: "exposure-detection-refresh-contrast", iconTintColor: iconTintColor, color: color, separatorColor: separatorColor)
+			let item2 = HomeRiskImageItemViewConfigurator(
+                title: dateTitle,
+                titleColor: titleColor,
+                iconImageName: "exposure-detection-refresh-contrast",
+                iconTintColor: iconTintColor,
+                color: color,
+                separatorColor: separatorColor
+            )
 			itemCellConfigurators.append(contentsOf: [item1, item2])
 		}
 		cell.configureRiskViews(cellConfigurators: itemCellConfigurators)

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -104,6 +104,7 @@ final class ENATaskScheduler {
 		executeFetchTestResults(task) { executeFetchTestResultsSuccess in
 			self.executeExposureDetectionRequest(task) { executeExposureDetectionRequestSuccess in
 				let success = executeFetchTestResultsSuccess && executeExposureDetectionRequestSuccess
+				// swiftlint:disable:next line_length
 				log(message: "Task complete! executeFetchTestResultsSuccess \(executeFetchTestResultsSuccess) && executeExposureDetectionRequestSuccess \(executeExposureDetectionRequestSuccess)")
 				// TODO: testing
 				UNUserNotificationCenter.current().presentNotification(title: "\(#function)", body: "\(task.identifier) complete!", identifier: UUID().uuidString)

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -102,7 +102,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 		setupUI()
 
 		NotificationCenter.default.addObserver(self, selector: #selector(isOnboardedDidChange(_:)), name: .isOnboardedDidChange, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(backgroundRefreshStatusDidChange), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: nil)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(backgroundRefreshStatusDidChange),
+			name: UIApplication.backgroundRefreshStatusDidChangeNotification,
+			object: nil
+		)
 	}
 
 	func sceneWillEnterForeground(_ scene: UIScene) {
@@ -330,11 +335,19 @@ extension SceneDelegate: HomeViewControllerDelegate {
 }
 
 extension SceneDelegate: UNUserNotificationCenterDelegate {
-	func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+	func userNotificationCenter(
+		_: UNUserNotificationCenter,
+		willPresent _: UNNotification,
+		withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+	) {
 		completionHandler([.alert, .badge, .sound])
 	}
 
-	func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+	func userNotificationCenter(
+		_: UNUserNotificationCenter,
+		didReceive response: UNNotificationResponse,
+		withCompletionHandler completionHandler: @escaping () -> Void
+	) {
 		switch response.actionIdentifier {
 		case UserNotificationAction.openExposureDetectionResults.rawValue,
 			 UserNotificationAction.openTestResults.rawValue:

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+DynamicTableViewModel.swift
@@ -20,7 +20,12 @@ import UIKit
 
 private extension DynamicCell {
 	static func phone(text: String, number: String, accessibilityIdentifier: String?) -> Self {
-		var cell: DynamicCell = .icon(UIImage(systemName: "phone"), text: text, tintColor: .enaColor(for: .textPrimary1), action: .call(number: number)) { _, cell, _ in
+		var cell: DynamicCell = .icon(
+			UIImage(systemName: "phone"),
+			text: text,
+			tintColor: .enaColor(for: .textPrimary1),
+			action: .call(number: number)
+		) { _, cell, _ in
 			cell.textLabel?.textColor = .enaColor(for: .textTint)
 			(cell.textLabel as? ENALabel)?.style = .title2
 			cell.accessibilityIdentifier = accessibilityIdentifier

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
@@ -40,7 +40,12 @@ extension DynamicCell {
 		case space = "spaceCell"
 	}
 
-	static func identifier(_ identifier: TableViewCellReuseIdentifiers, action: DynamicAction = .none, accessoryAction: DynamicAction = .none, configure: CellConfigurator? = nil) -> Self {
+	static func identifier(
+		_ identifier: TableViewCellReuseIdentifiers,
+		action: DynamicAction = .none,
+		accessoryAction: DynamicAction = .none,
+		configure: CellConfigurator? = nil
+	) -> Self {
 		.init(
 			cellReuseIdentifier: identifier,
 			action: action,
@@ -50,7 +55,12 @@ extension DynamicCell {
 		)
 	}
 
-	static func custom<T: DynamicTableViewController>(withIdentifier identifier: TableViewCellReuseIdentifiers, action: DynamicAction = .none, accessoryAction: DynamicAction = .none, configure: GenericCellConfigurator<T>? = nil) -> Self {
+	static func custom<T: DynamicTableViewController>(
+		withIdentifier identifier: TableViewCellReuseIdentifiers,
+		action: DynamicAction = .none,
+		accessoryAction: DynamicAction = .none,
+		configure: GenericCellConfigurator<T>? = nil
+	) -> Self {
 		.identifier(identifier, action: action, accessoryAction: accessoryAction) { viewController, cell, indexPath in
 			if let viewController = viewController as? T {
 				configure?(viewController, cell, indexPath)
@@ -62,7 +72,16 @@ extension DynamicCell {
 }
 
 extension DynamicCell {
-	static func dynamicType(text: String, size: CGFloat = 17, weight: UIFont.Weight = .regular, style: UIFont.TextStyle = .body, color: UIColor? = nil, accessibilityIdentifier: String? = nil, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
+	static func dynamicType(
+		text: String,
+		size: CGFloat = 17,
+		weight: UIFont.Weight = .regular,
+		style: UIFont.TextStyle = .body,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String? = nil,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
 		.identifier(CellReuseIdentifier.dynamicTypeText, action: .none, accessoryAction: .none) { viewController, cell, indexPath in
 			guard let cell = cell as? DynamicTypeTableViewCell else { return }
 			cell.configureDynamicType(size: size, weight: weight, style: style)
@@ -72,7 +91,14 @@ extension DynamicCell {
 		}
 	}
 
-	static func icon(_ image: UIImage?, text: String, tintColor: UIColor? = nil, style: ENAFont = .body, action: DynamicAction = .none, configure: CellConfigurator? = nil) -> Self {
+	static func icon(
+		_ image: UIImage?,
+		text: String,
+		tintColor: UIColor? = nil,
+		style: ENAFont = .body,
+		action: DynamicAction = .none,
+		configure: CellConfigurator? = nil
+	) -> Self {
 		.identifier(CellReuseIdentifier.icon, action: action, accessoryAction: .none) { viewController, cell, indexPath in
 			(cell as? DynamicTableViewIconCell)?.configure(image: image, text: text, tintColor: tintColor, style: style)
 			configure?(viewController, cell, indexPath)
@@ -89,31 +115,124 @@ extension DynamicCell {
 }
 
 extension DynamicCell {
-	private static func enaLabelStyle(_ style: ENALabel.Style, text: String, color: UIColor?, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
-		dynamicType(text: text, size: style.fontSize, weight: UIFont.Weight(style.fontWeight), style: style.textStyle, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	private static func enaLabelStyle(
+		_ style: ENALabel.Style,
+		text: String, color: UIColor?,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		dynamicType(
+			text: text,
+			size: style.fontSize,
+			weight: UIFont.Weight(style.fontWeight),
+			style: style.textStyle,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func title1(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = [.header, .staticText], configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.title1, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func title1(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = [.header, .staticText],
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.title1,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func title2(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = [.header, .staticText], configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.title2, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func title2(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = [.header, .staticText],
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.title2,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func headline(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.headline, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func headline(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.headline,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func body(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.body, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func body(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.body,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func subheadline(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.subheadline, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func subheadline(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.subheadline,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 
-	static func footnote(text: String, color: UIColor? = nil, accessibilityIdentifier: String?, accessibilityTraits: UIAccessibilityTraits = .staticText, configure: CellConfigurator? = nil) -> Self {
-		.enaLabelStyle(.footnote, text: text, color: color, accessibilityIdentifier: accessibilityIdentifier, accessibilityTraits: accessibilityTraits, configure: configure)
+	static func footnote(
+		text: String,
+		color: UIColor? = nil,
+		accessibilityIdentifier: String?,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.enaLabelStyle(
+			.footnote,
+			text: text,
+			color: color,
+			accessibilityIdentifier: accessibilityIdentifier,
+			accessibilityTraits: accessibilityTraits,
+			configure: configure
+		)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
@@ -55,7 +55,10 @@ class DynamicTableViewController: UIViewController, UITableViewDataSource, UITab
 
 		tableView.register(DynamicTypeTableViewCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.dynamicTypeText.rawValue)
 		tableView.register(DynamicTableViewSpaceCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.space.rawValue)
-		tableView.register(UINib(nibName: String(describing: DynamicTableViewIconCell.self), bundle: nil), forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.icon.rawValue)
+		tableView.register(
+			UINib(nibName: String(describing: DynamicTableViewIconCell.self), bundle: nil),
+			forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.icon.rawValue
+		)
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewSection.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewSection.swift
@@ -37,7 +37,13 @@ struct DynamicSection {
 		self.cells = cells
 	}
 
-	static func section(header: DynamicHeader = .none, footer: DynamicFooter = .none, separators: Bool = false, isHidden: ((DynamicTableViewController) -> Bool)? = nil, cells: [DynamicCell]) -> Self {
+	static func section(
+		header: DynamicHeader = .none,
+		footer: DynamicFooter = .none,
+		separators: Bool = false,
+		isHidden: ((DynamicTableViewController) -> Bool)? = nil,
+		cells: [DynamicCell]
+	) -> Self {
 		.init(header: header, footer: footer, separators: separators, isHidden: isHidden, cells: cells)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -152,8 +152,20 @@ extension ExposureNotificationSettingViewController {
 				fatalError("Not all cases of actions covered when handling the bluetooth")
 			}
 		}
-		alert.addAction(UIAlertAction(title: AppStrings.ExposureNotificationSetting.privacyConsentActivateAction, style: .default, handler: { action in completionHandler(action) }))
-		alert.addAction(UIAlertAction(title: AppStrings.ExposureNotificationSetting.privacyConsentDismissAction, style: .cancel, handler: { action in completionHandler(action) }))
+		alert.addAction(
+			UIAlertAction(
+				title: AppStrings.ExposureNotificationSetting.privacyConsentActivateAction,
+				style: .default,
+				handler: { action in completionHandler(action) }
+			)
+		)
+		alert.addAction(
+			UIAlertAction(
+				title: AppStrings.ExposureNotificationSetting.privacyConsentDismissAction,
+				style: .cancel,
+				handler: { action in completionHandler(action) }
+			)
+		)
 		self.present(alert, animated: true, completion: nil)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
@@ -68,7 +68,12 @@ private extension DynamicCell {
 		case hotline = "hotlineCell"
 	}
 
-	private static func exposureDetectionCell(_ identifier: TableViewCellReuseIdentifiers, action: DynamicAction = .none, accessoryAction: DynamicAction = .none, configure: GenericCellConfigurator<ExposureDetectionViewController>? = nil) -> DynamicCell {
+	private static func exposureDetectionCell(
+		_ identifier: TableViewCellReuseIdentifiers,
+		action: DynamicAction = .none,
+		accessoryAction: DynamicAction = .none,
+		configure: GenericCellConfigurator<ExposureDetectionViewController>? = nil
+	) -> DynamicCell {
 		.custom(withIdentifier: identifier, action: action, accessoryAction: accessoryAction, configure: configure)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionDynamicCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionDynamicCell.swift
@@ -21,21 +21,41 @@ import Foundation
 import UIKit
 
 enum ExposureSubmissionDynamicCell {
-	static func stepCell(title: String, description: String?, icon: UIImage?, hairline: ExposureSubmissionStepCell.Hairline, bottomSpacing: ExposureSubmissionStepCell.Spacing = .large, action: DynamicAction = .none) -> DynamicCell {
+	static func stepCell(
+		title: String,
+		description: String?,
+		icon: UIImage?,
+		hairline: ExposureSubmissionStepCell.Hairline,
+		bottomSpacing: ExposureSubmissionStepCell.Spacing = .large,
+		action: DynamicAction = .none
+	) -> DynamicCell {
 		.identifier(ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell, action: action) { _, cell, _ in
 			guard let cell = cell as? ExposureSubmissionStepCell else { return }
 			cell.configure(title: title, description: description, icon: icon, hairline: hairline, bottomSpacing: bottomSpacing)
 		}
 	}
 
-	static func stepCell(style: ENAFont, color: UIColor = .enaColor(for: .textPrimary1), title: String, icon: UIImage? = nil, hairline: ExposureSubmissionStepCell.Hairline, bottomSpacing: ExposureSubmissionStepCell.Spacing = .large, action: DynamicAction = .none) -> DynamicCell {
+	static func stepCell(
+		style: ENAFont,
+		color: UIColor = .enaColor(for: .textPrimary1),
+		title: String,
+		icon: UIImage? = nil,
+		hairline: ExposureSubmissionStepCell.Hairline,
+		bottomSpacing: ExposureSubmissionStepCell.Spacing = .large,
+		action: DynamicAction = .none
+	) -> DynamicCell {
 		.identifier(ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell, action: action) { _, cell, _ in
 			guard let cell = cell as? ExposureSubmissionStepCell else { return }
 			cell.configure(style: style, color: color, title: title, icon: icon, hairline: hairline, bottomSpacing: bottomSpacing)
 		}
 	}
 
-	static func stepCell(bulletPoint title: String, hairline: ExposureSubmissionStepCell.Hairline = .none, bottomSpacing: ExposureSubmissionStepCell.Spacing = .normal, action: DynamicAction = .none) -> DynamicCell {
+	static func stepCell(
+		bulletPoint title: String,
+		hairline: ExposureSubmissionStepCell.Hairline = .none,
+		bottomSpacing: ExposureSubmissionStepCell.Spacing = .normal,
+		action: DynamicAction = .none
+	) -> DynamicCell {
 		.identifier(ExposureSubmissionSuccessViewController.CustomCellReuseIdentifiers.stepCell, action: action) { _, cell, _ in
 			guard let cell = cell as? ExposureSubmissionStepCell else { return }
 			cell.configure(bulletPoint: title, hairline: hairline, bottomSpacing: bottomSpacing)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionHotlineViewController.swift
@@ -55,7 +55,10 @@ class ExposureSubmissionHotlineViewController: DynamicTableViewController {
 	private func setupTableView() {
 		tableView.delegate = self
 		tableView.dataSource = self
-		tableView.register(UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil), forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue)
+		tableView.register(
+			UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil),
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue
+		)
 
 		dynamicTableViewModel = DynamicTableViewModel(
 			[

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionIntroViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionIntroViewController.swift
@@ -60,7 +60,10 @@ class ExposureSubmissionIntroViewController: DynamicTableViewController, Exposur
 	private func setupTableView() {
 		tableView.dataSource = self
 		tableView.delegate = self
-		tableView.register(UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil), forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue)
+		tableView.register(
+			UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil),
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue
+		)
 		dynamicTableViewModel = .intro
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
@@ -164,19 +164,31 @@ class ExposureSubmissionNavigationController: UINavigationController, UINavigati
 		applyDefaultRightBarButtonItem(to: topViewController)
 		applyNavigationBarItem(of: topViewController)
 
-		keyboardWillShowObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil) { [weak self] notification in
+		keyboardWillShowObserver = NotificationCenter.default.addObserver(
+			forName: UIResponder.keyboardWillShowNotification,
+			object: nil,
+			queue: nil
+		) { [weak self] notification in
 			self?.isKeyboardHidden = false
 			self?.keyboardWindowFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
 			self?.updateBottomSafeAreaInset(animated: true)
 		}
 
-		keyboardWillHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { [weak self] notification in
+		keyboardWillHideObserver = NotificationCenter.default.addObserver(
+			forName: UIResponder.keyboardWillHideNotification,
+			object: nil,
+			queue: nil
+		) { [weak self] notification in
 			self?.isKeyboardHidden = true
 			self?.keyboardWindowFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
 			self?.updateBottomSafeAreaInset(animated: true)
 		}
 
-		keyboardWillChangeFrameObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: nil) { [weak self] notification in
+		keyboardWillChangeFrameObserver = NotificationCenter.default.addObserver(
+			forName: UIResponder.keyboardWillChangeFrameNotification,
+			object: nil,
+			queue: nil
+		) { [weak self] notification in
 			self?.keyboardWindowFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
 			self?.updateBottomSafeAreaInset(animated: true)
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -57,7 +57,10 @@ class ExposureSubmissionOverviewViewController: DynamicTableViewController, Spin
 			),
 			forHeaderFooterViewReuseIdentifier: "test"
 		)
-		tableView.register(UINib(nibName: String(describing: ExposureSubmissionImageCardCell.self), bundle: nil), forCellReuseIdentifier: CustomCellReuseIdentifiers.imageCard.rawValue)
+		tableView.register(
+			UINib(nibName: String(describing: ExposureSubmissionImageCardCell.self), bundle: nil),
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.imageCard.rawValue
+		)
 		title = AppStrings.ExposureSubmissionDispatch.title
 	}
 
@@ -295,7 +298,11 @@ private extension ExposureSubmissionOverviewViewController {
 			),
 			.imageCard(
 				title: AppStrings.ExposureSubmissionDispatch.hotlineButtonTitle,
-				attributedDescription: applyFont(style: .headline, to: AppStrings.ExposureSubmissionDispatch.hotlineButtonDescription, with: AppStrings.ExposureSubmissionDispatch.positiveWord),
+				attributedDescription: applyFont(
+					style: .headline,
+					to: AppStrings.ExposureSubmissionDispatch.hotlineButtonDescription,
+					with: AppStrings.ExposureSubmissionDispatch.positiveWord
+				),
 				image: UIImage(named: "Illu_Submission_Anruf"),
 				action: .perform(segue: Segue.hotline),
 				accessibilityIdentifier: "AppStrings.ExposureSubmissionDispatch.hotlineButtonDescription"

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionSuccessViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionSuccessViewController.swift
@@ -30,7 +30,10 @@ final class ExposureSubmissionSuccessViewController: DynamicTableViewController 
 
 	private func setUpView() {
 		navigationItem.hidesBackButton = true
-		tableView.register(UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil), forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue)
+		tableView.register(
+			UINib(nibName: String(describing: ExposureSubmissionStepCell.self), bundle: nil),
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.stepCell.rawValue
+		)
 		dynamicTableViewModel = .data
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionViewUtils.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionViewUtils.swift
@@ -41,7 +41,15 @@ enum ExposureSubmissionViewUtils {
 		setupAlert(message: error.localizedDescription, retry: retry, retryActionHandler: retryActionHandler)
 	}
 
-	static func setupAlert(title: String? = nil, message: String, okTitle: String? = nil, retryTitle: String? = nil, retry: Bool = false, action completion: (() -> Void)? = nil, retryActionHandler: (() -> Void)? = nil) -> UIAlertController {
+	static func setupAlert(
+		title: String? = nil,
+		message: String,
+		okTitle: String? = nil,
+		retryTitle: String? = nil,
+		retry: Bool = false,
+		action completion: (() -> Void)? = nil,
+		retryActionHandler: (() -> Void)? = nil
+	) -> UIAlertController {
 		let alert = UIAlertController(
 			title: title ?? AppStrings.ExposureSubmission.generalErrorTitle,
 			message: message,

--- a/src/xcode/ENA/ENA/Source/Scenes/FriendsInvite/FriendsInviteController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FriendsInvite/FriendsInviteController.swift
@@ -48,7 +48,17 @@ final class FriendsInviteController: UIViewController {
 		inviteButton.setTitle(AppStrings.InviteFriends.submit, for: .normal)
 
 		if let inviteButton = inviteButton, let titleLabel = inviteButton.titleLabel {
-			inviteButton.addConstraint(NSLayoutConstraint(item: inviteButton, attribute: .height, relatedBy: .equal, toItem: titleLabel, attribute: .height, multiplier: 1, constant: 0))
+			inviteButton.addConstraint(
+				NSLayoutConstraint(
+					item: inviteButton,
+					attribute: .height,
+					relatedBy: .equal,
+					toItem: titleLabel,
+					attribute: .height,
+					multiplier: 1,
+					constant: 0
+				)
+			)
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/Cells/MainSettingsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/Cells/MainSettingsTableViewCell.swift
@@ -56,12 +56,25 @@ class MainSettingsTableViewCell: UITableViewCell {
 	}
 
 	private func setLayoutConstraints() {
-		regularConstraints = [imageContainerCenterConstraint, descriptionLabelTrailingConstraint, descriptionLabelBottom, stateLabelLeading, stateLabelTop, disclosureIndicatorLeading]
+		regularConstraints = [
+			imageContainerCenterConstraint,
+			descriptionLabelTrailingConstraint,
+			descriptionLabelBottom,
+			stateLabelLeading,
+			stateLabelTop,
+			disclosureIndicatorLeading
+		]
 
 		let labelHalfCapHeight = descriptionLabel.font.capHeight / 2
 		imageContainerFirstBaselineConstraint.constant = labelHalfCapHeight
 
-		largeTextConstraints = [descriptionLabelLeadingConstraint, imageContainerFirstBaselineConstraint, stateLabelTopLarge, stateLabelLeadingLarge, disclosureIndicatorLeadingLarge]
+		largeTextConstraints = [
+			descriptionLabelLeadingConstraint,
+			imageContainerFirstBaselineConstraint,
+			stateLabelTopLarge,
+			stateLabelLeadingLarge,
+			disclosureIndicatorLeadingLarge
+		]
 	}
 
 	private func updateLayoutConstraints() {

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettingsViewController.swift
@@ -132,7 +132,17 @@ class NotificationSettingsViewController: UIViewController {
 		infoViewButton.titleLabel?.lineBreakMode = .byWordWrapping
 
 		if let infoViewButton = infoViewButton {
-			infoViewButton.addConstraint(NSLayoutConstraint(item: infoViewButton, attribute: .height, relatedBy: .equal, toItem: infoViewButton.titleLabel, attribute: .height, multiplier: 1, constant: 0))
+			infoViewButton.addConstraint(
+				NSLayoutConstraint(
+					item: infoViewButton,
+					attribute: .height,
+					relatedBy: .equal,
+					toItem: infoViewButton.titleLabel,
+					attribute: .height,
+					multiplier: 1,
+					constant: 0
+				)
+			)
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/ResetViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/ResetViewController.swift
@@ -73,7 +73,17 @@ final class ResetViewController: UIViewController {
 		discardButton.setTitle(AppStrings.Reset.discardButton, for: .normal)
 
 		if let resetButton = resetButton, let titleLabel = resetButton.titleLabel {
-			resetButton.addConstraint(NSLayoutConstraint(item: resetButton, attribute: .height, relatedBy: .equal, toItem: titleLabel, attribute: .height, multiplier: 1, constant: 0))
+			resetButton.addConstraint(
+				NSLayoutConstraint(
+					item: resetButton,
+					attribute: .height,
+					relatedBy: .equal,
+					toItem: titleLabel,
+					attribute: .height,
+					multiplier: 1,
+					constant: 0
+				)
+			)
 		}
 
 		navigationItem.rightBarButtonItem?.accessibilityLabel = AppStrings.AccessibilityLabel.close

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -290,7 +290,11 @@ extension SettingsViewController: ResetDelegate {
 }
 
 extension SettingsViewController: ExposureNotificationSettingViewControllerDelegate {
-	func exposureNotificationSettingViewController(_: ExposureNotificationSettingViewController, setExposureManagerEnabled enabled: Bool, then completion: @escaping (ExposureNotificationError?) -> Void) {
+	func exposureNotificationSettingViewController(
+		_: ExposureNotificationSettingViewController,
+		setExposureManagerEnabled enabled: Bool,
+		then completion: @escaping (ExposureNotificationError?) -> Void
+	) {
 		setExposureManagerEnabled(enabled, then: completion)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
@@ -165,7 +165,12 @@ extension ExposureDetectionDelegateMock: ExposureDetectionDelegate {
 		writtenPackages()
 	}
 
-	func exposureDetection(_ detection: ExposureDetection, detectSummaryWithConfiguration configuration: ENExposureConfiguration, writtenPackages: WrittenPackages, completion: @escaping (Result<ENExposureDetectionSummary, Error>) -> Void) {
+	func exposureDetection(
+		_ detection: ExposureDetection,
+		detectSummaryWithConfiguration configuration: ENExposureConfiguration,
+		writtenPackages: WrittenPackages,
+		completion: @escaping (Result<ENExposureDetectionSummary, Error>) -> Void
+	) {
 		completion(summaryResult(configuration, writtenPackages))
 	}
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -17,7 +17,7 @@
 
 import UIKit
 
-// swiftlint:disable:next type_body_length
+// swiftlint:disable type_body_length identifier_name line_length
 enum AppStrings {
 	enum Common {
 		static let alertTitleGeneral = NSLocalizedString("Alert_TitleGeneral", comment: "")

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/HomeTestResultCollectionViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Cells/HomeTestResultCollectionViewCell.swift
@@ -51,7 +51,15 @@ class HomeTestResultCollectionViewCell: HomeCardCollectionViewCell {
 		setupAccessibility()
 	}
 
-	func configure(title: String, subtitle: String? = nil, description: String, button buttonTitle: String, image: UIImage?, tintColor: UIColor = .enaColor(for: .textPrimary1), accessibilityIdentifier: String?) {
+	func configure(
+		title: String,
+		subtitle: String? = nil,
+		description: String,
+		button buttonTitle: String,
+		image: UIImage?,
+		tintColor: UIColor = .enaColor(for: .textPrimary1),
+		accessibilityIdentifier: String?
+	) {
 		titleLabel.text = title
 		subtitleLabel.text = subtitle
 		descriptionLabel.text = description

--- a/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
@@ -173,6 +173,7 @@ class SQLiteKeyValueStore {
 	func flush() {
 		openDbIfNeeded()
 		databaseQueue?.inDatabase { db in
+			// swiftlint:disable:next line_length
 			let deleteStmt = "DELETE FROM kv WHERE key NOT IN('developerSubmissionBaseURLOverride','developerDistributionBaseURLOverride','developerVerificationBaseURLOverride');"
 			do {
 				try db.executeUpdate(deleteStmt, values: [])

--- a/src/xcode/ENA/ENA/Source/Workers/Update Checker/AppUpdateCheckHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Update Checker/AppUpdateCheckHelper.swift
@@ -66,7 +66,11 @@ final class AppUpdateCheckHelper {
 
 	private func setObserver(vc: UIViewController?, alertType: UpdateAlertType) {
 		guard self.applicationDidBecomeActiveObserver == nil else { return }
-		self.applicationDidBecomeActiveObserver = NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
+		self.applicationDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+			forName: UIApplication.didBecomeActiveNotification,
+			object: nil,
+			queue: nil
+		) { [weak self] _ in
 			guard let self = self else { return }
 			guard let alert = self.createAlert(alertType, vc: vc) else {
 				return

--- a/src/xcode/ENA/ENAUITests/ENAUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests.swift
@@ -24,7 +24,8 @@ class ENAUITests: XCTestCase {
 		// In UI tests it is usually best to stop immediately when a failure occurs.
 		continueAfterFailure = false
 
-		// In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+		// In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run.
+		// The setUp method is a good place to do this.
 	}
 
 	override func tearDownWithError() throws {

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -43,8 +43,8 @@ platform :ios do
 
     swiftlint(
       mode: :lint,
+      path: "ENA",
       output_file: "swiftlint.result.json",
-      config_file: "ENA/.swiftlint.yml",
       raise_if_swiftlint_error: true,
       reporter: "sonarqube"
     )


### PR DESCRIPTION
## Description
This is the fourth follow-up smaller PR to https://github.com/corona-warn-app/cwa-app-ios/pull/104. Together with the other PRs I will be posting, all SwiftLint warnings should be fixed to allow us to enable the `--strict` mode of SwiftLint on the CI to prevent any new warnings getting merged in the future.

In this specific PR, I've turned on the due to it's loose configuration effectively turned off rule `line_length` where I really don't understand why it was effectively turned off. As you can see in the many fixe I needed to make, already many lines really got out of hand and were way too long. It is a very important rule for any programming language.

Note that I've chosen a `max_length` of 160 and not the default 120 because nowadays monitors are widescreen and have a high resolution, also in Swift development brevity isn't necessarily a goal in variable and class naming, conciseness is much more important which can sometimes lead to some longer lines. I think 160 is a good compromise. If you disagree, I think merging my PR still makes sense as it's a good step forward from 500 and 120 can be reached in a subsequent PR if needed.

## Related PRs
https://github.com/corona-warn-app/cwa-app-ios/pull/516, https://github.com/corona-warn-app/cwa-app-ios/pull/518, https://github.com/corona-warn-app/cwa-app-ios/pull/522, https://github.com/corona-warn-app/cwa-app-ios/pull/531, https://github.com/corona-warn-app/cwa-app-ios/pull/534.

_Note that all these PRs are completely independent and **can be merged in any order**._