### PR TITLE
Show Alert on exposure detection error

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -97,6 +97,13 @@
 
 "ExposureDetection_Button_Refresh" = "Aktualisieren";
 
+/* Exposure Detection Errors */
+"ExposureDetectionError_Alert_Title" = "Etwas ist schief gelaufen";
+
+"ExposureDetectionError_Alert_Action_Details" = "Details";
+
+"ExposureDetectionError_Alert_Message" = "Während der Risiko-Ermittlung ist ein Fehler aufgetreten.";
+
 /* Settings */
 "Settings_StatusActive" = "An";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -97,6 +97,13 @@
 
 "ExposureDetection_Button_Refresh" = "Update";
 
+/* Exposure Detection Errors */
+"ExposureDetectionError_Alert_Title" = "Something went wrong";
+
+"ExposureDetectionError_Alert_Action_Details" = "Details";
+
+"ExposureDetectionError_Alert_Message" = "An error occurred during risk calculation.";
+
 /* Settings */
 "Settings_StatusActive" = "On";
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
@@ -16,6 +16,7 @@
 // under the License.
 
 import Foundation
+import ExposureNotification
 
 extension ExposureDetection {
 	enum DidEndPrematurelyReason: Error {
@@ -30,5 +31,25 @@ extension ExposureDetection {
 		case noExposureConfiguration
 		/// Unable to write diagnosis keys
 		case unableToWriteDiagnosisKeys
+	}
+}
+
+extension ExposureDetection.DidEndPrematurelyReason: LocalizedError {
+	public var errorDescription: String? {
+		switch self {
+		case .noExposureManager:
+			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoExposureManager"
+		case .unableToWriteDiagnosisKeys:
+			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: DignosisKeys"
+		case .noSummary(let error):
+			guard let enError = error as? ENError else {
+				return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoSummary"
+			}
+			return AppStrings.ExposureDetectionError.errorAlertMessage + " EN Code: \(enError.code)"
+		case .noDaysAndHours:
+			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoDaysAndHours"
+		case .noExposureConfiguration:
+			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoExposureConfiguration"
+		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -233,6 +233,12 @@ enum AppStrings {
 		static let buttonRefresh = NSLocalizedString("ExposureDetection_Button_Refresh", comment: "")
 	}
 
+	enum ExposureDetectionError {
+		static let errorAlertTitle = NSLocalizedString("ExposureDetectionError_Alert_Title", comment: "")
+				static let errorAlertMessage = NSLocalizedString("ExposureDetectionError_Alert_Message", comment: "")
+		static let errorAlertActionDetails = NSLocalizedString("ExposureDetectionError_Alert_Action_Details", comment: "")
+	}
+
 	enum Settings {
 		static let trackingStatusActive = NSLocalizedString("Settings_KontaktProtokollStatusActive", comment: "")
 		static let trackingStatusInactive = NSLocalizedString("Settings_KontaktProtokollStatusInactive", comment: "")


### PR DESCRIPTION
## Description

For debugging & troubleshooting purposes it might be useful to receive an alert with a message & trace when exposure detection fails.

Not sure if this PR will be used yet, this is to be discussed. 
