### PR TITLE
[Feature] Add confirm dialog before resetting the app

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -787,6 +787,14 @@
 
 "Reset_ImageDescription" = "Eine Hand hält ein Smartphone, auf dem das Zurücksetzen der Anwendung symbolisiert wird.";
 
+"Reset_ConfirmDialog_Title" = "Anwendung zurücksetzen";
+
+"Reset_ConfirmDialog_Description" = "Sie werden nicht mehr über Ihre Risiko-Begegnungen informiert und können andere Nutzerinnen und Nutzer nicht mehr warnen. Dieser Vorgang kann nicht rückgängig gemacht werden.";
+
+"Reset_ConfirmDialog_Cancel"  = "Abbrechen";
+
+"Reset_ConfirmDialog_Confirm" = "Zurücksetzen";
+
 /* Safari */
 "safari_corona_website" = "https://www.bundesregierung.de/corona-warn-app-faq";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -787,6 +787,14 @@
 
 "Reset_ImageDescription" = "One person is holding a device displaying a symbol indicating that the app is being reset.";
 
+"Reset_ConfirmDialog_Title" = "Reset App";
+
+"Reset_ConfirmDialog_Description" = "You will no longer be notified of your exposures and you will no longer be able to warn other users. This procedure cannot be undone.";
+
+"Reset_ConfirmDialog_Cancel"  = "Cancel";
+
+"Reset_ConfirmDialog_Confirm" = "Reset";
+
 /* Safari */
 "safari_corona_website" = "https://www.bundesregierung.de/corona-warn-app-faq";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/ResetViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/ResetViewController.swift
@@ -38,8 +38,30 @@ final class ResetViewController: UIViewController {
 	weak var delegate: ResetDelegate?
 
 	@IBAction func resetData(_: Any) {
-		delegate?.reset()
-		dismiss(animated: true, completion: nil)
+		let alertController = UIAlertController(
+			title: AppStrings.Reset.confirmDialogTitle,
+			message: AppStrings.Reset.confirmDialogDescription,
+			preferredStyle: .alert
+		)
+
+		let delete = UIAlertAction(
+			title: AppStrings.Reset.confirmDialogConfirm,
+			style: .destructive,
+			handler: { _ in
+				self.delegate?.reset()
+				self.dismiss(animated: true, completion: nil)
+			}
+		)
+
+		let cancel = UIAlertAction(
+			title: AppStrings.Reset.confirmDialogCancel,
+			style: .cancel
+		)
+
+		alertController.addAction(delete)
+		alertController.addAction(cancel)
+
+		present(alertController, animated: true, completion: nil)
 	}
 
 	override func viewDidLoad() {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -470,6 +470,11 @@ enum AppStrings {
 		static let infoDescription = NSLocalizedString("Reset_InfoDescription", comment: "")
 		static let subtitle = NSLocalizedString("Reset_Subtitle", comment: "")
 		static let imageDescription = NSLocalizedString("Reset_ImageDescription", comment: "")
+
+		static let confirmDialogTitle = NSLocalizedString("Reset_ConfirmDialog_Title", comment: "")
+		static let confirmDialogDescription = NSLocalizedString("Reset_ConfirmDialog_Description", comment: "")
+		static let confirmDialogCancel = NSLocalizedString("Reset_ConfirmDialog_Cancel", comment: "")
+		static let confirmDialogConfirm = NSLocalizedString("Reset_ConfirmDialog_Confirm", comment: "")
 	}
 
 	enum SafariView {


### PR DESCRIPTION
This PR adds a confirm dialog before resetting the app.

Localizations both for English and German are included in this PR and are signed off by Karina.

<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84517860-214b9d00-acd0-11ea-9bc8-df49038085f7.png">
