### PR TITLE
[Lint] Turn off SwiftLint todo rule on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           name: Install dependencies
           command: brew install swiftlint && cd src/xcode && bundle install
       - run:
+          name: Disable SwiftLint rule todo
+          command: sed -i '' "s/# - todo/  - todo/g" src/xcode/ENA/.swiftlint.yml
+      - run:
           name: Build
           command: cd src/xcode && bundle exec fastlane build
   test:

--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -198,6 +198,7 @@ disabled_rules:
   - type_name
   - identifier_name
   - redundant_string_enum_value # disabled because it conflicts with explicit_enum_raw_value
+# - todo # keep this in here for the CI to work properly (will be uncommented on the CI so it can use the `--strict` mode)
 
 # Included paths (disables --path option)
 included:


### PR DESCRIPTION
## Description
This is the fifth follow-up smaller PR to https://github.com/corona-warn-app/cwa-app-ios/pull/104. Together with the other PRs I will be posting, all SwiftLint warnings should be fixed to allow us to enable the `--strict` mode of SwiftLint on the CI to prevent any new warnings getting merged in the future.

In this specific PR, I've added an outcommented line into the `disabled_rules` section of the SwiftLint configuration file and placed a script that will uncomment this line on Circle CI so the `todo` rule gets disabled on the CI. The reason for this is, that this way developers will continue to see the `// TODO:` entries within code as warnings in the Xcode sidebar while we can also turn on the `--strict` mode on the CI without TODOs preventing us from merging the PR.

Note that I think `todo` is the only rule where this kind of discrepancy between the CI and the dev machines makes sense and we should be very careful about even thinking about treating other rules the same way. But because TODO is not a style or formatting warning, but rather a note that developers leave consciously for other developers, for this rule it makes only sense.

## Related PRs
https://github.com/corona-warn-app/cwa-app-ios/pull/516, https://github.com/corona-warn-app/cwa-app-ios/pull/518, https://github.com/corona-warn-app/cwa-app-ios/pull/522, https://github.com/corona-warn-app/cwa-app-ios/pull/527, https://github.com/corona-warn-app/cwa-app-ios/pull/534.

_Note that all these PRs are completely independent and **can be merged in any order**._