### PR TITLE
[Feature] Globally disabled footer view translucency

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAFooterView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENAFooterView.swift
@@ -22,7 +22,7 @@ import UIKit
 
 @IBDesignable
 class ENAFooterView: UIVisualEffectView {
-	@IBInspectable var isTranslucent: Bool = true { didSet { updateBackground() } }
+	@IBInspectable var isTranslucent: Bool = false { didSet { updateBackground() } }
 
 	private var isSettingEffectInternally: Bool = false
 	override var effect: UIVisualEffect? {


### PR DESCRIPTION
This PR globally disables the footer view translucency as seen during onboarding, in the risk detail screen and the submission flow.