### PR TITLE
[Bug] Fix scroll content inset on risk detail screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
@@ -16,8 +16,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="1100"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alwaysBounceVertical="YES" contentInsetAdjustmentBehavior="never" delaysContentTouches="NO" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QWK-uI-Gcu">
-                                <rect key="frame" x="0.0" y="60.5" width="414" height="1039.5"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" delaysContentTouches="NO" dataMode="prototypes" style="grouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="QWK-uI-Gcu">
+                                <rect key="frame" x="0.0" y="73.5" width="414" height="1026.5"/>
                                 <color key="backgroundColor" name="ENA Background Color"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="riskCell" id="XQi-Gr-JdM" customClass="ExposureDetectionRiskCell" customModule="ENA" customModuleProvider="target">

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -62,7 +62,7 @@ extension ExposureDetectionViewController {
 
 		titleLabel.accessibilityTraits = .header
 
-    closeControl.isAccessibilityElement = true
+		closeControl.isAccessibilityElement = true
 		closeControl.accessibilityTraits = .button
 		closeControl.accessibilityLabel = AppStrings.AccessibilityLabel.close
 		closeControl.accessibilityIdentifier = "AppStrings.AccessibilityLabel.close"

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -84,11 +84,12 @@ extension ExposureDetectionViewController {
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
 
-		switch state.detectionMode {
-		case .automatic:
+		if footerView.isHidden {
 			tableView.contentInset.bottom = 0
-		case .manual:
-			tableView.contentInset.bottom = footerView.frame.height
+			tableView.verticalScrollIndicatorInsets.bottom = 0
+		} else {
+			tableView.contentInset.bottom = footerView.frame.height - tableView.safeAreaInsets.bottom
+			tableView.verticalScrollIndicatorInsets.bottom = tableView.contentInset.bottom
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the scroll content inset on the risk detail screen.

Notice the scroll indicator in the screenshots. Both have been scrolled to the very bottom.

|Before|After{
|:--|:--|
|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84446084-0e3fbb00-ac45-11ea-804c-9db92668e86a.png">|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84445949-cb7de300-ac44-11ea-8df9-c210e9edd91e.png">|
