### PR TITLE
[Bug] Remove invalid separator line in risk detail screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
@@ -72,22 +72,22 @@ private extension DynamicCell {
 		.custom(withIdentifier: identifier, action: action, accessoryAction: accessoryAction, configure: configure)
 	}
 
-	static func risk(configure: @escaping GenericCellConfigurator<ExposureDetectionViewController>) -> DynamicCell {
+	static func risk(hasSeparator: Bool = true, configure: @escaping GenericCellConfigurator<ExposureDetectionViewController>) -> DynamicCell {
 		.exposureDetectionCell(ReusableCellIdentifer.risk) { viewController, cell, indexPath in
 			let state = viewController.state
 			cell.backgroundColor = state.riskTintColor
 			cell.tintColor = state.isTracingEnabled ? .enaColor(for: .textContrast) : .enaColor(for: .riskNeutral)
 			cell.textLabel?.textColor = state.riskContrastColor
 			if let cell = cell as? ExposureDetectionRiskCell {
-				cell.separatorView.isHidden = (indexPath.row == 0)
+				cell.separatorView.isHidden = (indexPath.row == 0) || !hasSeparator
 				cell.separatorView.backgroundColor = state.isTracingEnabled ? .enaColor(for: .hairlineContrast) : .enaColor(for: .hairline)
 			}
 			configure(viewController, cell, indexPath)
 		}
 	}
 
-	static func riskLastRiskLevel(text: String, image: UIImage?) -> DynamicCell {
-		.risk { viewController, cell, _ in
+	static func riskLastRiskLevel(hasSeparator: Bool = true, text: String, image: UIImage?) -> DynamicCell {
+		.risk(hasSeparator: hasSeparator) { viewController, cell, _ in
 			let state = viewController.state
 			cell.textLabel?.text = String(format: text, state.actualRiskText)
 			cell.imageView?.image = image
@@ -294,7 +294,7 @@ extension ExposureDetectionViewController {
 				footer: .separator(color: .enaColor(for: .hairline), height: 1, insets: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)),
 				cells: [
 					.riskText(text: AppStrings.ExposureDetection.offText),
-					.riskLastRiskLevel(text: AppStrings.ExposureDetection.lastRiskLevel, image: UIImage(named: "Icons_LetzteErmittlung-Light")),
+					.riskLastRiskLevel(hasSeparator: false, text: AppStrings.ExposureDetection.lastRiskLevel, image: UIImage(named: "Icons_LetzteErmittlung-Light")),
 					.riskRefreshed(text: AppStrings.ExposureDetection.refreshed, image: UIImage(named: "Icons_Aktualisiert"))
 				]
 			),
@@ -313,7 +313,7 @@ extension ExposureDetectionViewController {
 				footer: .separator(color: .enaColor(for: .hairline), height: 1, insets: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0)),
 				cells: [
 					.riskText(text: AppStrings.ExposureDetection.outdatedText),
-					.riskLastRiskLevel(text: AppStrings.ExposureDetection.lastRiskLevel, image: UIImage(named: "Icons_LetzteErmittlung-Light")),
+					.riskLastRiskLevel(hasSeparator: false, text: AppStrings.ExposureDetection.lastRiskLevel, image: UIImage(named: "Icons_LetzteErmittlung-Light")),
 					.riskRefreshed(text: AppStrings.ExposureDetection.refreshed, image: UIImage(named: "Icons_Aktualisiert"))
 				]
 			),


### PR DESCRIPTION
This PR removes a redundant line is the risk detail screen.

Take not on the first line before "Letzte Risiko-Ermittlung". This change applies to both disabled and outdated state.

|Before|After|
|:--|:--|
|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84444166-6f658f80-ac41-11ea-9cba-3ed7d0b418fa.png">|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84444193-8310f600-ac41-11ea-9e44-c5f417f5b871.png">|


