### PR TITLE
[Feature] Add support for reduced transparency accessibility setting

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		710ABB292475353900948792 /* DynamicTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710ABB282475353900948792 /* DynamicTableViewModel.swift */; };
 		71176E2F248922B0004B0C9F /* ENAColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71176E2D24891C02004B0C9F /* ENAColorTests.swift */; };
 		71176E32248957C3004B0C9F /* AppNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71176E31248957C3004B0C9F /* AppNavigationController.swift */; };
+		711EFCC72492EE31005FEF21 /* ENAFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711EFCC62492EE31005FEF21 /* ENAFooterView.swift */; };
 		71330E41248109F600EB10F6 /* DynamicTableViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71330E40248109F600EB10F6 /* DynamicTableViewSection.swift */; };
 		71330E43248109FD00EB10F6 /* DynamicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71330E42248109FD00EB10F6 /* DynamicTableViewCell.swift */; };
 		71330E4524810A0500EB10F6 /* DynamicTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71330E4424810A0500EB10F6 /* DynamicTableViewHeader.swift */; };
@@ -487,6 +488,7 @@
 		710ABB282475353900948792 /* DynamicTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewModel.swift; sourceTree = "<group>"; };
 		71176E2D24891C02004B0C9F /* ENAColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAColorTests.swift; sourceTree = "<group>"; };
 		71176E31248957C3004B0C9F /* AppNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationController.swift; sourceTree = "<group>"; };
+		711EFCC62492EE31005FEF21 /* ENAFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAFooterView.swift; sourceTree = "<group>"; };
 		71330E40248109F600EB10F6 /* DynamicTableViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewSection.swift; sourceTree = "<group>"; };
 		71330E42248109FD00EB10F6 /* DynamicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewCell.swift; sourceTree = "<group>"; };
 		71330E4424810A0500EB10F6 /* DynamicTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewHeader.swift; sourceTree = "<group>"; };
@@ -1164,6 +1166,7 @@
 				8595BF5E246032D90056EA27 /* ENASwitch.swift */,
 				71FE1C81247AC30300851FEB /* ENATanInput.swift */,
 				71B804462484CC0800D53506 /* ENALabel.swift */,
+				711EFCC62492EE31005FEF21 /* ENAFooterView.swift */,
 			);
 			path = BaseElements;
 			sourceTree = "<group>";
@@ -2152,6 +2155,7 @@
 				A16714BB248D18D20031B111 /* SummaryMetadata.swift in Sources */,
 				51C779162486E5BA004582F8 /* RiskFindingPositiveCollectionViewCell.swift in Sources */,
 				B10FD5F4246EAC1700E9D7F2 /* AppleFilesWriter.swift in Sources */,
+				711EFCC72492EE31005FEF21 /* ENAFooterView.swift in Sources */,
 				B1FE13F024891D1500D012E5 /* RiskCalculation.swift in Sources */,
 				514C0A14247C163800F235F6 /* HomeLowRiskCellConfigurator.swift in Sources */,
 				51C779122486E549004582F8 /* HomeFindingPositiveRiskCellConfigurator.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/ExposureDetection.storyboard
@@ -525,7 +525,7 @@
                                     <outlet property="delegate" destination="DFY-cN-Vfe" id="Gqn-Rh-hQi"/>
                                 </connections>
                             </tableView>
-                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iKv-vN-XYX">
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iKv-vN-XYX" customClass="ENAFooterView" customModule="ENA" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="984" width="414" height="116"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Yff-4j-Uub">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="116"/>

--- a/src/xcode/ENA/ENA/Resources/Storyboards/Onboarding.storyboard
+++ b/src/xcode/ENA/ENA/Resources/Storyboards/Onboarding.storyboard
@@ -91,7 +91,7 @@
                                     <constraint firstItem="OQb-9Z-xLl" firstAttribute="width" secondItem="1HX-Yf-LyV" secondAttribute="width" id="ufc-l2-buW"/>
                                 </constraints>
                             </scrollView>
-                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0oH-fF-RI6">
+                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0oH-fF-RI6" customClass="ENAFooterView" customModule="ENA" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="722" width="414" height="174"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="5H2-LC-1rB">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="174"/>

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
@@ -296,6 +296,7 @@ extension ExposureSubmissionNavigationController {
 
 extension ExposureSubmissionNavigationController {
 	private func setupBottomView() {
+		// TODO: Apply ENAFooterView
 		let view = UIView()
 		view.backgroundColor = .enaColor(for: .background)
 		view.insetsLayoutMarginsFromSafeArea = true

--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAFooterView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAFooterView.swift
@@ -1,0 +1,83 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+import UIKit
+
+@IBDesignable
+class ENAFooterView: UIVisualEffectView {
+	@IBInspectable var isTranslucent: Bool = true { didSet { updateBackground() } }
+
+	private var isSettingEffectInternally: Bool = false
+	override var effect: UIVisualEffect? {
+		didSet {
+			guard !isSettingEffectInternally else { return }
+			cachedEffect = effect
+			updateBackground()
+		}
+	}
+
+	private var cachedEffect: UIVisualEffect?
+
+	private var reducedTransparencyObserver: NSObjectProtocol?
+
+	convenience init() {
+		self.init(effect: nil)
+	}
+
+	required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		setup()
+	}
+
+	override init(effect: UIVisualEffect?) {
+		super.init(effect: effect)
+		setup()
+	}
+
+	private func setup () {
+		cachedEffect = effect
+		updateBackground()
+	}
+
+	private func updateBackground() {
+		isSettingEffectInternally = true
+		if isTranslucent && !UIAccessibility.isReduceTransparencyEnabled {
+			if effect != cachedEffect { effect = cachedEffect }
+			backgroundColor = nil
+		} else {
+			effect = nil
+			backgroundColor = .enaColor(for: .background)
+		}
+		isSettingEffectInternally = false
+	}
+
+	override func willMove(toSuperview newSuperview: UIView?) {
+		if nil == newSuperview, let observer = reducedTransparencyObserver {
+			NotificationCenter.default.removeObserver(observer, name: UIAccessibility.reduceTransparencyStatusDidChangeNotification, object: nil)
+		}
+	}
+
+	override func didMoveToSuperview() {
+		guard nil == reducedTransparencyObserver else { return }
+		reducedTransparencyObserver = NotificationCenter.default.addObserver(forName: UIAccessibility.reduceTransparencyStatusDidChangeNotification, object: nil, queue: nil, using: { [weak self] _ in
+			self?.updateBackground()
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the reduced transparency accessibility setting for footer views with buttons (used during onboarding, in the risk detail screen and the submission flow).

Basically the translucency of the footer view is replaced by the defined ENA background color.

|Normal Appearance|Reduced Transparency|
|:--|:--|
|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84449876-ef462680-ac4e-11ea-94a6-bd7be8579cd3.png">|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84449968-274d6980-ac4f-11ea-8e62-82e199fb22de.png">|

