### PR TITLE
[Localization] Important updates to terms of use and data privacy

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -740,7 +740,7 @@
 "App_Information_Legal_Navigation" = "Rechtliche Hinweise";
 
 /* App Information - Privacy */
-"App_Information_Privacy_Navigation" = "Datenschutzinformation";
+"App_Information_Privacy_Navigation" = "Datenschutz";
 
 "App_Information_Legal_ImageDescription" = "Eine Hand hält ein Smartphone mit viel Text, daneben ist eine Balkenwaage als Symbol für rechtliche Hinweise.";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -377,19 +377,19 @@
 
 				<ul>
 					<li>
-						<p>Internet</p>
+						<p>Internet<br></p>
 						<p>Die App benötigt für die Funktionen Risiko-Ermittlung, Testergebnisse erhalten und Testergebnis übermitteln eine Internetverbindung, um mit den Serversystemen der App kommunizieren zu können.</p>
 					</li>
 					<li>
-						<p>Bluetooth</p>
+						<p>Bluetooth<br></p>
 						<p>Die Bluetooth-Schnittstelle Ihres Smartphones muss aktiviert sein, damit Ihr Smartphone Zufalls-IDs von anderen Smartphones erfassen und im Kontaktprotokoll des Geräts speichern kann.</p>
 					</li>
 					<li>
-						<p>Kamera</p>
+						<p>Kamera<br></p>
 						<p>Ihr Smartphone benötigt eine Kamera, um damit einen QR-Code im Rahmen der Testregistrierung scannen können.</p>
 					</li>
 					<li>
-						<p>Hintergrundbetrieb</p>
+						<p>Hintergrundbetrieb<br></p>
 						<p>Die App nutzt den Hintergrundbetrieb (also wenn Sie die App nicht gerade aktiv nutzen), um Ihr Risiko automatisch zu ermitteln und den Status eines registrierten Tests abfragen zu können. Wenn Sie den Hintergrundbetrieb im Betriebssystem Ihres Smartphones deaktivieren, müssen Sie alle Aktionen in der App selbst starten.</p>
 					</li>
 				</ul>
@@ -402,15 +402,15 @@
 
 				<ul>
 					<li>
-						<p>Benachrichtigungen zu möglicher Begegnung mit COVID-19-Infizierten</p>
+						<p>Benachrichtigungen zu möglicher Begegnung mit COVID-19-Infizierten<br></p>
 						<p>Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.</p>
 					</li>
 					<li>
-						<p>Standortermittlung</p>
+						<p>Standortermittlung<br></p>
 						<p>Die Standortermittlung Ihres Smartphones muss aktiviert sein, damit Ihr Gerät nach Bluetooth-Signalen anderer Smartphones sucht. Standortdaten werden dabei jedoch nicht erhoben.</p>
 					</li>
 					<li>
-						<p>Benachrichtigung</p>
+						<p>Benachrichtigung<br></p>
 						<p>Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Die dafür notwendige Benachrichtigungsfunktion ist im Betriebssystem bereits aktiviert.</p>
 					</li>
 				</ul>
@@ -419,7 +419,7 @@
 
 				<ul>
 					<li>
-						<p>Kamera</p>
+						<p>Kamera<br></p>
 						<p>Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR-Code auslesen zu können.</p>
 					</li>
 				</ul>
@@ -432,11 +432,11 @@
 
 				<ul>
 					<li>
-						<p>COVID-19-Kontaktprotokoll</p>
+						<p>COVID-19-Kontaktprotokoll<br></p>
 						<p>Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.</p>
 					</li>
 					<li>
-						<p>Mitteilungen</p>
+						<p>Mitteilungen<br></p>
 						<p>Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Mitteilungen müssen dafür aktiviert sein.</p>
 					</li>
 				</ul>
@@ -445,7 +445,7 @@
 
 				<ul>
 					<li>
-						<p>Kamera</p>
+						<p>Kamera<br></p>
 						<p>Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR-Code auslesen zu können.</p>
 					</li>
 				</ul>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -199,7 +199,7 @@
 			<h2>1. Wer stellt Ihnen diese App zur Verfügung?</h2>
 			<p>Der Anbieter der Corona-Warn-App (im Folgenden die „<strong>App</strong>“) ist das Robert Koch-Institut, Nordufer 20, 13353 Berlin (im Folgenden „<strong>RKI</strong>“).</p>
 			<p>Das RKI ist auch der datenschutzrechtlich Verantwortliche für die Verarbeitung von personenbezogenen Daten der App-Nutzer.</p>
-			<p>Den Datenschutzbeauftragten des RKI erreichen Sie unter der oben genannten Anschrift (zu Händen „Behördlicher Datenschutzbeauftragter“) und per E-Mail an: datenschutz@rki.de).</p>
+			<p>Den Datenschutzbeauftragten des RKI erreichen Sie unter der oben genannten Anschrift (zu Händen „Behördlicher Datenschutzbeauftragter“) und per E-Mail an: datenschutz@rki.de.</p>
 		</section>
 		<p>&nbsp;</p>
 
@@ -473,7 +473,7 @@
 				<h3>b. Test registrieren</h3>
 				<ul>
 					<li>Die gehashte Kennzahl wird auf dem Serversystem der App nach 21 Tagen gelöscht.</li>
-					<li>Die gehashte Kennzahl und das Testergebnis in der Testergebnis-Datenbank werden im Fall eines negativen Testergebnisses unmittelbar nach dem Abruf des Testergebnisses und im Fall eines positiven Testergebnissen unmittelbar nach dem Löschen der auf Serversystem gespeicherten Kopie der TAN gelöscht (s.u.).</li>
+					<li>Die gehashte Kennzahl und das Testergebnis in der Testergebnis-Datenbank werden im Fall eines negativen Testergebnisses unmittelbar nach dem Abruf des Testergebnisses und im Fall eines positiven Testergebnissen unmittelbar nach dem Löschen der auf Serversystem gespeicherten Kopie der TAN gelöscht (s. u.).</li>
 					<li>Das Token, das auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
 					<li>Das Token, das in der App gespeichert ist, wird nach Löschung der App vom Smartphone oder nach Ausführung der Funktion „Testergebnis teilen“ gelöscht.</li>
 				</ul>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -169,7 +169,7 @@
 			</style>
 	</head>
 
-	<body class="browser">
+	<body>
 
 
 		<!-- Templates -->
@@ -186,7 +186,7 @@
 		<!-- Updated: 13.06.20 -->
 
 
-		<!-- Preambel -->
+		<!-- Präambel -->
 		<section>
 			<p>In dieser Datenschutzerklärung erfahren Sie, welche Daten bei der Nutzung der Corona-Warn-App erhoben werden, wie sie verwendet werden und welche Datenschutzrechte Sie haben.</p>
 			<p>Damit diese Datenschutzerklärung für alle Nutzer verständlich ist, bemühen wir uns um eine einfache und möglichst untechnische Darstellung.</p>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -17,6 +17,11 @@
 			}
 
 
+			a {
+				text-decoration: underline;
+			}
+
+
 			a[href] {
 				color: var(--ena-text-tint-color);
 			}
@@ -41,6 +46,11 @@
 			}
 
 
+			section {
+				margin-bottom: 3rem;
+			}
+
+
 			h1 {
 				/*font-size: 28px;*/
 				font-size: 1.6470588235rem;
@@ -59,6 +69,22 @@
 				/*font-size: 17px;*/
 				font-size: 1.0rem;
 				font-weight: 600;
+			}
+
+
+			h4 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: 600;
+				font-style: italic;
+			}
+
+
+			h5 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: normal;
+				text-decoration: underline;
 			}
 
 
@@ -83,13 +109,13 @@
 			}
 
 
-			ul {
-				list-style-type: disc;
+			li {
+				text-indent: 2em;
 			}
 
 
-			li {
-				text-indent: 2em;
+			ul > ul li {
+				text-indent: 4em;
 			}
 
 
@@ -108,235 +134,415 @@
 			}
 
 
+			h4 {
+				margin-bottom: 1rem;
+			}
+
+
+			h5 {
+				margin-bottom: 1rem;
+			}
+
+
 			p, ul, li {
 				margin-bottom: 1rem;
 			}
 
-				</style>
-			</head>
 
-	<body>
+			body.browser {
+				padding: 3rem;
+				width: 38.5rem;
+				margin: 0 auto;
+			}
 
-		<!--<h1>Datenschutzerklärung</h1>-->
 
-		<!--<h1>Corona-Warn-App</h1>-->
+			body.browser,
+			body.browser,
+			body.browser table {
+				font-family: "Times New Roman", serif !important;
+			}
 
-		<p>In dieser Datenschutzerklärung erfahren Sie, welche Daten bei der Nutzung der Corona- Warn-App erhoben werden, wie sie verwendet werden und welche Datenschutzrechte Sie haben.</p>
-		<p>Damit diese Datenschutzerklärung für alle Nutzer verständlich ist, bemühen wir uns um eine einfache und möglichst untechnische Darstellung.</p>
-		<h2>1. Wer stellt Ihnen diese App zur Verfügung?</h2>
-		<p>Der Anbieter der Corona-Warn-App (im Folgenden die <b>„App“</b>) ist das Robert Koch-Institut, Nordufer 20, 13353 Berlin (im Folgenden <b>„RKI“</b>).</p>
-		<p>Das RKI ist auch der datenschutzrechtlich Verantwortliche für die Verarbeitung von personenbezogenen Daten der App-Nutzer.</p>
-		<p>Den Datenschutzbeauftragten des RKI erreichen Sie unter der oben genannten Anschrift (zu Händen <b>„Behördlicher Datenschutzbeauftragter“</b>) und per E-Mail an: datenschutz@rki.de).</p>
-		<h2>2. Ist die Nutzung der App freiwillig?</h2>
-		<p>Die Benutzung der App basiert ausschließlich auf Freiwilligkeit. Es ist daher allein Ihre Entscheidung, ob und wie Sie die App nutzen.</p>
-		<p>Auch wenn die Installation und die Benutzung der App freiwillig sind, müssen Sie nach dem erstmaligen Aufruf der App gegenüber dem RKI durch Antippen des Buttons <b>„Risiko- Ermittlung aktivieren“</b> zustimmen, dass die App im Rahmen der Risiko-Ermittlung Ihre personenbezogenen Daten verarbeiten darf. Falls die App dabei ein Infektionsrisiko für Sie ermittelt, stellen Ihre Daten auch Gesundheitsdaten dar. Ihre Zustimmung ist erforderlich, da andernfalls die App nicht auf die Kontaktaufzeichnungs-Funktion Ihres Smartphones zugreifen kann. Sie können die Risiko-Ermittlung jedoch jederzeit über den Schieberegler innerhalb der App deaktivieren. In diesem Fall stehen Ihnen nicht alle Funktionen der App zur Verfügung. Gesonderte Einwilligungen sind darüber hinaus für die Datenverarbeitung der folgenden Funktionen erforderlich:</p>
-		<ul>
-			<li>Test registrieren (siehe Ziffer 6 b.)</li>
-			<li>Testergebnis teilen (siehe Ziffer 6 c.)</li>
-		</ul>
-		<p>Die Datenverarbeitung im Rahmen dieser Funktionen wird in den folgenden Abschnitten näher beschrieben.</p>
-		<h2>3. Auf welcher Rechtsgrundlage werden Ihre Daten verarbeitet?</h2>
-		<p>Das RKI verarbeitet Ihre personenbezogenen Daten grundsätzlich nur auf Grundlage einer von Ihnen erteilten Einwilligung nach Artikel 6 Absatz 1 Satz 1 Buchstabe a und Artikel 9 Absatz 2 Buchstabe a der Datenschutzgrundverordnung (DSGVO). Sie können eine von Ihnen erteilte Einwilligung jederzeit widerrufen. Weitere Informationen zu Ihrem Widerrufsrecht und Hinweise, wie Sie dieses ausüben können, finden Sie unter Ziffer 11.</p>
-		<h2>4. An wen richtet sich die App?</h2>
-		<p>Die App richtet sich an Personen, die sich in Deutschland aufhalten und mindestens 16 Jahre alt sind.</p>
-		<h2>5. Welche personenbezogenen Daten werden verarbeitet?</h2>
-		<p>Die App ist so konzipiert, dass so wenig personenbezogene Daten wie möglich verarbeitet werden. Das bedeutet zum Beispiel, dass die App keine Daten erfasst, die es dem RKI oder anderen Nutzern ermöglichen, auf Ihre Identität, Ihren Gesundheitsstatus oder Ihren Standort zu schließen. Zudem verzichtet die App bewusst auf jegliche Erfassung oder Analyse Ihres Nutzungsverhaltens durch Tracking-Tools.</p>
-		<p>Die von der App verarbeiteten Daten lassen sich den folgenden Kategorien zuordnen:</p>
 
-		<h3>a. Zugriffsdaten</h3>
-		<p>Zugriffsdaten fallen an, wenn Sie die folgenden Funktionen nutzen bzw. aktivieren:</p>
-		<ul>
-			<li>Risiko-Ermittlung</li>
-			<li>Test registrieren</li>
-			<li>Testergebnis teilen</li>
-		</ul>
-		<p>Bei jedem Abruf von Daten vom Serversystem der App wird Ihre IP-Adresse (auf dem vorgelagerten Load Balancer) maskiert und im Weiteren nicht mehr innerhalb des Serversystems der App verarbeitet.</p>
-		<p>Zusätzlich werden folgende Daten verarbeitet:</p>
-		<ul>
-			<li>Datum und Uhrzeit des Abrufs (Zeitstempel)</li>
-			<li>übertragene Datenmenge (bzw. Paketlänge)</li>
-			<li>Meldung über erfolgreichen Abruf</li>
-		</ul>
-		<p>Diese Zugriffsdaten werden nur zur Sicherung und Aufrechterhaltung der technischen Infrastruktur verarbeitet. Sie werden dabei nicht als Nutzer der App persönlich identifiziert und es kann kein Nutzungsprofil erstellt werden. Eine Speicherung der IP-Adresse über das Ende des Nutzungsvorgangs hinaus erfolgt nicht.</p>
-		<h3>b. Begegnungsdaten</h3>
-		<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes zu bezeichnet (im Folgenden: <b>„Zufalls-IDs“</b>), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen</p>
+			body.browser p {
+				text-align: justify;
+			}
+			</style>
+	</head>
 
-		<p>Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
-		<ul>
-			<li>Datum und Zeitpunkt des Kontakts</li>
-			<li>Dauer des Kontakts</li>
-			<li>Bluetooth-Signalstärke des Kontakts</li>
-			<li>Verschlüsselte Metadaten (Protokollversion und Sendestärke).</li>
-		</ul>
-		<p>Die eigenen und von anderen Smartphones empfangenen Zufalls-IDs und die weiteren Begegnungsdaten (Datum und Zeitpunkt des Kontakts, Dauer des Kontakts, Signalstärke des Kontakts und verschlüsselte Metadaten) werden von Ihrem Smartphone in einem Kontaktprotokoll der Kontaktaufzeichnungs-Funktion erfasst und dort zurzeit für 14 Tage gespeichert.</p>
-		<p>Die Kontaktaufzeichnungs-Funktion heißt bei Android-Smartphones "Benachrichtigungen zu möglicher Begegnung mit Infizierten" und bei iPhones „COVID-19-Kontaktprotokoll“. Wir weisen Sie darauf hin, dass diese Kontaktaufzeichnungs-Funktionen kein Bestandteil der App, sondern ein integraler Bestandteil des Betriebssystems Ihres Smartphones sind. Die Kontaktaufzeichnungs-Funktion wird Ihnen daher von Apple (iPhones) bzw. Google (Android- Smartphones) bereitgestellt und unterliegt dementsprechend den Datenschutzbestimmungen dieser Unternehmen. Die betriebssystemseitige Datenverarbeitung im Rahmen der Kontaktaufzeichnungs-Funktion liegt außerhalb des Einflussbereichs des RKI.</p>
-		<p>Weitere Informationen zu der Kontaktaufzeichnungs-Funktion von Android-Smartphones finden Sie unter: https://support.google.com/android/answer/9888358?hl=de.</p>
-		<p>Weitere Informationen zu der Kontaktaufzeichnungs-Funktion von Apple finden Sie in den Einstellungen Ihres iPhones unter "Datenschutz“ > „Health" > „COVID-19-Kontaktprotokoll“. Bitte beachten Sie: Die Kontaktaufzeichnungs-Funktion steht Ihnen nur zur Verfügung, wenn auf Ihrem iPhone das Betriebssystem iOS ab Version 13.5 installiert ist.</p>
-		<p>Die vom Smartphone erzeugten und gespeicherten Begegnungsdaten werden von der App nur verarbeitet, wenn die Risiko-Ermittlung aktiviert ist.</p>
-		<h3>a. Gesundheitsdaten</h3>
-		<p>Gesundheitsdaten sind alle Daten, die Informationen zum Gesundheitszustand einer bestimmten Person enthalten. Dazu gehören nicht nur Angaben zu früheren und aktuellen Krankheiten, sondern auch zu Krankheitsrisiken einer Person (z. B. das Risiko, dass eine Person sich mit dem Corona-Virus infiziert hat).</p>
-		<p>In den folgenden Fällen handelt es sich um eine Verarbeitung von Gesundheitsdaten:</p>
-		<ul>
-			<li>Wenn die Risiko-Ermittlung erkennt, dass Sie möglicherweise Kontakt zu einer Person hatten, die sich mit dem Corona-Virus infiziert hat.</li>
-			<li>Wenn Sie einen Test registrieren.</li>
-			<li>Wenn Sie ein positives Testergebnis teilen.</li>
-		</ul>
+	<body class="browser">
 
-		<h2>6. Funktionen der App a. Risiko-Ermittlung</h2>
-		<p>Die Risiko-Ermittlung ist die Kernfunktion der App. Sie dient dazu, mögliche Kontakte zu mit dem Corona-Virus infizierten anderen Nutzern der App nachzuverfolgen, das infolge für Sie bestehende Infektionsrisiko zu bewerten und Ihnen, basierend auf dem für Sie ermittelten Risikowert, Verhaltens- und Gesundheitshinweise bereitzustellen.</p>
-		<p>Wenn Sie die Risiko-Ermittlung aktivieren, ruft die App von den Serversystemen der App im Hintergrundbetrieb mehrmals täglich (oder wenn Sie auf „Aktualisieren“ tippen) eine Liste mit Zufalls-IDs von Nutzern ab, die positiv getestet wurden und Ihre eigenen Zufalls-IDs geteilt haben. Die App gibt die Zufalls-IDs an die Kontaktaufzeichnungs-Funktion Ihres Smartphones weiter, welche diese dann mit den im Kontaktprotokoll Ihres Smartphones gespeicherten Zufalls-IDs abgleicht. Wenn die Kontaktaufzeichnungs-Funktion Ihres Smartphones eine Übereinstimmung feststellt, übergibt sie der App die Begegnungsdaten (Datum, Dauer, Signalstärke), nicht jedoch die Zufalls-ID des betreffenden Kontakts.</p>
-		<p>Im Fall eines Kontakts werden die von der Kontaktaufzeichnungs-Funktion übergebenen Begegnungsdaten von der App analysiert, um Ihr individuelles Infektionsrisiko zu ermitteln. Der Bewertungsalgorithmus, der festlegt, wie die Begegnungsdaten interpretiert werden (z. B. welchen Einfluss die Dauer eines Kontakts auf das Infektionsrisiko hat) basiert auf den aktuellen wissenschaftlichen Erkenntnissen. Bei neuen Erkenntnissen kann der Bewertungsalgorithmus daher durch das RKI aktualisiert werden, indem die Einstellungen für den Bewertungsalgorithmus neu gesetzt werden. Die Einstellungen für den Bewertungsalgorithmus werden dann zusammen mit der Liste der Zufalls-IDs infizierter Personen an die App übermittelt.</p>
-		<p>Die Ermittlung des Infektionsrisikos findet ausschließlich lokal auf Ihrem Smartphone statt, das heißt die Daten werden offline verarbeitet. Das ermittelte Infektionsrisiko wird ebenfalls ausschließlich in der App gespeichert und an keine anderen Empfänger (auch nicht an das RKI, Apple, Google und sonstige Dritte) weitergegeben.</p>
-		<p>Rechtsgrundlage der oben beschriebenen Verarbeitung Ihrer Zugriffsdaten, Begegnungsdaten und ggf. Gesundheitsdaten (sofern für Sie ein Infektionsrisiko ermittelt wird) ist Ihre Einwilligung, die Sie bei der Aktivierung der Risiko-Ermittlung erteilt haben.</p>
-		<h3>b. Test registrieren</h3>
-		<p>Wenn Sie auf eine Infektion mit dem Corona-Virus getestet wurden, können Sie den Test in der App registrieren, indem Sie den QR-Code, den Sie von Ihrem Arzt bzw. der Testeinrichtung erhalten haben, in der App einscannen. Die App informiert Sie dann, sobald das Testergebnis des Labors vorliegt.</p>
-		<p>Dies setzt voraus, dass das Testlabor an das Serversystem der App angeschlossen ist und Sie im Rahmen der Testdurchführung gesondert in die Übermittlung Ihres Testergebnisses durch das Labor an das Serversystem der App (Testergebnis-Datenbank) eingewilligt haben. Testergebnisse von Laboren, die nicht an das Serversystem der App angeschlossen sind, können nicht in der App angezeigt werden. Wenn Sie keinen QR-Code erhalten haben, ist das Testlabor nicht angeschlossen. In diesem Fall können Sie diese Funktion nicht nutzen.</p>
-		<p><u>Testregistrierung</u></p>
-		<p>Damit Sie das Testergebnis in der App erhalten können, müssen Sie den durchgeführten Test zunächst in der App registrieren. Hierzu erhalten Sie von Ihrem Arzt bzw. der Testeinrichtung im Rahmen der Probenentnahme einen QR-Code. Dieser QR-Code enthält eine Kennzahl, die mit einem QR-Code-Scanner ausgelesen werden kann. Zur Testregistrierung müssen Sie den QR-Code in der App mit der Kamera Ihres Smartphones scannen.</p>
-		<p>Die aus dem QR-Code ausgelesene Kennzahl wird von der App dann gehasht, das bedeutet, die Kennzahl wird nach einem bestimmten mathematischen Verfahren so verfremdet, dass die dahinterstehende Kennzahl nicht mehr erkennbar ist. Sobald Ihr Smartphone eine Verbindung zum Internet hat, wird die App die gehashte Kennzahl an die Serversysteme der App übermitteln. Im Gegenzug erhält die App vom Serversystem einen Token, also einen digitalen Zugangsschlüssel, der in der App gespeichert wird. Das Token ist auf dem Serversystem mit der gehashten Kennzahl verknüpft. Die App löscht dann die auf Ihrem Smartphone gehashte Kennzahl. Das Serversystem wird für jede gehashte Kennzahl nur ein einziges Mal einen Token vergeben. Auf diese Weise wird sichergestellt, dass Ihr QR-Code nicht von anderen Nutzern der App für die Abfrage von Testergebnissen verwendet werden kann.</p>
-		<p>Die Registrierung Ihres Tests ist damit abgeschlossen.</p>
-		<p><u>Hinterlegung des Testergebnisses</u></p>
-		<p>Sobald dem Testlabor das Testergebnis vorliegt, hinterlegt es das Ergebnis unter Angabe der gehashten Kennzahl in der vom RKI betriebenen Testergebnis-Datenbank. Die Testergebnis- Datenbank wird vom RKI auf einem speziellen Server innerhalb des Serversystems der App betrieben. Das Testlabor erzeugt die gehashte Kennzahl ebenfalls auf Basis der an Sie im ausgegebenen QR-Code enthaltenen Kennzahl unter Verwendung des gleichen mathematischen Verfahrens, das auch die App einsetzt.</p>
-		<p><u>Abruf des Testergebnisses</u></p>
-		<p>Die App fragt bei dem Serversystem der App unter Verwendung des Tokens regelmäßig den Status des registrierten Tests ab. Das Serversystem ordnet das Token dann der gehashten Kennzahl zu und übermittelt diese an die Testergebnis-Datenbank. Ist das Testergebnis dort mittlerweile abgelegt, sendet die Testergebnis-Datenbank das Testergebnis an das Serversystem zurück, der dieses ohne Kenntnisnahme des Inhalts an die App weiterleitet. Im Fall eines positiven Testergebnis fordert die App beim Serversystem unter erneuter Verwendung des Tokens eine TAN (Transaktionsnummer) an. Das Serversystem ordnet das Token wieder der gehashten Kennzahl zu und fordert von der Testergebnis-Datenbank eine Bestätigung an, dass zu der gehashten Kennzahl ein positives Testergebnis vorliegt. Sofern die Testergebnis-Datenbank dies bestätigt, erzeugt das Serversystem die TAN und übermittelt sie an die App. Eine Kopie der TAN verbleibt auf dem Serversystem.</p>
-		<p>Die TAN wird benötigt, um im Fall einer Übermittlung des positiven Testergebnisses sicherzustellen, dass keine falschen Informationen an andere Nutzer verteilt werden. Rechtsgrundlage der oben beschriebenen Verarbeitung der zuvor genannten Daten ist Ihre Einwilligung für die Funktion „Test registrieren“.</p>
-		<h3>c. Testergebnisteilen</h3>
-		<p>Wenn Sie die Funktion „Testergebnis teilen“ nutzen um andere Nutzer zu warnen, überträgt die App die von Ihrem Smartphone gespeicherten eigenen Zufalls-IDs der letzten 14 Tage und die TAN an das Serversystem der App. Dieses prüft zunächst, ob die TAN gültig ist und trägt Ihre Zufalls-IDs sodann in die Liste der Zufalls-IDs von Nutzern, die ihr positives Testergebnis geteilt haben, ein. Ihre Zufalls-IDs können nun von anderen Nutzern im Rahmen der Risiko-Ermittlung heruntergeladen werden.</p>
-		<p><u>Wenn Sie Ihr Testergebnis nicht in der App abgerufen haben:</u></p>
-		<p>Auch wenn Sie ein positives Testergebnis nicht in der App abgerufen haben, können Sie das Testergebnis per App teilen, um andere Nutzer zu warnen. In diesem Fall fordert Sie die App zur Eingabe einer sogenannten TeleTAN auf, die als TAN fungiert.</p>
-		<p>Für den Erhalt der TeleTAN können Sie die Hotline der Corona-Warn-App unter der Nummer +49 (0)800 7540002 anrufen. Der dort für Sie zuständige Ansprechpartner wird Ihnen zunächst am Telefon einige Fragen stellen, um die Plausibilität Ihres Anrufs zu überprüfen. Diese Fragen dienen der Vorbeugung einer missbräuchlichen Infektionsmeldung und daraus resultierender fehlerhafter Warnungen und Risikowerte. Nach ausreichender Beantwortung dieser Fragen werden Sie nach Ihrer Handy-/Telefonnummer gefragt. Dies dient dazu, Sie später zurückrufen zu können, um Ihnen eine TeleTAN zur Eingabe in der App mitzuteilen. Ihre Handy-/Telefonnummer wird nur zu diesem Zweck vorübergehend gespeichert und spätestens innerhalb einer Stunde gelöscht.</p>
-		<p>Nach Ihrem Anruf wird der Hotline-Mitarbeiter über einen speziellen Zugang zum Serversystem der App eine TeleTAN generieren und Sie sodann anrufen, um Ihnen die TeleTAN mitzuteilen. Wenn Sie die TeleTAN in der App eingeben, wird die TeleTAN von der App zum Abgleich und Verifizierung an das Serversystem der App zurückgesendet. Im Gegenzug erhält die App vom Serversystem einen Token, also einen digitalen Zugangsschlüssel, der in der App gespeichert wird. Mit diesem Token fordert die App beim Serversystem dann eine TAN an.</p>
-		<p>Rechtsgrundlage dieser Verarbeitung Ihrer Zugriffsdaten und Gesundheitsdaten (Zufalls-IDs, Testergebnis, TAN und ggf. TeleTAN) ist Ihre Einwilligung für die Funktion „Testergebnis teilen“.</p>
-		<h3>d. Informatorische Nutzung der App</h3>
-		<p>Soweit Sie die App nur informatorisch nutzen, also keine der oben genannten Funktionen der App verwenden und keine Daten eingeben, findet die Verarbeitung ausschließlich lokal auf Ihrem Smartphone statt und es fallen keine personenbezogenen Daten an. In der App verlinkte Webseiten z.B.: <u>www.bundesregierung.de</u> werden im Standard-Browser Ihres Smartphones geöffnet und angezeigt. Welche Daten dabei verarbeitet werden hängt von dem genutzten Browser, dessen Konfiguration sowie der Datenverarbeitungspraxis der aufgerufenen Webseite ab.</p>
-		<h2>7. Welche Berechtigungen und Funktionen benötigt die App?</h2>
-		<p>Die App benötigt Zugriff auf verschiedene Funktionen und Schnittstellen Ihres Smartphones. Dazu ist es erforderlich, dass Sie der App bestimmte Berechtigungen erteilen. Die Berechtigungen sind von den verschiedenen Herstellern unterschiedlich programmiert. So können z. B. Einzelberechtigungen zu Berechtigungskategorien zusammengefasst sein, wobei Sie der Berechtigungskategorie nur insgesamt zustimmen können. Bitte beachten Sie, dass Sie im Falle der Ablehnung eines Zugriffs durch die App keine oder nur wenige Funktionen der App nutzen können.</p>
 
-		<h3>a. Technische Voraussetzungen (alle Smartphones)</h3>
-		<ul>
-			<li>Internet<br/>
-				Die App benötigt für die Funktionen Risiko-Ermittlung, Testergebnisse erhalten und Testergebnis übermitteln eine Internetverbindung, um mit den Serversystemen der App kommunizieren zu können.
-			</li>
-		</ul>
-		<ul>
-			<li>Bluetooth<br/>
-				Die Bluetooth-Schnittstelle Ihres Smartphones muss aktiviert sein, damit Ihr Smartphone Zufalls-IDs von anderen Smartphones erfassen und im Kontaktprotokoll des Geräts speichern kann.
-			</li>
-		</ul>
-		<ul>
-			<li>Kamera<br/>
-				Ihr Smartphone benötigt eine Kamera, um damit einen QR-Code im Rahmen der Testregistrierung scannen können.
-			</li>
-		</ul>
-		
-		<ul>
-			<li>Hintergrundbetrieb<br/>
-				Die App nutzt den Hintergrundbetrieb (also wenn Sie die App nicht gerade aktiv nutzen), um Ihr Risiko automatisch zu ermitteln und den Status eines registrierten Tests abfragen zu können. Wenn Sie den Hintergrundbetrieb im Betriebssystem Ihres Smartphones deaktivieren, müssen Sie alle Aktionen in der App selbst starten.
-			</li>
-		</ul>
-		
-		<h3>b. Android-Smartphones</h3>
-		<p>Wenn Sie ein Android-Gerät verwenden, müssen außerdem folgende Systemfunktionen aktiviert sein:</p>
-		<ul>
-			<li>Benachrichtigungen zu möglicher Begegnung mit COVID-19-Infizierten<br/>
-			Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.
-		</li>
-		</ul>
-		<ul>
-			<li>Standortermittlung<br/>
-			Die Standortermittlung Ihres Smartphones muss aktiviert sein, damit Ihr Gerät nach Bluetooth-Signalen anderer Smartphones sucht. Standortdaten werden dabei jedoch nicht erhoben.
-		</li>
-		</ul>
-		<ul>
-			<li>Benachrichtigung<br/>
-			Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Die dafür notwendige Benachrichtigungsfunktion ist im Betriebssystem bereits aktiviert.
-		</li>
-		</ul>
-		<p>Daneben benötigt die App folgende Berechtigungen:</p>
-		<ul>
-			<li>Kamera<br/>
-			Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR- Code auslesen zu können.
-		</li>
-		</ul>
+		<!-- Templates -->
 
-		<h3>c. iPhones(AppleiOS)</h3>
-		<p>Wenn Sie ein iPhone verwenden, müssen folgende Systemfunktionen aktiviert sein:</p>
-		<ul>
-			<li>COVID-19-Kontaktprotokoll<br/>
-			Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.
-		</li>
-		</ul>
-		<ul>
-			<li>Mitteilungen<br/>
-			Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Mitteilungen müssen dafür aktiviert sein.
-		</li>
-		</ul>
-		<p>Die App benötigt zudem folgende Berechtigungen:</p>
-		<ul>
-			<li>Kamera<br/>
-			Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR-Code auslesen zu können.
-		</li>
-		</ul>
+		<!--<h1>Title 1</h1>-->
+		<!--<h2>Title 2</h2>-->
+		<!--<h3>Headline</h3>-->
+		<!--<p>Body</p>-->
+		<!--<span>Subheadline</span>-->
+		<!--<aside>Footnote</aside>-->
 
-		<h2>8. Wann werden die Daten gelöscht?</h2>
-		<p>Alle in der App gespeicherten Daten werden gelöscht, sobald sie für die Funktionen der App nicht mehr benötigt werden:</p>
-		<h3>a. Risiko-Ermittlung</h3>
 
-		<ul>
-			<li>Die Liste der Zufalls-IDs von Nutzern, die ein positives Testergebnis geteilt haben, wird in der App unverzüglich und im Übrigen im Kontaktprotokoll Ihres Smartphones nach 14 Tagen automatisch gelöscht.</li>
-			<li>Auf die Löschung der Begegnungsdaten im Kontaktprotokoll Ihres Smartphones (einschließlich Ihrer eigenen Zufalls-IDs) und die Begegnungsdaten auf anderen Smartphones hat das RKI keinen Einfluss, da diese Funktion von Apple bzw. Google bereitgestellt werden. Die Löschung richtet sich nach den Festlegungen von Apple bzw. Google. Zurzeit werden die Daten nach 14 Tagen automatisch gelöscht. Zudem können Sie im Rahmen der von Apple und Google bereitgestellten Funktionalitäten in den Systemeinstellungen Ihres Geräts gegebenenfalls eine manuelle Löschung anstoßen.</li>
-			<li>Der in der App angezeigte Risikowert wird gelöscht, sobald ein neuer Risikowert ermittelt worden ist. Ein neuer Risikowert wird in der Regel ermittelt, nachdem die App eine neue Liste mit Zufalls-IDs erhalten hat.</li>
-		</ul>
+		<!-- Document: "CWA Privacy Notice DE.docx" -->
+		<!-- Updated: 13.06.20 -->
 
-		<h3>b. Test registrieren</h3>
 
-		<ul>
-			<li>Die gehashte Kennzahl wird auf dem Serversystem der App nach 21 Tagen gelöscht.</li>
-			<li>Die gehashte Kennzahl und das Testergebnis in der Testergebnis- Datenbank werden im Fall eines negativen Testergebnisses unmittelbar nach dem Abruf des Testergebnisses und im Fall eines positiven Testergebnissen unmittelbar nach dem Löschen der auf Serversystem gespeicherten Kopie der TAN gelöscht (s.u.).</li>
-			<li>Das Token, das auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
-			<li>Das Token, das in der App gespeichert ist, wird nach Löschung der App vom Smartphone oder nach Ausführung der Funktion „Testergebnis teilen“ gelöscht.</li>
-		</ul>
+		<!-- Preambel -->
+		<section>
+			<p>In dieser Datenschutzerklärung erfahren Sie, welche Daten bei der Nutzung der Corona-Warn-App erhoben werden, wie sie verwendet werden und welche Datenschutzrechte Sie haben.</p>
+			<p>Damit diese Datenschutzerklärung für alle Nutzer verständlich ist, bemühen wir uns um eine einfache und möglichst untechnische Darstellung.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h3>c. Testergebnis teilen</h3>
 
-		<ul>
-			<li>Die in der App geteilten eigenen Zufalls-IDs werden nach 14 Tagen vom Serversystem gelöscht.</li>
-			<li>Die Kopie der TAN, die auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
-			<li>Die TAN, die in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
-			<li>Die TeleTAN, die in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
-			<li>Die TeleTAN, die auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
-			<li>Die TeleTAN, die dem Mitarbeiter der Hotline übermittelt wird, wird dort direkt nach der telefonischen Weitergabe an Sie gelöscht.</li>
-			<li>Das Token, das auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
-			<li>Das Token, das in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
-		</ul>
+		<!-- 1. Wer stellt Ihnen diese App zur Verfügung? -->
+		<section>
+			<h2>1. Wer stellt Ihnen diese App zur Verfügung?</h2>
+			<p>Der Anbieter der Corona-Warn-App (im Folgenden die „<strong>App</strong>“) ist das Robert Koch-Institut, Nordufer 20, 13353 Berlin (im Folgenden „<strong>RKI</strong>“).</p>
+			<p>Das RKI ist auch der datenschutzrechtlich Verantwortliche für die Verarbeitung von personenbezogenen Daten der App-Nutzer.</p>
+			<p>Den Datenschutzbeauftragten des RKI erreichen Sie unter der oben genannten Anschrift (zu Händen „Behördlicher Datenschutzbeauftragter“) und per E-Mail an: datenschutz@rki.de).</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h2>9. An wen werden Ihre Daten weitergegeben?</h2>
-		<p>Wenn Sie ein Testergebnis teilen, um andere Nutzer zu warnen, werden Ihre Zufalls-IDs der letzten 14 Tage an die Apps der anderen Nutzer weitergegeben.</p>
-		<p>Mit dem Betrieb und der Wartung eines Teils der technischen Infrastruktur der App (z. B. Serversysteme, Hotline) hat das RKI die T-Systems International GmbH und die SAP Deutschland SE & Co. KG beauftragt, die insoweit als Auftragsverarbeiter des RKI tätig werden (Artikel 28 DSGVO).</p>
-		<p>Im Übrigen gibt das RKI personenbezogene Daten, die im Zusammenhang mit der Nutzung der App erhoben werden, nur an Dritte weiter, soweit das RKI rechtlich dazu verpflichtet ist oder die Weitergabe im Falle von Angriffen auf die technische Infrastruktur der App zur Rechts- oder Strafverfolgung erforderlich ist. Eine Weitergabe in anderen Fällen erfolgt grundsätzlich nicht.</p>
 
-		<h2>10. Werden Daten in ein Drittland übermittelt?</h2>
-		<p>Die bei der Nutzung der App anfallenden Daten werden ausschließlich auf Servern in Deutschland oder in einem anderem EU- oder EWR-Mitgliedsstaat verarbeitet.</p>
+		<!-- 2. Ist die Nutzung der App freiwillig? -->
+		<section>
+			<h2>2. Ist die Nutzung der App freiwillig?</h2>
 
-		<h2>11. Widerruf von Einwilligungen</h2>
-		<p>Ihnen steht das Recht zu, die in der App erteilten Einwilligungen gegenüber dem RKI jederzeit mit Wirkung für die Zukunft zu widerrufen. Die Rechtmäßigkeit der Verarbeitung bis zum Widerruf wird dadurch jedoch nicht berührt.</p>
-		<p>Zum Widerruf Ihrer Einwilligung in die Risiko-Ermittlung können Sie die Funktion über den Schieberegler innerhalb der App deaktivieren oder die App löschen. Wenn Sie die Risiko- Ermittlung wieder nutzen möchten, können Sie den Schieberegler erneut aktivieren oder die App erneut installieren.</p>
-		<p>Zum Widerruf Ihrer Einwilligung für die Funktion „Test registrieren“ können Sie die Testregistrierung in der App löschen. Das Token zum Abruf des Testergebnisses wird dann von Ihrem Gerät gelöscht. Weder das RKI noch das Testlabor können die übermittelten Daten dann Ihrer App oder Ihrem Smartphone zuordnen. Wenn Sie einen weiteren Test registrieren möchten, werden Sie um eine neue Einwilligung gebeten.</p>
-		<p>Zum Widerruf Ihrer Einwilligung für die Funktion „Testergebnis teilen“ müssen Sie die App löschen. Sämtliche Ihrer in der App gespeicherten Zufalls-IDs werden dann entfernt und können Ihrem Smartphone nicht mehr zugeordnet werden. Wenn Sie erneut ein Testergebnis melden möchten, können Sie in der App erneut installieren und eine neue Einwilligung erteilen. Alternativ können Sie Ihre eigenen Zufalls-IDs gegebenenfalls im Rahmen der Kontaktaufzeichnungs-Funktion in den Systemeinstellungen Ihres Smartphones löschen. Bitte beachten Sie, dass das RKI keine Möglichkeit hat, um Ihre bereits übermittelten Zufalls-IDs unmittelbar aus den bereitgestellten Listen und von Smartphones anderer Nutzer zu löschen.</p>
+			<p>Die Benutzung der App basiert ausschließlich auf Freiwilligkeit. Es ist daher allein Ihre Entscheidung, ob und wie Sie die App nutzen.</p>
 
-		<h2>12. Ihre weiteren Datenschutzrechte</h2>
-		<p>Soweit das RKI personenbezogene Daten von Ihnen verarbeitet, stehen Ihnen außerdem folgende Datenschutzrechte zu:</p>
+			<p>Auch wenn die Installation und die Benutzung der App freiwillig sind, müssen Sie nach dem erstmaligen Aufruf der App gegenüber dem RKI durch Antippen des Buttons „Risiko-Ermittlung aktivieren“ zustimmen, dass die App im Rahmen der Risiko-Ermittlung Ihre personenbezogenen Daten verarbeiten darf. Falls die App dabei ein Infektionsrisiko für Sie ermittelt, stellen Ihre Daten auch Gesundheitsdaten dar. Ihre Zustimmung ist erforderlich, da andernfalls die App nicht auf die Kontaktaufzeichnungs-Funktion Ihres Smartphones zugreifen kann. Sie können die Risiko-Ermittlung jedoch jederzeit über den Schieberegler innerhalb der App deaktivieren. In diesem Fall stehen Ihnen nicht alle Funktionen der App zur Verfügung. Gesonderte Einwilligungen sind darüber hinaus für die Datenverarbeitung der folgenden Funktionen erforderlich:</p>
 
-		<ul>
-			<li>die Rechte aus den Artikeln 15, 16, 17, 18, 20 und 21 DSGVO,</li>
-			<li>das Recht, den behördlichen <u>Datenschutzbeauftragten des RKI</u> zu kontaktierenund Ihr Anliegen vorzubringen (Artikel 38 Abs. 4 DSGVO) und</li>
-			<li>das Recht, sich bei einer zuständigen Aufsichtsbehörde für den Datenschutz zu beschweren. Dazu können Sie sich entweder an die zuständige Aufsichtsbehörde an Ihrem Wohnort oder an die am Sitz des RKI zuständige</li>
-		</ul>
+			<ul>
+				<li>Test registrieren (siehe Ziffer 6 b.)</li>
+				<li>Testergebnis teilen (siehe Ziffer 6 c.)</li>
+			</ul>
 
-		<p>Behörde wenden. Die zuständige Aufsichtsbehörde für das RKI ist der Bundesbeauftragte für den Datenschutz und die Informationsfreiheit, Graurheindorfer Str. 153, 53117 Bonn.</p>
-		<p>Es wird darauf hingewiesen, dass die vorgenannten Rechte vom RKI nur erfüllt werden können, wenn die Daten, auf die sich die geltend gemachten Ansprüche beziehen, eindeutig Ihrer Person zugeordnet werden können. Dies wäre nur möglich, wenn das RKI weitere personenbezogene Daten erhebt, die eine eindeutige Zuordnung der oben genannten Daten zu Ihrer Person oder Ihrem Smartphone erlaubt. Da dies für die Zwecke der App nicht erforderlich – und auch nicht gewollt – ist, ist das RKI zu einer solchen zusätzlichen Datenerhebung nicht verpflichtet (Artikel 11 Abs. 2 DSGVO). Zudem würde dies dem erklärten Ziel zuwiderlaufen, die Datenverarbeitung im Rahmen der App so datensparsam wie möglich durchzuführen. Aus diesem Hintergrund werden die vorgenannten Datenschutzrechte aus den Artikeln 15, 16, 17, 18, 20 und 21 DSGVO in der Regel nicht unmittelbar und nur mit zusätzlichen Informationen zu Ihrer Person, die dem RKI nicht vorliegen, erfüllt werden können.</p>
+			<p>Die Datenverarbeitung im Rahmen dieser Funktionen wird in den folgenden Abschnitten näher beschrieben.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 3. Auf welcher Rechtsgrundlage werden Ihre Daten verarbeitet? -->
+		<section>
+			<h2>3. Auf welcher Rechtsgrundlage werden Ihre Daten verarbeitet?</h2>
+			<p>Das RKI verarbeitet Ihre personenbezogenen Daten grundsätzlich nur auf Grundlage einer von Ihnen erteilten Einwilligung nach Artikel 6 Absatz 1 Satz 1 Buchstabe a und Artikel 9 Absatz 2 Buchstabe a der Datenschutzgrundverordnung (DSGVO). Sie können eine von Ihnen erteilte Einwilligung jederzeit widerrufen. Weitere Informationen zu Ihrem Widerrufsrecht und Hinweise, wie Sie dieses ausüben können, finden Sie unter Ziffer 11.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 4. An wen richtet sich die App? -->
+		<section>
+			<h2>4. An wen richtet sich die App?</h2>
+			<p>Die App richtet sich an Personen, die sich in Deutschland aufhalten und mindestens 16 Jahre alt sind.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 5. Welche personenbezogenen Daten werden verarbeitet? -->
+		<section>
+			<h2>5. Welche personenbezogenen Daten werden verarbeitet?</h2>
+			<p>Die App ist so konzipiert, dass so wenig personenbezogene Daten wie möglich verarbeitet werden. Das bedeutet zum Beispiel, dass die App keine Daten erfasst, die es dem RKI oder anderen Nutzern ermöglichen, auf Ihre Identität, Ihren Gesundheitsstatus oder Ihren Standort zu schließen. Zudem verzichtet die App bewusst auf jegliche Erfassung oder Analyse Ihres Nutzungsverhaltens durch Tracking-Tools.</p>
+			<p>Die von der App verarbeiteten Daten lassen sich den folgenden Kategorien zuordnen:</p>
+
+			<div>
+				<h3>a. Zugriffsdaten</h3>
+
+				<p>Zugriffsdaten fallen an, wenn Sie die folgenden Funktionen nutzen bzw. aktivieren:</p>
+
+				<ul>
+					<li>Risiko-Ermittlung</li>
+					<li>Test registrieren</li>
+					<li>Testergebnis teilen</li>
+				</ul>
+
+				<p>Bei jedem Abruf von Daten vom Serversystem der App wird Ihre IP-Adresse (auf dem vorgelagerten Load Balancer) maskiert und im Weiteren nicht mehr innerhalb des Serversystems der App verarbeitet.</p>
+
+				<p>Zusätzlich werden folgende Daten verarbeitet:</p>
+
+				<ul>
+					<li>Datum und Uhrzeit des Abrufs (Zeitstempel)</li>
+					<li>übertragene Datenmenge (bzw. Paketlänge)</li>
+					<li>Meldung über erfolgreichen Abruf</li>
+				</ul>
+
+				<p>Diese Zugriffsdaten werden nur zur Sicherung und Aufrechterhaltung der technischen Infrastruktur verarbeitet. Sie werden dabei nicht als Nutzer der App persönlich identifiziert und es kann kein Nutzungsprofil erstellt werden. Eine Speicherung der IP-Adresse über das Ende des Nutzungsvorgangs hinaus erfolgt nicht.</p>
+			</div>
+
+			<div>
+				<h3>b. Begegnungsdaten</h3>
+
+				<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes zu bezeichnet (im Folgenden: „<strong>Zufalls-IDs</strong>“), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
+
+				<ul>
+					<li>Datum und Zeitpunkt des Kontakts</li>
+					<li>Dauer des Kontakts</li>
+					<li>Bluetooth-Signalstärke des Kontakts</li>
+					<li>Verschlüsselte Metadaten (Protokollversion und Sendestärke).</li>
+				</ul>
+
+				<p>Die eigenen und von anderen Smartphones empfangenen Zufalls-IDs und die weiteren Begegnungsdaten (Datum und Zeitpunkt des Kontakts, Dauer des Kontakts, Signalstärke des Kontakts und verschlüsselte Metadaten) werden von Ihrem Smartphone in einem Kontaktprotokoll der Kontaktaufzeichnungs-Funktion erfasst und dort zurzeit für 14 Tage gespeichert.</p>
+
+				<p>Die Kontaktaufzeichnungs-Funktion heißt bei Android-Smartphones „Benachrichtigungen zu möglicher Begegnung mit Infizierten“ und bei iPhones „COVID-19-Kontaktprotokoll“. Wir weisen Sie darauf hin, dass diese Kontaktaufzeichnungs-Funktionen kein Bestandteil der App, sondern ein integraler Bestandteil des Betriebssystems Ihres Smartphones sind. Die Kontaktaufzeichnungs-Funktion wird Ihnen daher von Apple (iPhones) bzw. Google (Android-Smartphones) bereitgestellt und unterliegt dementsprechend den Datenschutzbestimmungen dieser Unternehmen. Die betriebssystemseitige Datenverarbeitung im Rahmen der Kontaktaufzeichnungs-Funktion liegt außerhalb des Einflussbereichs des RKI.</p>
+
+				<p>Weitere Informationen zu der Kontaktaufzeichnungs-Funktion von Android-Smartphones finden Sie unter: <a>https://support.google.com/android/answer/9888358?hl=de.</a></p>
+
+				<p>Weitere Informationen zu der Kontaktaufzeichnungs-Funktion von Apple finden Sie in den Einstellungen Ihres iPhones unter „Datenschutz“ &gt; „Health“ &gt; „COVID-19-Kontaktprotokoll“. Bitte beachten Sie: Die Kontaktaufzeichnungs-Funktion steht Ihnen nur zur Verfügung, wenn auf Ihrem iPhone das Betriebssystem iOS ab Version 13.5 installiert ist.</p>
+
+				<p>Die vom Smartphone erzeugten und gespeicherten Begegnungsdaten werden von der App nur verarbeitet, wenn die Risiko-Ermittlung aktiviert ist.</p>
+			</div>
+
+			<div>
+				<h2>c. Gesundheitsdaten</h2>
+
+				<p>Gesundheitsdaten sind alle Daten, die Informationen zum Gesundheitszustand einer bestimmten Person enthalten. Dazu gehören nicht nur Angaben zu früheren und aktuellen Krankheiten, sondern auch zu Krankheitsrisiken einer Person (z. B. das Risiko, dass eine Person sich mit dem Corona-Virus infiziert hat).</p>
+
+				<p>In den folgenden Fällen handelt es sich um eine Verarbeitung von Gesundheitsdaten:</p>
+
+				<ul>
+					<li>Wenn die Risiko-Ermittlung erkennt, dass Sie möglicherweise Kontakt zu einer Person hatten, die sich mit dem Corona-Virus infiziert hat.</li>
+					<li>Wenn Sie einen Test registrieren.</li>
+					<li>Wenn Sie ein positives Testergebnis teilen.</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 6. Funktionen der App -->
+		<section>
+			<h2>6. Funktionen der App</h2>
+
+			<div>
+				<h3>a. Risiko-Ermittlung</h3>
+
+				<p>Die Risiko-Ermittlung ist die Kernfunktion der App. Sie dient dazu, mögliche Kontakte zu mit dem Corona-Virus infizierten anderen Nutzern der App nachzuverfolgen, das infolge für Sie bestehende Infektionsrisiko zu bewerten und Ihnen, basierend auf dem für Sie ermittelten Risikowert, Verhaltens- und Gesundheitshinweise bereitzustellen.</p>
+
+				<p>Wenn Sie die Risiko-Ermittlung aktivieren, ruft die App von den Serversystemen der App im Hintergrundbetrieb mehrmals täglich (oder wenn Sie auf „Aktualisieren“ tippen) eine Liste mit Zufalls-IDs von Nutzern ab, die positiv getestet wurden und Ihre eigenen Zufalls-IDs geteilt haben. Die App gibt die Zufalls-IDs an die Kontaktaufzeichnungs-Funktion Ihres Smartphones weiter, welche diese dann mit den im Kontaktprotokoll Ihres Smartphones gespeicherten Zufalls-IDs abgleicht. Wenn die Kontaktaufzeichnungs-Funktion Ihres Smartphones eine Übereinstimmung feststellt, übergibt sie der App die Begegnungsdaten (Datum, Dauer, Signalstärke), nicht jedoch die Zufalls-ID des betreffenden Kontakts.</p>
+
+				<p>Im Fall eines Kontakts werden die von der Kontaktaufzeichnungs-Funktion übergebenen Begegnungsdaten von der App analysiert, um Ihr individuelles Infektionsrisiko zu ermitteln. Der Bewertungsalgorithmus, der festlegt, wie die Begegnungsdaten interpretiert werden (z. B. welchen Einfluss die Dauer eines Kontakts auf das Infektionsrisiko hat) basiert auf den aktuellen wissenschaftlichen Erkenntnissen. Bei neuen Erkenntnissen kann der Bewertungsalgorithmus daher durch das RKI aktualisiert werden, indem die Einstellungen für den Bewertungsalgorithmus neu gesetzt werden. Die Einstellungen für den Bewertungsalgorithmus werden dann zusammen mit der Liste der Zufalls-IDs infizierter Personen an die App übermittelt.</p>
+
+				<p>Die Ermittlung des Infektionsrisikos findet ausschließlich lokal auf Ihrem Smartphone statt, das heißt die Daten werden offline verarbeitet. Das ermittelte Infektionsrisiko wird ebenfalls ausschließlich in der App gespeichert und an keine anderen Empfänger (auch nicht an das RKI, Apple, Google und sonstige Dritte) weitergegeben.</p>
+
+				<p>Rechtsgrundlage der oben beschriebenen Verarbeitung Ihrer Zugriffsdaten, Begegnungsdaten und ggf. Gesundheitsdaten (sofern für Sie ein Infektionsrisiko ermittelt wird) ist Ihre Einwilligung, die Sie bei der Aktivierung der Risiko-Ermittlung erteilt haben.</p>
+			</div>
+
+			<div>
+				<h3>b. Test registrieren</h3>
+
+				<p>Wenn Sie auf eine Infektion mit dem Corona-Virus getestet wurden, können Sie den Test in der App registrieren, indem Sie den QR-Code, den Sie von Ihrem Arzt bzw. der Testeinrichtung erhalten haben, in der App einscannen. Die App informiert Sie dann, sobald das Testergebnis des Labors vorliegt.</p>
+				<p>Dies setzt voraus, dass das Testlabor an das Serversystem der App angeschlossen ist und Sie im Rahmen der Testdurchführung gesondert in die Übermittlung Ihres Testergebnisses durch das Labor an das Serversystem der App (Testergebnis-Datenbank) eingewilligt haben. Testergebnisse von Laboren, die nicht an das Serversystem der App angeschlossen sind, können nicht in der App angezeigt werden. Wenn Sie keinen QR-Code erhalten haben, ist das Testlabor nicht angeschlossen. In diesem Fall können Sie diese Funktion nicht nutzen.</p>
+
+				<h5>Testregistrierung</h5>
+				<p>Damit Sie das Testergebnis in der App erhalten können, müssen Sie den durchgeführten Test zunächst in der App registrieren. Hierzu erhalten Sie von Ihrem Arzt bzw. der Testeinrichtung im Rahmen der Probenentnahme einen QR-Code. Dieser QR-Code enthält eine Kennzahl, die mit einem QR-Code-Scanner ausgelesen werden kann. Zur Testregistrierung müssen Sie den QR-Code in der App mit der Kamera Ihres Smartphones scannen.</p>
+				<p>Die aus dem QR-Code ausgelesene Kennzahl wird von der App dann gehasht, das bedeutet, die Kennzahl wird nach einem bestimmten mathematischen Verfahren so verfremdet, dass die dahinterstehende Kennzahl nicht mehr erkennbar ist. Sobald Ihr Smartphone eine Verbindung zum Internet hat, wird die App die gehashte Kennzahl an die Serversysteme der App übermitteln. Im Gegenzug erhält die App vom Serversystem einen Token, also einen digitalen Zugangsschlüssel, der in der App gespeichert wird. Das Token ist auf dem Serversystem mit der gehashten Kennzahl verknüpft. Die App löscht dann die auf Ihrem Smartphone gehashte Kennzahl. Das Serversystem wird für jede gehashte Kennzahl nur ein einziges Mal einen Token vergeben. Auf diese Weise wird sichergestellt, dass Ihr QR-Code nicht von anderen Nutzern der App für die Abfrage von Testergebnissen verwendet werden kann.</p>
+				<p>Die Registrierung Ihres Tests ist damit abgeschlossen.</p>
+
+				<h5>Hinterlegung des Testergebnisses</h5>
+				<p>Sobald dem Testlabor das Testergebnis vorliegt, hinterlegt es das Ergebnis unter Angabe der gehashten Kennzahl in der vom RKI betriebenen Testergebnis-Datenbank. Die Testergebnis-Datenbank wird vom RKI auf einem speziellen Server innerhalb des Serversystems der App betrieben. Das Testlabor erzeugt die gehashte Kennzahl ebenfalls auf Basis der an Sie im ausgegebenen QR-Code enthaltenen Kennzahl unter Verwendung des gleichen mathematischen Verfahrens, das auch die App einsetzt.</p>
+
+				<h5>Abruf des Testergebnisses</h5>
+				<p>Die App fragt bei dem Serversystem der App unter Verwendung des Tokens regelmäßig den Status des registrierten Tests ab. Das Serversystem ordnet das Token dann der gehashten Kennzahl zu und übermittelt diese an die Testergebnis-Datenbank. Ist das Testergebnis dort mittlerweile abgelegt, sendet die Testergebnis-Datenbank das Testergebnis an das Serversystem zurück, der dieses ohne Kenntnisnahme des Inhalts an die App weiterleitet.</p>
+				<p>Im Fall eines positiven Testergebnis fordert die App beim Serversystem unter erneuter Verwendung des Tokens eine TAN (Transaktionsnummer) an. Das Serversystem ordnet das Token wieder der gehashten Kennzahl zu und fordert von der Testergebnis-Datenbank eine Bestätigung an, dass zu der gehashten Kennzahl ein positives Testergebnis vorliegt. Sofern die Testergebnis-Datenbank dies bestätigt, erzeugt das Serversystem die TAN und übermittelt sie an die App. Eine Kopie der TAN verbleibt auf dem Serversystem.</p>
+				<p>Die TAN wird benötigt, um im Fall einer Übermittlung des positiven Testergebnisses sicherzustellen, dass keine falschen Informationen an andere Nutzer verteilt werden.</p>
+				<p>Rechtsgrundlage der oben beschriebenen Verarbeitung der zuvor genannten Daten ist Ihre Einwilligung für die Funktion „Test registrieren“.</p>
+			</div>
+
+			<div>
+				<h3>c. Testergebnis teilen</h3>
+
+				<p>Wenn Sie die Funktion „Testergebnis teilen“ nutzen um andere Nutzer zu warnen, überträgt die App die von Ihrem Smartphone gespeicherten eigenen Zufalls-IDs der letzten 14 Tage und die TAN an das Serversystem der App. Dieses prüft zunächst, ob die TAN gültig ist und trägt Ihre Zufalls-IDs sodann in die Liste der Zufalls-IDs von Nutzern, die ihr positives Testergebnis geteilt haben, ein. Ihre Zufalls-IDs können nun von anderen Nutzern im Rahmen der Risiko-Ermittlung heruntergeladen werden.</p>
+
+				<h5>Wenn Sie Ihr Testergebnis nicht in der App abgerufen haben:</h5>
+				<p>Auch wenn Sie ein positives Testergebnis nicht in der App abgerufen haben, können Sie das Testergebnis per App teilen, um andere Nutzer zu warnen. In diesem Fall fordert Sie die App zur Eingabe einer sogenannten TeleTAN auf, die als TAN fungiert.</p>
+				<p>Für den Erhalt der TeleTAN können Sie die Hotline der Corona-Warn-App unter der Nummer +49 (0)800 7540002 anrufen. Der dort für Sie zuständige Ansprechpartner wird Ihnen zunächst am Telefon einige Fragen stellen, um die Plausibilität Ihres Anrufs zu überprüfen. Diese Fragen dienen der Vorbeugung einer missbräuchlichen Infektionsmeldung und daraus resultierender fehlerhafter Warnungen und Risikowerte. Nach ausreichender Beantwortung dieser Fragen werden Sie nach Ihrer Handy-/Telefonnummer gefragt. Dies dient dazu, Sie später zurückrufen zu können, um Ihnen eine TeleTAN zur Eingabe in der App mitzuteilen. Ihre Handy-/Telefonnummer wird nur zu diesem Zweck vorübergehend gespeichert und spätestens innerhalb einer Stunde gelöscht.</p>
+				<p>Nach Ihrem Anruf wird der Hotline-Mitarbeiter über einen speziellen Zugang zum Serversystem der App eine TeleTAN generieren und Sie sodann anrufen, um Ihnen die TeleTAN mitzuteilen. Wenn Sie die TeleTAN in der App eingeben, wird die TeleTAN von der App zum Abgleich und Verifizierung an das Serversystem der App zurückgesendet. Im Gegenzug erhält die App vom Serversystem einen Token, also einen digitalen Zugangsschlüssel, der in der App gespeichert wird. Mit diesem Token fordert die App beim Serversystem dann eine TAN an.</p>
+				<p>Rechtsgrundlage dieser Verarbeitung Ihrer Zugriffsdaten und Gesundheitsdaten (Zufalls-IDs, Testergebnis, TAN und ggf. TeleTAN) ist Ihre Einwilligung für die Funktion „Testergebnis teilen“.</p>
+			</div>
+
+			<div>
+				<h3>d. Informatorische Nutzung der App</h3>
+				<p>Soweit Sie die App nur informatorisch nutzen, also keine der oben genannten Funktionen der App verwenden und keine Daten eingeben, findet die Verarbeitung ausschließlich lokal auf Ihrem Smartphone statt und es fallen keine personenbezogenen Daten an. In der App verlinkte Webseiten z.B.: <a>www.bundesregierung.de</a> werden im Standard-Browser Ihres Smartphones geöffnet und angezeigt. Welche Daten dabei verarbeitet werden hängt von dem genutzten Browser, dessen Konfiguration sowie der Datenverarbeitungspraxis der aufgerufenen Webseite ab.</p>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 7. Welche Berechtigungen und Funktionen benötigt die App? -->
+		<section>
+			<h2>7. Welche Berechtigungen und Funktionen benötigt die App?</h2>
+			<p>Die App benötigt Zugriff auf verschiedene Funktionen und Schnittstellen Ihres Smartphones. Dazu ist es erforderlich, dass Sie der App bestimmte Berechtigungen erteilen. Die Berechtigungen sind von den verschiedenen Herstellern unterschiedlich programmiert. So können z. B. Einzelberechtigungen zu Berechtigungskategorien zusammengefasst sein, wobei Sie der Berechtigungskategorie nur insgesamt zustimmen können. Bitte beachten Sie, dass Sie im Falle der Ablehnung eines Zugriffs durch die App keine oder nur wenige Funktionen der App nutzen können.</p>
+
+			<div>
+				<h3>a. Technische Voraussetzungen (alle Smartphones)</h3>
+
+				<ul>
+					<li>
+						<p>Internet</p>
+						<p>Die App benötigt für die Funktionen Risiko-Ermittlung, Testergebnisse erhalten und Testergebnis übermitteln eine Internetverbindung, um mit den Serversystemen der App kommunizieren zu können.</p>
+					</li>
+					<li>
+						<p>Bluetooth</p>
+						<p>Die Bluetooth-Schnittstelle Ihres Smartphones muss aktiviert sein, damit Ihr Smartphone Zufalls-IDs von anderen Smartphones erfassen und im Kontaktprotokoll des Geräts speichern kann.</p>
+					</li>
+					<li>
+						<p>Kamera</p>
+						<p>Ihr Smartphone benötigt eine Kamera, um damit einen QR-Code im Rahmen der Testregistrierung scannen können.</p>
+					</li>
+					<li>
+						<p>Hintergrundbetrieb</p>
+						<p>Die App nutzt den Hintergrundbetrieb (also wenn Sie die App nicht gerade aktiv nutzen), um Ihr Risiko automatisch zu ermitteln und den Status eines registrierten Tests abfragen zu können. Wenn Sie den Hintergrundbetrieb im Betriebssystem Ihres Smartphones deaktivieren, müssen Sie alle Aktionen in der App selbst starten.</p>
+					</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>b. Android-Smartphones</h3>
+
+				<p>Wenn Sie ein Android-Gerät verwenden, müssen außerdem folgende Systemfunktionen aktiviert sein:</p>
+
+				<ul>
+					<li>
+						<p>Benachrichtigungen zu möglicher Begegnung mit COVID-19-Infizierten</p>
+						<p>Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.</p>
+					</li>
+					<li>
+						<p>Standortermittlung</p>
+						<p>Die Standortermittlung Ihres Smartphones muss aktiviert sein, damit Ihr Gerät nach Bluetooth-Signalen anderer Smartphones sucht. Standortdaten werden dabei jedoch nicht erhoben.</p>
+					</li>
+					<li>
+						<p>Benachrichtigung</p>
+						<p>Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Die dafür notwendige Benachrichtigungsfunktion ist im Betriebssystem bereits aktiviert.</p>
+					</li>
+				</ul>
+
+				<p>Daneben benötigt die App folgende Berechtigungen:</p>
+
+				<ul>
+					<li>
+						<p>Kamera</p>
+						<p>Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR-Code auslesen zu können.</p>
+					</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>c. iPhones (Apple iOS)</h3>
+
+				<p>Wenn Sie ein iPhone verwenden, müssen folgende Systemfunktionen aktiviert sein:</p>
+
+				<ul>
+					<li>
+						<p>COVID-19-Kontaktprotokoll</p>
+						<p>Die Risiko-Ermittlung benötigt diese Funktion, da andernfalls kein Kontaktprotokoll mit den Zufalls-IDs Ihrer Kontakte zur Verfügung steht. Die Funktion muss innerhalb der App aktiviert werden, damit die App auf das Kontaktprotokoll zugreifen darf.</p>
+					</li>
+					<li>
+						<p>Mitteilungen</p>
+						<p>Der Nutzer wird lokal über die Risiko-Ermittlung und vorhandene Testergebnisse benachrichtigt. Mitteilungen müssen dafür aktiviert sein.</p>
+					</li>
+				</ul>
+
+				<p>Die App benötigt zudem folgende Berechtigungen:</p>
+
+				<ul>
+					<li>
+						<p>Kamera</p>
+						<p>Die App benötigt Zugriff auf die Kamera, um bei der Testregistrierung den QR-Code auslesen zu können.</p>
+					</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 8. Wann werden die Daten gelöscht? -->
+		<section>
+			<h2>8. Wann werden die Daten gelöscht?</h2>
+
+			<p>Alle in der App gespeicherten Daten werden gelöscht, sobald sie für die Funktionen der App nicht mehr benötigt werden:</p>
+
+			<div>
+				<h3>a. Risiko-Ermittlung</h3>
+				<ul>
+					<li>Die Liste der Zufalls-IDs von Nutzern, die ein positives Testergebnis geteilt haben, wird in der App unverzüglich und im Übrigen im Kontaktprotokoll Ihres Smartphones nach 14 Tagen automatisch gelöscht.</li>
+					<li>Auf die Löschung der Begegnungsdaten im Kontaktprotokoll Ihres Smartphones (einschließlich Ihrer eigenen Zufalls-IDs) und die Begegnungsdaten auf anderen Smartphones hat das RKI keinen Einfluss, da diese Funktion von Apple bzw. Google bereitgestellt werden. Die Löschung richtet sich nach den Festlegungen von Apple bzw. Google. Zurzeit werden die Daten nach 14 Tagen automatisch gelöscht. Zudem können Sie im Rahmen der von Apple und Google bereitgestellten Funktionalitäten in den Systemeinstellungen Ihres Geräts gegebenenfalls eine manuelle Löschung anstoßen.</li>
+					<li>Der in der App angezeigte Risikowert wird gelöscht, sobald ein neuer Risikowert ermittelt worden ist. Ein neuer Risikowert wird in der Regel ermittelt, nachdem die App eine neue Liste mit Zufalls-IDs erhalten hat.</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>b. Test registrieren</h3>
+				<ul>
+					<li>Die gehashte Kennzahl wird auf dem Serversystem der App nach 21 Tagen gelöscht.</li>
+					<li>Die gehashte Kennzahl und das Testergebnis in der Testergebnis-Datenbank werden im Fall eines negativen Testergebnisses unmittelbar nach dem Abruf des Testergebnisses und im Fall eines positiven Testergebnissen unmittelbar nach dem Löschen der auf Serversystem gespeicherten Kopie der TAN gelöscht (s.u.).</li>
+					<li>Das Token, das auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
+					<li>Das Token, das in der App gespeichert ist, wird nach Löschung der App vom Smartphone oder nach Ausführung der Funktion „Testergebnis teilen“ gelöscht.</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>c. Testergebnis teilen</h3>
+				<ul>
+					<li>Die in der App geteilten eigenen Zufalls-IDs werden nach 14 Tagen vom Serversystem gelöscht.</li>
+					<li>Die Kopie der TAN, die auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
+					<li>Die TAN, die in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
+					<li>Die TeleTAN, die in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
+					<li>Die TeleTAN, die auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
+					<li>Die TeleTAN, die dem Mitarbeiter der Hotline übermittelt wird, wird dort direkt nach der telefonischen Weitergabe an Sie gelöscht.</li>
+					<li>Das Token, das auf dem Serversystem gespeichert ist, wird nach 21 Tagen gelöscht.</li>
+					<li>Das Token, das in der App gespeichert ist, wird nach Teilen des Testergebnisses gelöscht.</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 9. An wen werden Ihre Daten weitergegeben? -->
+		<section>
+			<h2>9. An wen werden Ihre Daten weitergegeben?</h2>
+			<p>Wenn Sie ein Testergebnis teilen, um andere Nutzer zu warnen, werden Ihre Zufalls-IDs der letzten 14 Tage an die Apps der anderen Nutzer weitergegeben.</p>
+			<p>Mit dem Betrieb und der Wartung eines Teils der technischen Infrastruktur der App (z. B. Serversysteme, Hotline) hat das RKI die T-Systems International GmbH und die SAP Deutschland SE & Co. KG beauftragt, die insoweit als Auftragsverarbeiter des RKI tätig werden (Artikel 28 DSGVO).</p>
+			<p>Im Übrigen gibt das RKI personenbezogene Daten, die im Zusammenhang mit der Nutzung der App erhoben werden, nur an Dritte weiter, soweit das RKI rechtlich dazu verpflichtet ist oder die Weitergabe im Falle von Angriffen auf die technische Infrastruktur der App zur Rechts- oder Strafverfolgung erforderlich ist. Eine Weitergabe in anderen Fällen erfolgt grundsätzlich nicht.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 10. Werden Daten in ein Drittland übermittelt? -->
+		<section>
+			<h2>10. Werden Daten in ein Drittland übermittelt?</h2>
+			<p>Die bei der Nutzung der App anfallenden Daten werden ausschließlich auf Servern in Deutschland oder in einem anderem EU- oder EWR-Mitgliedsstaat verarbeitet.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 11. Widerruf von Einwilligungen -->
+		<section>
+			<h2>11. Widerruf von Einwilligungen</h2>
+			<p>Ihnen steht das Recht zu, die in der App erteilten Einwilligungen gegenüber dem RKI jederzeit mit Wirkung für die Zukunft zu widerrufen. Die Rechtmäßigkeit der Verarbeitung bis zum Widerruf wird dadurch jedoch nicht berührt.</p>
+			<p>Zum Widerruf Ihrer Einwilligung in die Risiko-Ermittlung können Sie die Funktion über den Schieberegler innerhalb der App deaktivieren oder die App löschen. Wenn Sie die Risiko-Ermittlung wieder nutzen möchten, können Sie den Schieberegler erneut aktivieren oder die App erneut installieren.</p>
+			<p>Zum Widerruf Ihrer Einwilligung für die Funktion „Test registrieren“ können Sie die Testregistrierung in der App löschen. Das Token zum Abruf des Testergebnisses wird dann von Ihrem Gerät gelöscht. Weder das RKI noch das Testlabor können die übermittelten Daten dann Ihrer App oder Ihrem Smartphone zuordnen. Wenn Sie einen weiteren Test registrieren möchten, werden Sie um eine neue Einwilligung gebeten.</p>
+			<p>Zum Widerruf Ihrer Einwilligung für die Funktion „Testergebnis teilen“ müssen Sie die App löschen. Sämtliche Ihrer in der App gespeicherten Zufalls-IDs werden dann entfernt und können Ihrem Smartphone nicht mehr zugeordnet werden. Wenn Sie erneut ein Testergebnis melden möchten, können Sie in der App erneut installieren und eine neue Einwilligung erteilen. Alternativ können Sie Ihre eigenen Zufalls-IDs gegebenenfalls im Rahmen der Kontaktaufzeichnungs-Funktion in den Systemeinstellungen Ihres Smartphones löschen. Bitte beachten Sie, dass das RKI keine Möglichkeit hat, um Ihre bereits übermittelten Zufalls-IDs unmittelbar aus den bereitgestellten Listen und von Smartphones anderer Nutzer zu löschen.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!--  -->
+		<section>
+			<h2>12. Ihre weiteren Datenschutzrechte</h2>
+
+			<p>Soweit das RKI personenbezogene Daten von Ihnen verarbeitet, stehen Ihnen außerdem folgende Datenschutzrechte zu:</p>
+
+			<ul>
+				<li>die Rechte aus den Artikeln 15, 16, 17, 18, 20 und 21 DSGVO,</li>
+				<li>das Recht, den behördlichen <a>Datenschutzbeauftragten des RKI</a> zu kontaktieren und Ihr Anliegen vorzubringen (Artikel 38 Abs. 4 DSGVO) und</li>
+				<li>das Recht, sich bei einer zuständigen Aufsichtsbehörde für den Datenschutz zu beschweren. Dazu können Sie sich entweder an die zuständige Aufsichtsbehörde an Ihrem Wohnort oder an die am Sitz des RKI zuständige Behörde wenden. Die zuständige Aufsichtsbehörde für das RKI ist der Bundesbeauftragte für den Datenschutz und die Informationsfreiheit, Graurheindorfer Str. 153, 53117 Bonn.</li>
+			</ul>
+
+			<p>Es wird darauf hingewiesen, dass die vorgenannten Rechte vom RKI nur erfüllt werden können, wenn die Daten, auf die sich die geltend gemachten Ansprüche beziehen, eindeutig Ihrer Person zugeordnet werden können. Dies wäre nur möglich, wenn das RKI weitere personenbezogene Daten erhebt, die eine eindeutige Zuordnung der oben genannten Daten zu Ihrer Person oder Ihrem Smartphone erlaubt. Da dies für die Zwecke der App nicht erforderlich – und auch nicht gewollt – ist, ist das RKI zu einer solchen zusätzlichen Datenerhebung nicht verpflichtet (Artikel 11 Abs. 2 DSGVO). Zudem würde dies dem erklärten Ziel zuwiderlaufen, die Datenverarbeitung im Rahmen der App so datensparsam wie möglich durchzuführen. Aus diesem Hintergrund werden die vorgenannten Datenschutzrechte aus den Artikeln 15, 16, 17, 18, 20 und 21 DSGVO in der Regel nicht unmittelbar und nur mit zusätzlichen Informationen zu Ihrer Person, die dem RKI nicht vorliegen, erfüllt werden können.</p>
+		</section>
+		<p>&nbsp;</p>
 
 		<aside>Stand: 12.06.2020</aside>
+
 
 	</body>
 </html>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -525,7 +525,7 @@
 		<p>&nbsp;</p>
 
 
-		<!--  -->
+		<!-- 12. Ihre weiteren Datenschutzrechte -->
 		<section>
 			<h2>12. Ihre weiteren Datenschutzrechte</h2>
 
@@ -540,6 +540,7 @@
 			<p>Es wird darauf hingewiesen, dass die vorgenannten Rechte vom RKI nur erfüllt werden können, wenn die Daten, auf die sich die geltend gemachten Ansprüche beziehen, eindeutig Ihrer Person zugeordnet werden können. Dies wäre nur möglich, wenn das RKI weitere personenbezogene Daten erhebt, die eine eindeutige Zuordnung der oben genannten Daten zu Ihrer Person oder Ihrem Smartphone erlaubt. Da dies für die Zwecke der App nicht erforderlich – und auch nicht gewollt – ist, ist das RKI zu einer solchen zusätzlichen Datenerhebung nicht verpflichtet (Artikel 11 Abs. 2 DSGVO). Zudem würde dies dem erklärten Ziel zuwiderlaufen, die Datenverarbeitung im Rahmen der App so datensparsam wie möglich durchzuführen. Aus diesem Hintergrund werden die vorgenannten Datenschutzrechte aus den Artikeln 15, 16, 17, 18, 20 und 21 DSGVO in der Regel nicht unmittelbar und nur mit zusätzlichen Informationen zu Ihrer Person, die dem RKI nicht vorliegen, erfüllt werden können.</p>
 		</section>
 		<p>&nbsp;</p>
+
 
 		<aside>Stand: 12.06.2020</aside>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -314,7 +314,7 @@
 
 		<h3>Sie benötigen aktuelle Versionen von iOS bzw. Android</h3>
 
-		<p>Die App verwendet eigens von Apple in iOS und Google in Android implementierte Funktionen (<i>sog. Exposure Notification</i>). Diese stehen in iOS erst ab Version 13.5 und in Android erst ab Version<b>[x]</b> zur Verfügung. Die App funktioniert daher leider nicht mit früheren Versionen der beiden Betriebssysteme.</p>
+		<p>Die App verwendet eigens von Apple in iOS und Google in Android implementierte Funktionen (<i>sog. Exposure Notification</i>). Diese stehen in iOS erst ab Version 13.5 und in Android erst ab Version 6.0 zur Verfügung. Die App funktioniert daher leider nicht mit früheren Versionen der beiden Betriebssysteme.</p>
 
 		<h2>8. Grenzen der App</h2>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -254,7 +254,7 @@
 
 			<h3>Technische Beschreibung der App</h3>
 			<p>Die technischen Funktionen der App sowie der damit verbundenen Dienste und Systeme sind unter folgendem Link detailliert beschrieben:</p>
-			<a>https://github.com/Corona-Warn-App</a>
+			<p><a>https://github.com/Corona-Warn-App</a></p>
 			<p>Diese technische Beschreibung dient lediglich der Erläuterung und ist nicht Bestandteil dieser Nutzungsbedingungen. Sie stellt auch keine Beschaffenheitsvereinbarung in Bezug auf die App dar.</p>
 
 			<h3>Weiterführende Informationen</h3>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -232,7 +232,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Welche Funktionen hat die App? -->
+		<!-- 1. Welche Funktionen hat die App? -->
 		<section>
 			<h2>1. WELCHE FUNKTIONEN HAT DIE APP?</h2>
 
@@ -265,7 +265,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Was bedeutet niedriges oder erhöhtes Risiko -->
+		<!-- 2. Was bedeutet niedriges oder erhöhtes Risiko -->
 		<section>
 			<h2>2. WAS BEDEUTET NIEDRIGES ODER ERHÖHTES RISIKO?</h2>
 
@@ -276,7 +276,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Risiko-Begegnung - Was tun? -->
+		<!-- 3. Risiko-Begegnung - Was tun? -->
 		<section>
 			<h2>3. RISIKO-BEGEGNUNG – WAS TUN?</h2>
 
@@ -291,7 +291,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Kein Infektionsschutz durch die App -->
+		<!-- 4. Kein Infektionsschutz durch die App -->
 		<section>
 			<h2>4. KEIN INFEKTIONSSCHUTZ DURCH DIE APP</h2>
 
@@ -322,7 +322,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Abrufen von Testergebnissen -->
+		<!-- 5. Abrufen von Testergebnissen -->
 		<section>
 			<h2>5. ABRUFEN VON TESTERGEBNISSEN</h2>
 
@@ -333,7 +333,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Auslösen einer Warnung -->
+		<!-- 6. Auslösen einer Warnung -->
 		<section>
 			<h2>6. AUSLÖSEN EINER WARNUNG</h2>
 
@@ -354,7 +354,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Voraussetzungen für die Nutzung der App -->
+		<!-- 7. Voraussetzungen für die Nutzung der App -->
 		<section>
 			<h2>7. VORAUSSETZUNGEN FÜR DIE NUTZUNG DER APP</h2>
 
@@ -385,7 +385,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Grenzen der App -->
+		<!-- 8. Grenzen der App -->
 		<section>
 			<h2>8. GRENZEN DER APP</h2>
 
@@ -398,7 +398,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Nutzungsrechte -->
+		<!-- 9. Nutzungsrechte -->
 		<section>
 			<p>9. NUTZUNGSRECHTE</p>
 
@@ -422,7 +422,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Wichtige Hinweise zu Verfügbarkeit und Änderungen -->
+		<!-- 10. Wichtige Hinweise zu Verfügbarkeit und Änderungen -->
 		<section>
 			<h2>10. WICHTIGE HINWEISE ZU VERFÜGBARKEIT UND ÄNDERUNGEN</h2>
 
@@ -442,7 +442,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Keine Gewährleistung -->
+		<!-- 11. Keine Gewährleistung -->
 		<section>
 			<h2>11. KEINE GEWÄHRLEISTUNG</h2>
 
@@ -460,7 +460,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Besondere Bedingungen für die iOS-Version der App -->
+		<!-- 12. Besondere Bedingungen für die iOS-Version der App -->
 		<section>
 			<h2>12. BESONDERE BEDINGUNGEN FÜR DIE IOS-VERSION DER APP</h2>
 
@@ -500,7 +500,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Schlussbestimmungen -->
+		<!-- 13. Schlussbestimmungen -->
 		<section>
 			<h2>13. SCHLUSSBESTIMMUNGEN</h2>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -80,6 +80,14 @@
 			}
 
 
+			h5 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: normal;
+				text-decoration: underline;
+			}
+
+
 			p, ul {
 				/*font-size: 17px;*/
 				font-size: 1.0rem;
@@ -127,6 +135,11 @@
 
 
 			h4 {
+				margin-bottom: 1rem;
+			}
+
+
+			h5 {
 				margin-bottom: 1rem;
 			}
 
@@ -194,7 +207,7 @@
 		<p>&nbsp;</p>
 
 
-		<!-- Preambel -->
+		<!-- Präambel -->
 		<section>
 			<p>Herausgeber der App ist das</p>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -310,7 +310,6 @@
 			<p><a>www.infektionsschutz.de/coronavirus</a></p>
 			<p><a>www.zusammengegencorona.de</a></p>
 			<p><a>www.rki.de/covid-19</a></p>
-
 			<p>Diese weiterführenden Informationen dienen lediglich Ihrer Information und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
 
 			<p>Halten Sie sich auch bei Verwendung der App an die <strong>AHA-Regeln</strong>:</p>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -306,7 +306,7 @@
 
 		<p>Bitte prüfen Sie in den Einstellungen ihres Endgeräts, ob diese Funktionen aktiviert und für die Verwendung der App freigegeben sind.</p>
 
-		<p>Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android finden Sie unter [<i>Link</i>]. Die Anleitung dient lediglich der Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.</p>
+		<p>Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android finden Sie unter https://www.coronawarn.app/de/. Die Anleitung dient lediglich der Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.</p>
 
 		<h3>Sie müssen immer die aktuelle Version der App verwenden</h3>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -72,6 +72,14 @@
 			}
 
 
+			h4 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: 600;
+				font-style: italic;
+			}
+
+
 			p, ul {
 				/*font-size: 17px;*/
 				font-size: 1.0rem;
@@ -118,6 +126,11 @@
 			}
 
 
+			h4 {
+				margin-bottom: 1rem;
+			}
+
+
 			p, ul, li {
 				margin-bottom: 1rem;
 			}
@@ -152,7 +165,7 @@
 		<!--<h2>Title 2</h2>-->
 		<!--<h3>Headline</h3>-->
 		<!--<p>Body</p>-->
-		<!--<aside>Subheadline</aside>-->
+		<!--<span>Subheadline</span>-->
 		<!--<aside>Footnote</aside>-->
 
 
@@ -319,7 +332,7 @@
 
 			<p>Wenn Sie nicht sicher sind, ob Sie sich infiziert haben oder nicht, dann kontaktieren Sie bitte Ihren Hausarzt oder das zuständige Gesundheitsamt, bevor Sie eine Warnung auslösen. Hier erhalten Sie weitere Beratung und können sich erforderlichenfalls auf eine Infektion testen lassen. In der Zwischenzeit befolgen Sie die allgemein gültigen Empfehlungen für das Verhalten bei dem Verdacht einer SARS-CoV-2-Infektion.</p>
 
-			<p><strong><em>Missbrauchsverbot</em></strong></p>
+			<h4>Missbrauchsverbot</h4>
 
 			<p><strong>Das missbräuchliche Auslösen einer Warnung ist untersagt und kann schwerwiegende Konsequenzen nach sich ziehen.</strong> Insbesondere können Sie sich eventuell gegenüber anderen betroffenen Personen schadenersatzpflichtig machen.</p>
 
@@ -334,13 +347,13 @@
 
 			<p>Folgende technische Voraussetzungen sind für die Nutzung der App erforderlich:</p>
 
-			<p><strong><em>Sie benötigen eine Datenverbindung</em></strong></p>
+			<h4>Sie benötigen eine Datenverbindung</h4>
 			<p>Bestimmte Funktionen der App setzen auf zentrale Dienste und Systeme auf, die über die CWA-Dienste zur Verfügung gestellt werden. Diese Funktionen stehen daher nur zur Verfügung, wenn Ihr Endgerät über eine Datenverbindung mit dem Internet verfügt, z.B. über UMTS, LTE oder WLAN, um hierüber auf die CWA-Dienste zugreifen zu können. Ohne Datenverbindung stehen einige oder alle Funktionen der App nicht zur Verfügung. Dies gilt auch, wenn Sie Ihr Endgerät in den Flugmodus versetzen oder ausschalten.</p>
 
-			<p><strong><em>Die App muss auf dem Endgerät laufen und eingeschaltet sein</em></strong></p>
+			<h4>Die App muss auf dem Endgerät laufen und eingeschaltet sein</h4>
 			<p>Die App muss auf Ihrem Endgerät im Vorder- oder Hintergrund laufen und eingeschaltet sein. Hierzu müssen Sie die App starten. Wenn Sie die App nicht starten, ausschalten oder beenden, speichert die App keine Begegnungen mit anderen Personen und erzeugt keine Zufallscodes zur Speicherung durch andere Personen. Wenn Sie das Endgerät neu starten (z.B. nach dem Ausschalten, nachdem die Batterie leer war oder nach einem Update des Betriebssystems), müssen Sie auch die App neu starten.</p>
 
-			<p><strong><em>Einstellungen im Endgerät</em></strong></p>
+			<h4>Einstellungen im Endgerät</h4>
 			<p>Für die Nutzung der App müssen Sie ferner die Bluetooth (BLE)-Funktionen auf Ihrem Endgerät aktivieren und ggf. zur Verwendung durch die App freigegeben.</p>
 			<p>Für die Nutzung der App empfiehlt das RKI ferner folgende Funktionen auf Ihrem Endgerät zu aktivieren und ggf. zur Verwendung durch die App freizugegeben, auch wenn diese nicht Voraussetzung für die Nutzung der grundlegenden Funktionen der App sind:</p>
 			<ul>
@@ -350,10 +363,10 @@
 			<p>Bitte prüfen Sie in den Einstellungen ihres Endgeräts, ob diese Funktionen aktiviert und für die Verwendung der App freigegeben sind.</p>
 			<p>Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android finden Sie unter [Link]. Die Anleitung dient lediglich der Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.</p>
 
-			<p><strong><em>Sie müssen immer die aktuelle Version der App verwenden</em></strong></p>
+			<h4>Sie müssen immer die aktuelle Version der App verwenden</h4>
 			<p>Das RKI wird von Zeit zu Zeit Updates der App zur Verfügung stellen. Sie müssen diese Updates unverzüglich installieren und immer die neueste verfügbare Version der App verwenden. Beim Verwenden älterer Versionen kann es zu Fehlfunktionen und Störungen kommen.</p>
 
-			<p><strong><em>Sie benötigen aktuelle Versionen von iOS bzw. Android</em></strong></p>
+			<h4>Sie benötigen aktuelle Versionen von iOS bzw. Android</h4>
 			<p>Die App verwendet eigens von Apple in iOS und Google in Android implementierte Funktionen (sog. Exposure Notification). Diese stehen in iOS erst ab Version 13.5 und in Android erst ab Version 6 zur Verfügung. Die App funktioniert daher leider nicht mit früheren Versionen der beiden Betriebssysteme.</p>
 		</section>
 		<p>&nbsp;</p>
@@ -376,20 +389,20 @@
 		<section>
 			<p>9. NUTZUNGSRECHTE</p>
 
-			<p><strong><em>Einfaches Nutzungsrecht</em></strong></p>
+			<h4>Einfaches Nutzungsrecht</h4>
 			<p>Hiermit wird Ihnen eine eingeschränkte, nicht ausschließliche, nicht übertragbare, nicht unterlizenzierbare, widerrufliche Lizenz zur Nutzung der App für Ihre persönlichen, nicht kommerziellen Zwecke gewährt.</p>
 			<p>Die Lizenz für die iOS-Version der App umfasst die Nutzung auf jedem Apple-Gerät, an dem Sie Eigentum haben oder über das Sie Kontrolle ausüben, im Rahmen der geltenden Nutzungsbedingungen des App Stores, wobei auch über andere Apple Accounts, die mit Ihrem Apple Account via Family Sharing oder Volumenkauf verbunden sind, auf die App zugegriffen und diese genutzt werden kann.</p>
 			<p>Sie dürfen im Rahmen von Datensicherungen Kopien der App anfertigen. Darüberhinausgehende Rechte an der App werden Ihnen nicht eingeräumt.</p>
 
-			<p><strong><em>Eigentum an der App</em></strong></p>
+			<h4>Eigentum an der App</h4>
 			<p>Die App (einschließlich des Quellcodes) ist das alleinige und ausschließliche Eigentum von SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf („<strong>SAP</strong>“) oder deren Lizenzgebern, vorbehaltlich der Ihnen nach Ziffer 9 eingeräumten Rechte sowie sonstiger Rechte an der App, die SAP der Bundesrepublik Deutschland vertraglich eingeräumt hat.</p>
 
-			<p><strong><em>Open Source-Lizenzhinweise</em></strong></p>
+			<h4>Open Source-Lizenzhinweise</h4>
 			<p>Information über die Verwendung von Drittkomponenten in der App und die anwendbaren Lizenzbestimmungen finden Sie in den Open Source-Lizenzhinweisen in der App.</p>
 			<p>Der Quellcode der App ist unter den Lizenzbedingungen der "Apache 2.0 License" veröffentlicht und kann unter "<a>https://github.com/corona-warn-app</a>" heruntergeladen werden. Die Lizenzbedingungen der "Apache 2.0 License" sind unter "<a>https://www.apache.org/licenses/LICENSE-2.0</a>" abrufbar.</p>
 			<p>Die auf den Quellcode der App sowie auf in der App enthaltene Drittkomponenten jeweils anwendbaren Lizenzbestimmungen bleiben von der Rechteeinräumung nach dieser Ziffer 9 unberührt.</p>
 
-			<p><strong><em>Was nicht erlaubt ist</em></strong></p>
+			<h4>Was nicht erlaubt ist</h4>
 			<p>Sie dürfen die App nicht manipulieren oder verändern.</p>
 			<p>Sie dürfen die App und die Schnittstellen zu den CWA-Diensten nicht missbräuchlich verwenden. Sie dürfen die CWA-Dienste nicht für andere Zwecke nutzen als den bestimmungsgemäßen Betrieb der App auf Ihrem Endgerät. Sie dürfen auf die CWA-Dienste ausschließlich über die App zugreifen.</p>
 		</section>
@@ -400,17 +413,17 @@
 		<section>
 			<h2>10. WICHTIGE HINWEISE ZU VERFÜGBARKEIT UND ÄNDERUNGEN</h2>
 
-			<p><strong><em>Kein Anspruch auf bestimmte Funktionalität</em></strong></p>
+			<h4>Kein Anspruch auf bestimmte Funktionalität</h4>
 			<p>Die App wird Ihnen so zur Verfügung gestellt, wie sie vom RKI herausgegeben wird. Das RKI übernimmt keine Gewähr für die Funktionsfähigkeit der App oder der CWA-Dienste und vereinbart mit Ihnen keine bestimmte Beschaffenheit. Sie haben keinen Anspruch auf eine bestimmte Funktionalität oder anderweitige Beschaffenheit der App oder der CWA-Dienste. Das RKI kann die App jederzeit ändern und Funktionen ganz oder teilweise entfernen oder die App um zusätzliche Funktionen erweitern.</p>
 
-			<p><strong><em>Keine Verfügbarkeitszusage</em></strong></p>
+			<h4>Keine Verfügbarkeitszusage</h4>
 			<p>Das RKI kann den Betrieb der App und der CWA-Dienste jederzeit einschränken oder einstellen. Es besteht Ihrerseits kein Anspruch auf die weitergehende Verfügbarkeit der App oder der damit verbundenen Dienste und Systeme einschließlich der CWA-Dienste, weder in Bezug auf einzelne Funktionen noch in Bezug auf das System als Ganzes.</p>
 			<p>Das RKI macht keine Zusagen über die Verfügbarkeit oder Leistungsfähigkeit der CWA-Dienste. Diese können aufgrund von Wartungsarbeiten oder Störungen vorübergehend und ggf. auch für längere Zeiträume nicht zur Verfügung stehen. In diesen Fällen ist die Funktionalität der App ganz oder teilweise eingeschränkt.</p>
 
-			<p><strong><em>Änderung der Nutzungsbedingungen</em></strong></p>
+			<h4>Änderung der Nutzungsbedingungen</h4>
 			<p>Das RKI behält sich vor, diese Nutzungsbedingungen zu ändern. In diesem Fall werden Sie beim Start der App aufgefordert, den geänderten Nutzungsbedingungen zuzustimmen. Wenn Sie den geänderten Nutzungsbedingungen nicht zustimmen, können Sie die App und die CWA- Dienste nicht mehr nutzen und müssen die App von Ihrem Endgerät löschen.</p>
 
-			<p><strong><em>Risk Score</em></strong></p>
+			<h4>Risk Score</h4>
 			<p>Das RKI behält sich ferner vor, die im Rahmen der Risikobewertung (<em>risk score</em>) verwendeten Parameter jederzeit zu ändern, um dadurch jeweils aktuellen Forschungsergebnissen zur Virusübertragung zu entsprechen. Das RKI bestimmt die verwendeten Parameter jeweils nach seinem Ermessen.</p>
 		</section>
 		<p>&nbsp;</p>
@@ -440,16 +453,16 @@
 
 			<p>Die folgenden Bedingungen gelten für den Bezug der App über den Apple App Store und die Nutzung der App unter dem Betriebssystem iOS.</p>
 
-			<p><strong><em>Einwilligung zur Nutzung von Daten</em></strong></p>
+			<h4>Einwilligung zur Nutzung von Daten</h4>
 			<p>Sie erklären sich damit einverstanden, dass das RKI technische Daten und zugehörige Informationen – insbesondere technische Informationen über Ihr Gerät, System und Ihre Anwendungssoftware sowie Peripheriegeräte – erheben und nutzen darf, die in regelmäßigen Abständen erfasst werden, um die Bereitstellung von Software-Aktualisierungen, Produkt-Support und anderen im Zusammenhang mit der App gegenüber Ihnen erbrachten Dienstleistungen (soweit gegeben) zu erleichtern. Das RKI darf diese Informationen nutzen, um seine Produkte zu verbessern oder Ihnen Dienstleistungen oder Technologien zur Verfügung zu stellen, solange dies in einer Form erfolgt, die Ihre Identität nicht preisgibt.</p>
 
-			<p><strong><em>Wartung und Support</em></strong></p>
+			<h4>Wartung und Support</h4>
 			<p>Das RKI ist als Herausgeber der App allein verantwortlich für Wartung und Support der App nach Maßgabe dieser Nutzungsbedingungen. Apple übernimmt keinerlei Verpflichtung zur Erbringung irgendwelcher Wartungs- und Supportleistungen in Bezug auf die App.</p>
 
-			<p><strong><em>Keine Haftung von Apple für Störungen</em></strong></p>
+			<h4>Keine Haftung von Apple für Störungen</h4>
 			<p>Im Fall von Störungen der App steht es Ihnen frei, Apple hierüber zu informieren. Soweit gesetzlich zulässig hat Apple keine weitergehenden Pflichten wegen Störungen der App.</p>
 
-			<p><strong><em>Produkthaftung</em></strong></p>
+			<h4>Produkthaftung</h4>
 			<p>Apple ist nicht verantwortlich für etwaige Ansprüche Ihrerseits oder von Dritten in Bezug auf die App oder deren Besitz oder Verwendung einschließlich</p>
 			<ul>
 				<li>Ansprüchen wegen Produkthaftung,</li>
@@ -458,17 +471,17 @@
 			</ul>
 			<p>einschließlich im Zusammenhang mit der Nutzung der HealthKit und HomeKit-Frameworks.</p>
 
-			<p><strong><em>Verletzung von Schutzrechten Dritter</em></strong></p>
+			<h4>Verletzung von Schutzrechten Dritter</h4>
 			<p>Für den Fall, dass Dritte Ansprüche wegen der Verletzung von Schutzrechten durch die App oder den Besitz oder die Verwendung der App durch Sie geltend machen, ist Apple nicht verantwortlich für Untersuchungen, Verteidigung, Beilegung oder Erfüllung solcher Ansprüche wegen der Verletzung von Schutzrechten.</p>
 
-			<p><strong><em>US Embargos und Sanktionen</em></strong></p>
+			<h4>US Embargos und Sanktionen</h4>
 			<p>Mit Anerkennen dieser Nutzungsbedingungen bestätigten Sie,</p>
 			<ul>
 				<li>dass Sie sich nicht in einem Land aufhalten, das einem Embargo der Regierung der Vereinigten Staaten von Amerika unterliegt oder von der Regierung der Vereinigten Staaten von Amerika als Unterstützer von Terroristen (<em>"terrorist supporting" country</em>) designiert wurde und</li>
 				<li>dass Sie nicht auf einer Liste der Regierung der Vereinigten Staaten von Amerika als sog. <em>Prohibited or Restricted Party</em> geführt werden.</li>
 			</ul>
 
-			<p><strong><em>Drittbegünstigung von Apple</em></strong></p>
+			<h4>Drittbegünstigung von Apple</h4>
 			<p>Sie erkennen an und erklären sich damit einverstanden, dass Apple ein Drittbegünstigter unter diesen Nutzungsbedingungen ist und Apple daher diese Nutzungsbedingungen Ihnen gegenüber durchsetzen kann. Die Änderung und Aufhebung dieser Nutzungsbedingungen einschließlich der Rechte von Apple hierunter bleibt den Vertragsparteien vorbehalten und bedarf nicht der Zustimmung von Apple.</p>
 		</section>
 		<p>&nbsp;</p>
@@ -478,16 +491,16 @@
 		<section>
 			<h2>13. SCHLUSSBESTIMMUNGEN</h2>
 
-			<p><strong><em>Bestimmungsgemäße Nutzung / Sperrung bei missbräuchlicher Verwendung</em></strong></p>
+			<h4>Bestimmungsgemäße Nutzung / Sperrung bei missbräuchlicher Verwendung</h4>
 			<p>Sie dürfen die App und die CWA-Dienste nur bestimmungsgemäß nutzen. Das RKI behält sich vor, Sie bei missbräuchlicher Verwendung der App oder nicht bestimmungsgemäßem Zugriff auf die CWA-Dienste von der Nutzung der App und der CWA-Dienste auszuschließen.</p>
 
-			<p><strong><em>Dienste Dritter</em></strong></p>
+			<h4>Dienste Dritter</h4>
 			<p>Sofern Sie im Zusammenhang mit der Nutzung der App Dienste Dritter in Anspruch nehmen, insbesondere die Dienste von Telekommunikationsdienstleistern für die Bereitstellung einer Datenverbindung, sind Sie für damit im Zusammenhang stehenden Kosten und die Einhaltung der jeweiligen Vertragsbedingungen selbst verantwortlich.</p>
 
-			<p><strong><em>Anwendbares Recht</em></strong></p>
+			<h4>Anwendbares Recht</h4>
 			<p>Diese Nutzungsbedingungen unterliegen dem Recht der Bundesrepublik Deutschland. Das Übereinkommen der Vereinten Nationen über Verträge über den internationalen Warenkauf findet keine Anwendung. Die gesetzlichen Vorschriften zur Beschränkung der Rechtswahl und zur Anwendbarkeit zwingender Vorschriften insbesondere des Staates, in dem Sie als Verbraucher Ihren gewöhnlichen Aufenthalt haben, bleiben unberührt.</p>
 
-			<p><strong><em>Teilunwirksamkeit</em></strong></p>
+			<h4>Teilunwirksamkeit</h4>
 			<p>Diese Nutzungsbedingungen bleiben auch bei rechtlicher Unwirksamkeit einzelner Punkte in ihren übrigen Teilen verbindlich. Anstelle der unwirksamen Punkte treten, soweit vorhanden, die gesetzlichen Vorschriften. Soweit dies für eine Vertragspartei eine unzumutbare Härte darstellen würde, werden die Nutzungsbedingungen jedoch im Ganzen unwirksam.</p>
 		</section>
 		<p>&nbsp;</p>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -515,7 +515,6 @@
 			<h4>Teilunwirksamkeit</h4>
 			<p>Diese Nutzungsbedingungen bleiben auch bei rechtlicher Unwirksamkeit einzelner Punkte in ihren übrigen Teilen verbindlich. Anstelle der unwirksamen Punkte treten, soweit vorhanden, die gesetzlichen Vorschriften. Soweit dies für eine Vertragspartei eine unzumutbare Härte darstellen würde, werden die Nutzungsbedingungen jedoch im Ganzen unwirksam.</p>
 		</section>
-		<p>&nbsp;</p>
 
 
 	</body>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -239,25 +239,25 @@
 			<p>Ziel der Corona Warn App ist es, SARS-CoV-2-Infektionsketten frühzeitig zu durchbrechen. Personen sollen möglichst zuverlässig und schnell über Begegnungen mit infizierten Personen und damit mögliche Übertragungen des Virus informiert werden, damit sie sich freiwillig isolieren können, um damit zu einer Eindämmung der SARS-CoV-2-Pandemie beizutragen.</p>
 			<p>Die wesentlichen Funktionen der App sind nachstehend beschrieben. Hierbei handelt es sich um eine Beschreibung zu Ihrer Information und nicht um eine Beschaffenheitsvereinbarung oder die Vereinbarung bestimmter Funktionen, bitte beachten Sie die diesbezüglichen Hinweise und Vorbehalte unter Ziffer 10.</p>
 
-			<h3>Hintergrund</h3>
+			<h4>Hintergrund</h4>
 			<p>Die App läuft auf dem Endgerät im Hintergrund und speichert automatisiert und verschlüsselt die Zufallscodes (rolling proximity identifier) anderer in der Nähe befindlicher Endgeräte. In regelmäßigen Abständen holt sich die App über die CWA-Dienste eine Liste der Zufallscodes (temporary exposure keys) der Personen, die sich freiwillig infiziert gemeldet haben, und vergleicht diese mit den gespeicherten Zufallscodes im Gerät, um eine Risiko-Begegnung zu ermitteln.</p>
 			<p>Die App kann nur Begegnungen mit Personen registrieren, die ihrerseits ein Endgerät mit installierter App bei sich führen und alle Voraussetzungen für die Nutzung der App erfüllen (siehe unten Ziffer 7). Begegnungen mit anderen Personen kann die App nicht registrieren.</p>
 
-			<h3>Risikobenachrichtigung</h3>
+			<h4>Risikobenachrichtigung</h4>
 			<p>Bei einer festgestellten Risiko-Begegnung zu positiv getesteten Personen erhalten Sie eine Benachrichtigung und verhaltensbezogene Empfehlungen. Hier kann zum Beispiel die Kontaktaufnahme mit ärztlichem Fachpersonal, mit dem zuständigen Gesundheitsamt und/oder die freiwillige häusliche Isolation empfohlen werden.</p>
 
-			<h3>Benachrichtigung über Testergebnisse</h3>
+			<h4>Benachrichtigung über Testergebnisse</h4>
 			<p>Ab dem Zeitpunkt der Probenabgabe für einen Test auf eine SARS-CoV-2-Infektion können Sie über die App den digitalen Testinformationsprozess starten und damit über das Testergebnis benachrichtigt werden. Die App übermittelt lediglich das vom jeweiligen Labor mitgeteilte Testergebnis. Das RKI ist weder für die Durchführung des Tests noch für den Inhalt des Testergebnisses verantwortlich.</p>
 
-			<h3>Infektfall</h3>
+			<h4>Infektfall</h4>
 			<p>Im Fall eines positiven SARS-CoV-2-Befunds können Sie freiwillig die in der App gespeicherten eigenen Zufallscodes der letzten 14 Tage als Positivkennungen (diagnosis keys) veröffentlichen, damit andere Personen, die die App nutzen, auf ihrem eigenen Endgerät abgleichen können, ob sie mit Ihnen eine Risiko-Begegnung hatten.</p>
 
-			<h3>Technische Beschreibung der App</h3>
+			<h4>Technische Beschreibung der App</h4>
 			<p>Die technischen Funktionen der App sowie der damit verbundenen Dienste und Systeme sind unter folgendem Link detailliert beschrieben:</p>
 			<p><a>https://github.com/Corona-Warn-App</a></p>
 			<p>Diese technische Beschreibung dient lediglich der Erläuterung und ist nicht Bestandteil dieser Nutzungsbedingungen. Sie stellt auch keine Beschaffenheitsvereinbarung in Bezug auf die App dar.</p>
 
-			<h3>Weiterführende Informationen</h3>
+			<h4>Weiterführende Informationen</h4>
 			<p>Weiterführende Informationen zur App finden Sie unter folgendem Link: <a>https://www.coronawarn.app/de/</a></p>
 			<p>Weiterführende Informationen zur SARS-CoV-2-Pandemie finden Sie unter folgendem Link: <a>https://www.zusammengegencorona.de/</a></p>
 			<p>Diese weiterführenden Informationen dienen lediglich der Erläuterung und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
@@ -340,7 +340,7 @@
 
 			<p>Falls das zugelassene Testlabor noch nicht an die CWA-Dienste angeschlossen ist, erfolgt eine Überprüfung Ihres Infektionsstatus über eine vom RKI eingerichtete Verifikations-Hotline. Das Auslösen einer Warnung über die App auf der Grundlage einer bloßen Risiko-Mitteilung ist nicht zulässig.</p>
 
-			<p><strong>Bei Unsicherheit: erst Hausarzt oder Gesundheitsamt kontaktieren</strong></p>
+			<h4>Bei Unsicherheit: erst Hausarzt oder Gesundheitsamt kontaktieren</h4>
 
 			<p>Wenn Sie nicht sicher sind, ob Sie sich infiziert haben oder nicht, dann kontaktieren Sie bitte Ihren Hausarzt oder das zuständige Gesundheitsamt, bevor Sie eine Warnung auslösen. Hier erhalten Sie weitere Beratung und können sich erforderlichenfalls auf eine Infektion testen lassen. In der Zwischenzeit befolgen Sie die allgemein gültigen Empfehlungen für das Verhalten bei dem Verdacht einer SARS-CoV-2-Infektion.</p>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -17,6 +17,11 @@
 			}
 
 
+			a {
+				text-decoration: underline;
+			}
+
+
 			a[href] {
 				color: var(--ena-text-tint-color);
 			}
@@ -38,6 +43,11 @@
 				html, body, table {
 					font: -apple-system-body !important;
 				}
+			}
+
+
+			section {
+				margin-bottom: 3rem;
 			}
 
 
@@ -83,13 +93,13 @@
 			}
 
 
-			ul {
-				list-style-type: disc;
+			li {
+				text-indent: 2em;
 			}
 
 
-			li {
-				text-indent: 2em;
+			ul > ul li {
+				text-indent: 4em;
 			}
 
 
@@ -112,342 +122,376 @@
 				margin-bottom: 1rem;
 			}
 
-				</style>
+
+			body.browser {
+				padding: 3rem;
+				width: 38.5rem;
+				margin: 0 auto;
+			}
+
+
+			body.browser,
+			body.browser,
+			body.browser table {
+				font-family: "Times New Roman", serif !important;
+			}
+
+
+			body.browser p {
+				text-align: justify;
+			}
+			</style>
 	</head>
 
 	<body>
 
-		<!--<h1>Nutzungsbedingungen</h1>-->
 
-		<h2>Inhalt</h2>
-		<h3>1.  Welche Funktionen hat die APP? </h3>
-		<h3>2.  Was bedeutet niedriges oder erhöhtes Risiko?</h3>
-		<h3>3.  Risiko-Begegnung – was tun?</h3>
-		<h3>4.  Kein Infektionsschutz durch die App</h3>
-		<h3>5.  Abrufen von Testergebnissen</h3>
-		<h3>6.  Auslösen einer Warnung</h3>
-		<h3>7.  Voraussetzungen für die Nutzung der App</h3>
-		<h3>8.  Grenzen der App</h3>
-		<h3>9.  Nutzungsrechte </h3>
-		<h3>10. Wichtige Hinweise zu Verfügbarkeit und Änderungen</h3>
-		<h3>11. Keine Gewährleistung</h3>
-		<h3>12. Besondere Bedingungen für die iOS-Version der App</h3>
-		<h3>13. Schlussbestimmungen</h3>
+		<!-- Templates -->
 
-		<p></p>
+		<!--<h1>Title 1</h1>-->
+		<!--<h2>Title 2</h2>-->
+		<!--<h3>Headline</h3>-->
+		<!--<p>Body</p>-->
+		<!--<aside>Subheadline</aside>-->
+		<!--<aside>Footnote</aside>-->
 
-		<p>Herausgeber der App ist das</p>
 
-	
-		<p>
-			Robert Koch-Institut<br>
-			Nordufer 20<br>
-			13353 Berlin ('<b>RKI</b>')
-		</p>
+		<!-- Document: "CWA EULA DE.docx" -->
+		<!-- Updated: 13.06.20 -->
 
-		<p>vertreten durch den Präsidenten. Für Fragen, Beschwerden und Ansprüche im Zusammenhang mit diesen Nutzungsbedingungen können Sie das RKI telefonisch unter +49 30 18754-5100 und per E-Mail unter CoronaWarnApp@rki.de erreichen.</p>
 
-		<p>Bitte lesen Sie diese Nutzungsbedingungen sorgfältig. Diese Nutzungsbedingungen regeln Ihre Nutzung der Corona Warn App einschließlich der Nutzung zukünftiger Versionen (Patches, Updates und Upgrades) ('<b>App</b>') und der Nutzung weiterer Dienste ('<b>CWA-Dienste</b>'), die derzeit oder zukünftig vom RKI im Zusammenhang mit der App bereitgestellt werden. Die separate Datenschutzerklärung (siehe https://www.coronawarn.app/assets/documents/cwa-privacy-notice-de.pdf) ist Bestandteil dieser Nutzungsbedingungen. Bitte lesen Sie auch die Datenschutzerklärung sorgfältig.</p>
+		<!-- Inhalt -->
+		<section>
+			<h2>INHALT</h2>
 
-		<p>Die App ist für die Nutzung auf iOS-Geräten im Apple App Store verfügbar und für die Nutzung auf Android-Geräten bei Google Play. Allgemeine Nutzungsbedingungen für Applikationen von Apple oder Google finden im Verhältnis zum RKI keine Anwendung. Das RKI ist allein verantwortlich für die Inhalte der App sowie deren Wartung und Pflege und für Ansprüche, die Sie ggf. in Bezug auf die App haben.</p>
+			<p>1. Welche Funktionen hat die App?</p>
+			<p>2. Was bedeutet niedriges oder erhöhtes Risiko?</p>
+			<p>3. Risiko-Begegnung – was tun?</p>
+			<p>4. Kein Infektionsschutz durch die App</p>
+			<p>5. Abrufen von Testergebnissen</p>
+			<p>6. Auslösen einer Warnung</p>
+			<p>7. Voraussetzungen für die Nutzung der App</p>
+			<p>8. Grenzen der App</p>
+			<p>9. Nutzungsrechte</p>
+			<p>10. Wichtige Hinweise zu Verfügbarkeit und Änderungen</p>
+			<p>11. Keine Gewährleistung</p>
+			<p>12. Besondere Bedingungen für die iOS-Version der App</p>
+			<p>13. Schlussbestimmungen</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Mit der Installation und Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Sollten Sie mit den Nutzungsbedingungen nicht einverstanden sein, dürfen Sie die App nicht installieren oder nutzen (bzw. müssen diese wieder löschen) und dürfen auch die die damit verbundenen Dienste und Systeme nicht nutzen. Etwaige Rechte unter Open Source-Lizenzen in Bezug auf den Quellcode der App bleiben hiervon unberührt.</p>
 
-		<p>Sie sind für die Einhaltung dieser Nutzungsbedingungen auch dann verantwortlich, wenn Sie das Endgerät, auf dem Sie die App installiert haben, Dritten überlassen und diese die App verwenden.</p>
+		<!-- Preambel -->
+		<section>
+			<p>Herausgeber der App ist das</p>
 
-		<p>Die App richtet sich an Personen, die mindestens 16 Jahre alt sind. Personen unter 16 Jahren dürfen die App nur mit Zustimmung ihres/ihrer Sorgeberechtigten verwenden.</p>
+			<p>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Robert Koch-Institut<br>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Nordufer 20<br>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin ("<strong>RKI</strong>")
+			</p>
 
-		<h2>1. Welche Funktionen hat die APP?</h2>
+			<p>vertreten durch den Präsidenten. Für Fragen, Beschwerden und Ansprüche im Zusammenhang mit diesen Nutzungsbedingungen können Sie das RKI telefonisch unter +49 30 18754-5100 und per E-Mail unter CoronaWarnApp@rki.de erreichen.</p>
 
-		<p>Ziel der Corona Warn App ist es, SARS-CoV-2-Infektionsketten frühzeitig zu durchbrechen. Personen sollen möglichst zuverlässig und schnell über Begegnungen mit infizierten Personen und damit mögliche Übertragungen des Virus informiert werden, damit sie sich freiwillig isolieren können, um damit zu einer Eindämmung der SARS-CoV-2-Pandemie beizutragen.</p>
+			<p>Bitte lesen Sie diese Nutzungsbedingungen sorgfältig. Diese Nutzungsbedingungen regeln Ihre Nutzung der Corona Warn App einschließlich der Nutzung zukünftiger Versionen (Patches, Updates und Upgrades) ("<strong>App</strong>") und der Nutzung weiterer Dienste ("<strong>CWA-Dienste</strong>"), die derzeit oder zukünftig vom RKI im Zusammenhang mit der App bereitgestellt werden. Die separate Datenschutzerklärung (siehe <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-de.pdf</a>) ist Bestandteil dieser Nutzungsbedingungen. Bitte lesen Sie auch die Datenschutzerklärung sorgfältig.</p>
 
-		<p>Die wesentlichen Funktionen der App sind nachstehend beschrieben. Hierbei handelt es sich um eine Beschreibung zu Ihrer Information und nicht um eine Beschaffenheitsvereinbarung oder die Vereinbarung bestimmter Funktionen, bitte beachten Sie die diesbezüglichen Hinweise und Vorbehalte unter Ziffer 10.</p>
+			<p>Die App ist für die Nutzung auf iOS-Geräten im Apple App Store verfügbar und für die Nutzung auf Android-Geräten bei Google Play. Allgemeine Nutzungsbedingungen für Applikationen von Apple oder Google finden im Verhältnis zum RKI keine Anwendung. Das RKI ist allein verantwortlich für die Inhalte der App sowie deren Wartung und Pflege und für Ansprüche, die Sie ggf. in Bezug auf die App haben.</p>
 
-		<h3>Hintergrund</h3>
+			<p>Mit der Installation und Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Sollten Sie mit den Nutzungsbedingungen nicht einverstanden sein, dürfen Sie die App nicht installieren oder nutzen (bzw. müssen diese wieder löschen) und dürfen auch die die damit verbundenen Dienste und Systeme nicht nutzen. Etwaige Rechte unter Open Source-Lizenzen in Bezug auf den Quellcode der App bleiben hiervon unberührt.</p>
 
-		<p>Die App läuft auf dem Endgerät im Hintergrund und speichert automatisiert und verschlüsselt die Zufallscodes (<i>rolling proximity identifier</i>) anderer in der Nähe befindlicher Endgeräte. In regelmäßigen Abständen holt sich die App über dieCWA-Dienste eine Liste der Zufallscodes (<i>temporary exposure keys</i>) der Personen, die sich freiwillig infiziert gemeldet haben, und vergleicht diese mit den gespeicherten Zufallscodes im Gerät, um eine Risiko-Begegnung zu ermitteln.</p>
+			<p>Sie sind für die Einhaltung dieser Nutzungsbedingungen auch dann verantwortlich, wenn Sie das Endgerät, auf dem Sie die App installiert haben, Dritten überlassen und diese die App verwenden.</p>
 
-		<p>Die App kann nur Begegnungen mit Personen registrieren, die ihrerseits ein Endgerät mit installierter App bei sich führen und alle Voraussetzungen für die Nutzung der App erfüllen (siehe unten Ziffer 7). Begegnungen mit anderen Personen kann die App nicht registrieren.</p>
+			<p>Die App richtet sich an Personen, die mindestens 16 Jahre alt sind. Personen unter 16 Jahren dürfen die App nur mit Zustimmung ihres/ihrer Sorgeberechtigten verwenden.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h3>Risikobenachrichtigung</h3>
 
-		<p>Bei einer festgestellten Risiko-Begegnung zu positiv getesteten Personen erhalten Sie eine Benachrichtigung und verhaltensbezogene Empfehlungen. Hier kann zum Beispiel die Kontaktaufnahme mit ärztlichem Fachpersonal, mit dem zuständigen Gesundheitsamt und/oder die freiwillige häusliche Isolation empfohlen werden.</p>
+		<!-- Welche Funktionen hat die App? -->
+		<section>
+			<h2>1. WELCHE FUNKTIONEN HAT DIE APP?</h2>
 
-		<h3>Benachrichtigung über Testergebnisse</h3>
+			<p>Ziel der Corona Warn App ist es, SARS-CoV-2-Infektionsketten frühzeitig zu durchbrechen. Personen sollen möglichst zuverlässig und schnell über Begegnungen mit infizierten Personen und damit mögliche Übertragungen des Virus informiert werden, damit sie sich freiwillig isolieren können, um damit zu einer Eindämmung der SARS-CoV-2-Pandemie beizutragen.</p>
+			<p>Die wesentlichen Funktionen der App sind nachstehend beschrieben. Hierbei handelt es sich um eine Beschreibung zu Ihrer Information und nicht um eine Beschaffenheitsvereinbarung oder die Vereinbarung bestimmter Funktionen, bitte beachten Sie die diesbezüglichen Hinweise und Vorbehalte unter Ziffer 10.</p>
 
-		<p>Ab dem Zeitpunkt der Probenabgabe für einen Test auf eine SARS-CoV-2-Infektion
-		können Sie über die App den digitalen Testinformationsprozess starten und damit
-		über das Testergebnis benachrichtigt werden. Die App übermittelt lediglich das
-		vom jeweiligen Labor mitgeteilte Testergebnis. Das RKI ist weder für die Durchführung
-		des Tests noch für den Inhalt des Testergebnisses verantwortlich.</p>
+			<h3>Hintergrund</h3>
+			<p>Die App läuft auf dem Endgerät im Hintergrund und speichert automatisiert und verschlüsselt die Zufallscodes (rolling proximity identifier) anderer in der Nähe befindlicher Endgeräte. In regelmäßigen Abständen holt sich die App über die CWA-Dienste eine Liste der Zufallscodes (temporary exposure keys) der Personen, die sich freiwillig infiziert gemeldet haben, und vergleicht diese mit den gespeicherten Zufallscodes im Gerät, um eine Risiko-Begegnung zu ermitteln.</p>
+			<p>Die App kann nur Begegnungen mit Personen registrieren, die ihrerseits ein Endgerät mit installierter App bei sich führen und alle Voraussetzungen für die Nutzung der App erfüllen (siehe unten Ziffer 7). Begegnungen mit anderen Personen kann die App nicht registrieren.</p>
 
-		<h3>Infektfall</h3>
+			<h3>Risikobenachrichtigung</h3>
+			<p>Bei einer festgestellten Risiko-Begegnung zu positiv getesteten Personen erhalten Sie eine Benachrichtigung und verhaltensbezogene Empfehlungen. Hier kann zum Beispiel die Kontaktaufnahme mit ärztlichem Fachpersonal, mit dem zuständigen Gesundheitsamt und/oder die freiwillige häusliche Isolation empfohlen werden.</p>
 
-		<p>Im Fall eines positiven SARS-CoV-2-Befunds können Sie freiwillig die in der App gespeicherten eigenen Zufallscodes der letzten 14 Tage als Positivkennungen (<i>diagnosis keys</i>) veröffentlichen, damit andere Personen, die die App nutzen, auf ihrem eigenen Endgerät abgleichen können, ob sie mit Ihnen eine Risiko-Begegnung hatten.</p>
+			<h3>Benachrichtigung über Testergebnisse</h3>
+			<p>Ab dem Zeitpunkt der Probenabgabe für einen Test auf eine SARS-CoV-2-Infektion können Sie über die App den digitalen Testinformationsprozess starten und damit über das Testergebnis benachrichtigt werden. Die App übermittelt lediglich das vom jeweiligen Labor mitgeteilte Testergebnis. Das RKI ist weder für die Durchführung des Tests noch für den Inhalt des Testergebnisses verantwortlich.</p>
 
-		<h3>Technische Beschreibung der App</h3>
+			<h3>Infektfall</h3>
+			<p>Im Fall eines positiven SARS-CoV-2-Befunds können Sie freiwillig die in der App gespeicherten eigenen Zufallscodes der letzten 14 Tage als Positivkennungen (diagnosis keys) veröffentlichen, damit andere Personen, die die App nutzen, auf ihrem eigenen Endgerät abgleichen können, ob sie mit Ihnen eine Risiko-Begegnung hatten.</p>
 
-		<p>Die technischen Funktionen der App sowie der damit verbundenen Dienste und Systeme sind unter folgendem Link detailliert beschrieben:</p>
+			<h3>Technische Beschreibung der App</h3>
+			<p>Die technischen Funktionen der App sowie der damit verbundenen Dienste und Systeme sind unter folgendem Link detailliert beschrieben:</p>
+			<a>https://github.com/Corona-Warn-App</a>
+			<p>Diese technische Beschreibung dient lediglich der Erläuterung und ist nicht Bestandteil dieser Nutzungsbedingungen. Sie stellt auch keine Beschaffenheitsvereinbarung in Bezug auf die App dar.</p>
 
-		<p>https://github.com/Corona-Warn-App</p>
+			<h3>Weiterführende Informationen</h3>
+			<p>Weiterführende Informationen zur App finden Sie unter folgendem Link: <a>https://www.coronawarn.app/de/</a></p>
+			<p>Weiterführende Informationen zur SARS-CoV-2-Pandemie finden Sie unter folgendem Link: <a>https://www.zusammengegencorona.de/</a></p>
+			<p>Diese weiterführenden Informationen dienen lediglich der Erläuterung und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Diese technische Beschreibung dient lediglich der Erläuterung und ist nicht Bestandteil dieser Nutzungsbedingungen. Sie stellt auch keine Beschaffenheitsvereinbarung in Bezug auf die App dar.</p>
 
-		<h3>Weiterführende Informationen</h3>
+		<!-- Was bedeutet niedriges oder erhöhtes Risiko -->
+		<section>
+			<h2>2. WAS BEDEUTET NIEDRIGES ODER ERHÖHTES RISIKO?</h2>
 
-		<p>Weiterführende Informationen zur App finden Sie unter folgendem Link: https://www.coronawarn.app/de/</p>
+			<p>Die App berechnet auf Basis der festgestellten Begegnungen ein indikatives individuelles Risiko. Hierbei werden Faktoren wie der Zeitraum seit der Begegnung (<em>days since exposure</em>), die Dauer der Begegnung (<em>exposure duration</em>), die ungefähre Nähe zur infizierten Person, basierend auf der gemessenen Dämpfung des Bluetooth-Signals (<em>signal attenuation</em>) sowie ggf. Übertragungsrisiken (<em>transmission</em>) risk berücksichtigt. Auf dieser Basis wird Ihnen in der App entweder ein "niedriges Risiko" oder ein "erhöhtes Risiko" angezeigt. Es handelt sich hierbei um einen rein indikativen Wert auf der Grundlage der erfassten Daten. <strong>Eine Aussage über das Vorliegen einer tatsächlichen Infektion mit SARS-CoV-2 ist hiermit nicht verbunden</strong>. Auch bei der Angabe eines "niedrigen Risikos" kann eine Infektion vorliegen, während auch bei Angabe eines "erhöhten Risikos" eine Infektion nicht gegeben sein kann.</p>
 
-		<p>Weiterführende
-		Informationen zur SARS-CoV-2-Pandemie finden Sie unter folgendem Link: https://www.zusammengegencorona.de/</p>
+			<p><strong>Andere Faktoren können Ihr persönliches Infektionsrisiko erheblich beeinflussen. Diese werden von der App nicht berücksichtigt.</strong> Das sind insbesondere Ihre persönlichen Umstände, die äußeren Umstände einer Risiko-Begegnung mit einer infizierten Person, Ihr persönliches Verhalten sowie Begegnungen mit Dritten, die von der App nicht erfasst wurden. Bitte beachten Sie die Hinweise in Ziffer 4.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Diese weiterführenden Informationen dienen lediglich der Erläuterung und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
 
-		<h2>2. Was bedeutet niedriges oder erhöhtes Risiko?</h2>
+		<!-- Risiko-Begegnung - Was tun? -->
+		<section>
+			<h2>3. RISIKO-BEGEGNUNG – WAS TUN?</h2>
 
-		<p>Die App berechnet auf Basis der festgestellten Begegnungen ein indikatives individuelles Risiko. Hierbei werden Faktoren wie der Zeitraum seit der Begegnung (<i>days since exposure</i>), die Dauer der Begegnung (<i>exposure duration</i>), die ungefähre Nähe zur infizierten Person, basierend auf der gemessenen Dämpfung des Bluetooth-Signals (<i>signal attenuation</i>) sowie ggf. Übertragungsrisiken (<i>transmission risk</i>) berücksichtigt. Auf dieser Basis wird Ihnen in der App entweder ein 'niedriges Risiko' oder ein 'erhöhtes Risiko' angezeigt. Es handelt sich hierbei um einen rein indikativen Wert auf der Grundlage der erfassten Daten. <b>Eine Aussage über das Vorliegen einer tatsächlichen Infektion mit SARS-CoV-2 ist hiermit nicht verbunden.</b> Auch bei der Angabe eines 'niedrigen Risikos' kann eine Infektion vorliegen, während auch bei Angabe eines 'erhöhten Risikos' eine Infektion nicht gegeben sein kann.</p>
+			<p>Wenn Sie über die App eine Benachrichtigung über eine festgestellte Risiko-Begegnung mit infizierten Personen erhalten, erhalten Sie verhaltensbezogene Empfehlungen in der Benachrichtigung. Diese Empfehlungen sind rechtlich nicht verbindlich, ihre Befolgung wird aber vom RKI empfohlen. Gesetzliche und vertragliche Pflichten sowie behördliche Anordnungen für den Fall einer Risiko-Begegnung mit infizierten Personen bleiben unberührt und müssen von Ihnen unabhängig von diesen Empfehlungen befolgt werden.</p>
 
-		<p><b>Andere Faktoren können Ihr persönliches Infektionsrisiko erheblich beeinflussen. Diese werden von der App nicht berücksichtigt.</b> Das sind insbesondere Ihre persönlichen Umstände, die äußeren Umstände einer Risiko-Begegnung mit einer infizierten Person, Ihr persönliches Verhalten sowie Begegnungen mit Dritten, die von der App nicht erfasst wurden. Bitte beachten Sie die Hinweise in Ziffer 4.</p>
+			<p><strong>Innerhalb oder über die App erfolgt keinerlei medizinische Diagnose.</strong></p>
 
-		<h2>3. Risiko-Begegnung – was tun?</h2>
+			<p><strong>Die Benachrichtigung bedeutet nicht, dass Sie sich mit SARS-CoV-2 infiziert haben.</strong> Sie besagt lediglich, dass sie während der letzten 14 Tage eine Risiko-Begegnung mit einer anderen Person hatten, bei der eine SARS-CoV-2-Infektion positiv festgestellt wurde. Hieraus ergibt sich für Sie zunächst nur eine Möglichkeit, dass Sie sich ebenfalls infiziert haben könnten. Die Einstufung des diesbezüglichen Risikos als "niedrig" oder "erhöht" erfolgt allein auf der Basis der ermittelten Daten und lässt keine Aussage über das tatsächliche Vorliegen einer Infektion zu.</p>
 
-		<p>Wenn Sie über die App eine Benachrichtigung über eine festgestellte Risiko-Begegnung mit infizierten Personen erhalten, erhalten Sie verhaltensbezogene Empfehlungen in der Benachrichtigung. Diese Empfehlungen sind rechtlich nicht verbindlich, ihre Befolgung wird aber vom RKI empfohlen. Gesetzliche und vertragliche Pflichten sowie behördliche Anordnungen für den Fall einer Risiko-Begegnung mit infizierten Personen bleiben unberührt und müssen von Ihnen unabhängig von diesen Empfehlungen befolgt werden.</p>
+			<p><strong>Die Benachrichtigung über eine Risiko-Begegnung kann unzutreffend sein.</strong> Die Risiko-Begegnung kann von Ihrem Endgerät beispielsweise zu einem Zeitpunkt registriert worden sein, zu dem Sie sich nicht in der Nähe Ihres Endgeräts aufgehalten haben oder während eine andere Person Ihr Endgerät verwendet hat. Die Risiko-Begegnung kann auch aufgrund bestehender Grenzen bei der Kontaktmessung fälschlicherweise registriert worden sein (siehe unten Ziffer 8).</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p><b>Innerhalb oder über die App erfolgt keinerlei medizinische Diagnose.</b></p>
 
-		<p><b>Die Benachrichtigung bedeutet nicht, dass Sie sich mit SARS-CoV-2 infiziert haben.</b>Sie besagt lediglich, dass sie während der letzten 14 Tage eine Risiko-Begegnung mit einer anderen Person hatten, bei der eine SARS-CoV-2-Infektion positiv festgestellt wurde. Hieraus ergibt sich für Sie zunächst nur eine Möglichkeit, dass Sie sich ebenfalls infiziert haben könnten. Die Einstufung des diesbezüglichen Risikos als 'niedrig'oder 'erhöht' erfolgt allein auf der Basis der ermittelten Daten und lässt keine Aussage über das tatsächliche Vorliegen einer Infektion zu.</p>
+		<!-- Kein Infektionsschutz durch die App -->
+		<section>
+			<h2>4. KEIN INFEKTIONSSCHUTZ DURCH DIE APP</h2>
 
-		<p><b>Die Benachrichtigung über eine Risiko-Begegnung kann unzutreffend sein.</b> Die Risiko-Begegnung
-		kann von Ihrem Endgerät beispielsweise zu einem Zeitpunkt registriert worden
-		sein, zu dem Sie sich nicht in der Nähe Ihres Endgeräts aufgehalten haben oder
-		während eine andere Person Ihr Endgerät verwendet hat. Die Risiko-Begegnung kann
-		auch aufgrund bestehender Grenzen bei der Kontaktmessung fälschlicherweise
-		registriert worden sein (siehe unten Ziffer 8).</p>
-
-		<h2>4. Kein Infektionsschutz durch die App</h2>
-
-		<p>Die App dient der Unterbrechung von Infektionsketten.</p>
-
-		<ul>
-			<li>Die App schützt Sie nicht vor einer SARS-CoV-2-Infektion.</li>
-			<li>Die App reduziert Ihr persönliches Infektionsrisiko nicht.</li>
-			<li>Sie können sich auch mit SARS-CoV-2 infizieren, ohne dass die App Sie über die Risiko-Begegnung mit der Person benachrichtigt, die Sie infiziert hat:</li>
+			<p>Die App dient der Unterbrechung von Infektionsketten.</p>
 			<ul>
-				<li>Die App registriert nicht alle Ihre Begegnungen mit anderen Personen, z.B. weil andere Personen die App nicht verwenden, Sie Ihr Endgerät nicht immer bei sich tragen oder die App nicht immer in Betrieb haben oder weil die Kontaktmessung gewissen Grenzen unterliegt (siehe unten Ziffer 8).</li>
-				<li>Die App informiert Sie nur über festgestellte Risiko-Begegnungen mit infizierten Personen. Das setzt voraus, dass die App die Begegnung mit der infizierten Person registriert hat <u>und</u> die infizierte Person eine Warnung über die App auslöst. Das Auslösen der Warnung ist freiwillig und erfolgt möglicherweise nicht durch alle infizierten Personen.</li>
+				<li><strong>Die App schützt Sie nicht vor einer SARS-CoV-2-Infektion.</strong></li>
+				<li><strong>Die App reduziert Ihr persönliches Infektionsrisiko nicht.</strong></li>
+				<li><strong>Sie können sich auch mit SARS-CoV-2 infizieren, ohne dass die App Sie über die Risiko-Begegnung mit der Person benachrichtigt, die Sie infiziert hat:</strong></li>
+				<ul>
+					<li>Die App registriert nicht alle Ihre Begegnungen mit anderen Personen, z.B. weil andere Personen die App nicht verwenden, Sie Ihr Endgerät nicht immer bei sich tragen oder die App nicht immer in Betrieb haben oder weil die Kontaktmessung gewissen Grenzen unterliegt (siehe unten Ziffer 8).</li>
+					<li>Die App informiert Sie nur über festgestellte Risiko-Begegnungen mit infizierten Personen. Das setzt voraus, dass die App die Begegnung mit der infizierten Person registriert hat <u>und</u> die infizierte Person eine Warnung über die App auslöst. Das Auslösen der Warnung ist freiwillig und erfolgt möglicherweise nicht durch alle infizierten Personen.</li>
+				</ul>
 			</ul>
-		</ul>
 
+			<p>Bitte halten Sie auch bei Verwendung der App die sonstigen Vorsichtsmaßnahmen und behördlichen Anordnungen ein. Verlässliche Informationen über die SARS-CoV-2-Pandemie und Vorsichtsmaßnahmen finden Sie unter anderem auf:</p>
+			<p><a>www.infektionsschutz.de/coronavirus</a></p>
+			<p><a>www.zusammengegencorona.de</a></p>
+			<p><a>www.rki.de/covid-19</a></p>
 
-		<p></p>
+			<p>Diese weiterführenden Informationen dienen lediglich Ihrer Information und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
 
-		<p>Bitte halten Sie auch bei Verwendung der App die sonstigen Vorsichtsmaßnahmen und behördlichen Anordnungen ein. Verlässliche Informationen über die SARS-CoV-2-Pandemie und Vorsichtsmaßnahmen finden Sie unter anderem auf:</p>
+			<p>Halten Sie sich auch bei Verwendung der App an die <strong>AHA-Regeln</strong>:</p>
+			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Halten Sie mindestens 1,5m Abstand zu Ihren Mitmenschen</p>
+			<p><strong>H</strong>&nbsp;&nbsp;&nbsp;- Waschen Sie sich regelmäßig für mindestens 20 Sekunden die Hände</p>
+			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Tragen Sie beim Einkauf und in öffentlichen Verkehrsmitteln eine Alltagsmaske</p>
+			<p>So schützen Sie sich selbst und andere vor dem Virus.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>www.infektionsschutz.de/coronavirus</p>
 
-		<p>www.zusammengegencorona.de</p>
+		<!-- Abrufen von Testergebnissen -->
+		<section>
+			<h2>5. ABRUFEN VON TESTERGEBNISSEN</h2>
 
-		<p>www.rki.de/covid-19</p>
+			<p>Sie dürfen über die App ausschließlich Ihre eigenen Testergebnisse abrufen.</p>
 
-		<p>Diese weiterführenden Informationen dienen lediglich Ihrer Information und sind nicht Bestandteil dieser Nutzungsbedingungen.</p>
+			<p>Wenn Sie auf Testergebnisse warten und die CWA-Dienste nicht zur Verfügung stehen oder der Abruf der Testergebnisse über die App aus sonstigen Gründen nicht funktioniert, dann informieren Sie sich bitte über andere Kontaktwege über das Testergebnis, z.B. über die jeweilige Teststelle wie Ihren Hausarzt oder das örtliche Gesundheitsamt. Warten Sie nicht darauf, dass die App wieder zur Verfügung steht.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Halten Sie sich auch bei Verwendung der App an die <b>AHA-Regeln</b>:</p>
 
-		<p><b>A</b> ✋  - Halten Sie mindestens 1,5m Abstand zu Ihren Mitmenschen</p>
-		<p><b>H</b> �  - Waschen Sie sich regelmäßig für mindestens 20 Sekunden die Hände</p>
-		<p><b>A</b> �  - Tragen Sie beim Einkauf und in öffentlichen Verkehrsmitteln eine Alltagsmaske</p>
+		<!-- Auslösen einer Warnung -->
+		<section>
+			<h2>6. AUSLÖSEN EINER WARNUNG</h2>
 
-		<p>So schützen Sie sich selbst und andere vor dem Virus.</p>
+			<p>Sie können über die App andere Kontaktpersonen warnen, wenn Sie mit SARS-CoV-2 infiziert wurden. <strong>Sie dürfen diese Warnung nur auslösen, wenn die Infektion durch einen Test in einem zugelassenen Testlabor positiv bestätigt wurde.</strong></p>
 
-		<h2>Abrufen von Testergebnissen</h2>
+			<p>Falls das zugelassene Testlabor noch nicht an die CWA-Dienste angeschlossen ist, erfolgt eine Überprüfung Ihres Infektionsstatus über eine vom RKI eingerichtete Verifikations-Hotline. Das Auslösen einer Warnung über die App auf der Grundlage einer bloßen Risiko-Mitteilung ist nicht zulässig.</p>
 
-		<p>Sie dürfen über die App ausschließlich Ihre eigenen Testergebnisse abrufen.</p>
+			<p><strong>Bei Unsicherheit: erst Hausarzt oder Gesundheitsamt kontaktieren</strong></p>
 
-		<p>Wenn Sie auf Testergebnisse warten und die CWA-Dienste nicht zur Verfügung stehen oder der Abruf der Testergebnisse über die App aus sonstigen Gründen nicht funktioniert, dann informieren Sie sich bitte über andere Kontaktwege über das Testergebnis, z.B. über die jeweilige Teststelle wie Ihren Hausarzt oder das örtliche Gesundheitsamt. Warten Sie nicht darauf, dass die App wieder zur Verfügung steht.</p>
+			<p>Wenn Sie nicht sicher sind, ob Sie sich infiziert haben oder nicht, dann kontaktieren Sie bitte Ihren Hausarzt oder das zuständige Gesundheitsamt, bevor Sie eine Warnung auslösen. Hier erhalten Sie weitere Beratung und können sich erforderlichenfalls auf eine Infektion testen lassen. In der Zwischenzeit befolgen Sie die allgemein gültigen Empfehlungen für das Verhalten bei dem Verdacht einer SARS-CoV-2-Infektion.</p>
 
-		<h2>Auslösen einer Warnung</h2>
+			<p><strong><em>Missbrauchsverbot</em></strong></p>
 
-		<p>Sie können über die App andere Kontaktpersonen warnen, wenn Sie mit SARS-CoV-2 infiziert wurden.<b>Sie dürfen diese Warnung nur auslösen, wenn die Infektion durch einen Test in einem zugelassenen Testlabor positiv bestätigt wurde.</b></p>
+			<p><strong>Das missbräuchliche Auslösen einer Warnung ist untersagt und kann schwerwiegende Konsequenzen nach sich ziehen.</strong> Insbesondere können Sie sich eventuell gegenüber anderen betroffenen Personen schadenersatzpflichtig machen.</p>
 
-		<p>Falls das zugelassene Testlabor noch nicht an die CWA-Dienste angeschlossen ist, erfolgt eine Überprüfung Ihres Infektionsstatus über eine vom RKI eingerichtete Verifikations-Hotline. Das Auslösen einer Warnung über die App auf der Grundlage einer bloßen Risiko-Mitteilung ist nicht zulässig.</p>
+			<p>Das RKI behält sich vor, Sie bei Feststellung eines missbräuchlichen Verhaltens von der weiteren Nutzung der App und der CWA-Dienste auszuschließen.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h3>Bei Unsicherheit: erst Hausarzt oder Gesundheitsamt kontaktieren</h3>
 
-		<p>Wenn Sie nicht sicher sind, ob Sie sich infiziert haben oder nicht, dann kontaktieren Sie bitte Ihren Hausarzt oder das zuständige Gesundheitsamt, bevor Sie eine Warnung auslösen. Hier erhalten Sie weitere Beratung und können sich erforderlichenfalls auf eine Infektion testen lassen. In der Zwischenzeit befolgen Sie die allgemein gültigen Empfehlungen für das Verhalten bei dem Verdacht einer SARS-CoV-2-Infektion.</p>
+		<!-- Voraussetzungen für die Nutzung der App -->
+		<section>
+			<h2>7. VORAUSSETZUNGEN FÜR DIE NUTZUNG DER APP</h2>
 
-		<h3>Missbrauchsverbot</h3>
+			<p>Folgende technische Voraussetzungen sind für die Nutzung der App erforderlich:</p>
 
-		<p><b>Das missbräuchliche Auslösen einer Warnung ist untersagt und kann schwerwiegende Konsequenzen nach sich ziehen.</b> Insbesondere können Sie sich eventuell gegenüber anderen betroffenen Personen schadenersatzpflichtig machen.</p>
+			<p><strong><em>Sie benötigen eine Datenverbindung</em></strong></p>
+			<p>Bestimmte Funktionen der App setzen auf zentrale Dienste und Systeme auf, die über die CWA-Dienste zur Verfügung gestellt werden. Diese Funktionen stehen daher nur zur Verfügung, wenn Ihr Endgerät über eine Datenverbindung mit dem Internet verfügt, z.B. über UMTS, LTE oder WLAN, um hierüber auf die CWA-Dienste zugreifen zu können. Ohne Datenverbindung stehen einige oder alle Funktionen der App nicht zur Verfügung. Dies gilt auch, wenn Sie Ihr Endgerät in den Flugmodus versetzen oder ausschalten.</p>
 
-		<p>Das RKI behält sich vor, Sie bei Feststellung eines missbräuchlichen Verhaltens von der weiteren Nutzung der App und der CWA-Dienste auszuschließen.</p>
+			<p><strong><em>Die App muss auf dem Endgerät laufen und eingeschaltet sein</em></strong></p>
+			<p>Die App muss auf Ihrem Endgerät im Vorder- oder Hintergrund laufen und eingeschaltet sein. Hierzu müssen Sie die App starten. Wenn Sie die App nicht starten, ausschalten oder beenden, speichert die App keine Begegnungen mit anderen Personen und erzeugt keine Zufallscodes zur Speicherung durch andere Personen. Wenn Sie das Endgerät neu starten (z.B. nach dem Ausschalten, nachdem die Batterie leer war oder nach einem Update des Betriebssystems), müssen Sie auch die App neu starten.</p>
 
-		<h2>7. Voraussetzungen für die Nutzung der App</h2>
+			<p><strong><em>Einstellungen im Endgerät</em></strong></p>
+			<p>Für die Nutzung der App müssen Sie ferner die Bluetooth (BLE)-Funktionen auf Ihrem Endgerät aktivieren und ggf. zur Verwendung durch die App freigegeben.</p>
+			<p>Für die Nutzung der App empfiehlt das RKI ferner folgende Funktionen auf Ihrem Endgerät zu aktivieren und ggf. zur Verwendung durch die App freizugegeben, auch wenn diese nicht Voraussetzung für die Nutzung der grundlegenden Funktionen der App sind:</p>
+			<ul>
+				<li>Benachrichtigungen</li>
+				<li>Kamerafunktion</li>
+			</ul>
+			<p>Bitte prüfen Sie in den Einstellungen ihres Endgeräts, ob diese Funktionen aktiviert und für die Verwendung der App freigegeben sind.</p>
+			<p>Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android finden Sie unter [Link]. Die Anleitung dient lediglich der Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.</p>
 
-		<p>Folgende technische Voraussetzungen sind für die Nutzung der App erforderlich:</p>
+			<p><strong><em>Sie müssen immer die aktuelle Version der App verwenden</em></strong></p>
+			<p>Das RKI wird von Zeit zu Zeit Updates der App zur Verfügung stellen. Sie müssen diese Updates unverzüglich installieren und immer die neueste verfügbare Version der App verwenden. Beim Verwenden älterer Versionen kann es zu Fehlfunktionen und Störungen kommen.</p>
 
-		<h3>Sie benötigen eine Datenverbindung</h3>
+			<p><strong><em>Sie benötigen aktuelle Versionen von iOS bzw. Android</em></strong></p>
+			<p>Die App verwendet eigens von Apple in iOS und Google in Android implementierte Funktionen (sog. Exposure Notification). Diese stehen in iOS erst ab Version 13.5 und in Android erst ab Version 6 zur Verfügung. Die App funktioniert daher leider nicht mit früheren Versionen der beiden Betriebssysteme.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Bestimmte Funktionen der App setzen auf zentrale Dienste und Systeme auf, die über dieCWA-Dienste zur Verfügung gestellt werden. Diese Funktionen stehen daher nur zur Verfügung, wenn Ihr Endgerät über eine Datenverbindung mit dem Internet verfügt, z.B. über UMTS, LTE oder WLAN, um hierüber auf dieCWA-Dienste zugreifen zu können. Ohne Datenverbindung stehen einige oder alle Funktionen der App nicht zur Verfügung. Dies gilt auch, wenn Sie Ihr Endgerät in den Flugmodus versetzen oder ausschalten.</p>
 
-		<h3>Die App muss auf dem Endgerät laufen und eingeschaltet sein</h3>
+		<!-- Grenzen der App -->
+		<section>
+			<h2>8. GRENZEN DER APP</h2>
 
-		<p>Die App muss auf Ihrem Endgerät im Vorder- oder Hintergrund laufen und eingeschaltet sein. Hierzu müssen Sie die App starten. Wenn Sie die App nicht starten, ausschalten oder beenden, speichert die App keine Begegnungen mit anderen Personen und erzeugt keine Zufallscodes zur Speicherung durch andere Personen. Wenn Sie das Endgerät neu starten (z.B. nach dem Ausschalten, nachdem die Batterie leer war oder nach einem Update des Betriebssystems), müssen Sie auch die App neu starten.</p>
+			<p>Die App kann Sie dabei unterstützen, Risiko-Begegnungen mit Personen zu erkennen, die später positiv getestet wurden. Die App hat aber auch Grenzen, die berücksichtigt werden müssen.</p>
 
-		<h3>Einstellungen im Endgerät</h3>
+			<p>Eine dieser Grenzen ist, dass die App zwar laufend eigene Zufallscodes (<em>Rolling Proximity Identifiers</em>) aussendet, aber andere Zufallscodes nur in bestimmten Intervallen empfängt. Diese Empfangsfenster liegen derzeit noch bis zu fünf Minuten auseinander und sind nur als sehr kurz spezifiziert. Diese Funktionalitäten sind Bestandteil der Exposure Notification Frameworks von Google beziehungsweise Apple, welche jederzeit geändert werden können.</p>
 
-		<p>Für die Nutzung der App müssen Sie ferner die Bluetooth (BLE)-Funktionen auf Ihrem Endgerät aktivieren und ggf. zur Verwendung durch die App freigegeben.</p>
+			<p>Für die Entfernungsmessung wird die Dämpfung des Bluetooth-Signals verwendet. Eine geringere Dämpfung bedeutet dabei grundsätzlich, dass das andere Endgerät näher ist. Eine höhere Dämpfung kann entweder bedeuten, dass das andere Endgerät weiter entfernt ist (also eine Entfernung von mehr als zwei Metern) oder dass sich zwischen den beiden Endgeräten etwas befindet, was das Signal blockiert. Das können Objekte wie eine Wand oder eine Tasche, in der sich das Endgerät befindet, sein, aber genauso Personen oder Tiere.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Für die Nutzung der App empfiehlt das RKI ferner folgende Funktionen auf Ihrem Endgerät zu aktivieren und ggf. zur Verwendung durch die App freizugegeben, auch wenn diese nicht Voraussetzung für die Nutzung der grundlegenden Funktionen der App sind:</p>
 
-		<ul>
-			<li>Benachrichtigungen</li>
-			<li>Kamerafunktion</li>
-		</ul>
+		<!-- Nutzungsrechte -->
+		<section>
+			<p>9. NUTZUNGSRECHTE</p>
 
+			<p><strong><em>Einfaches Nutzungsrecht</em></strong></p>
+			<p>Hiermit wird Ihnen eine eingeschränkte, nicht ausschließliche, nicht übertragbare, nicht unterlizenzierbare, widerrufliche Lizenz zur Nutzung der App für Ihre persönlichen, nicht kommerziellen Zwecke gewährt.</p>
+			<p>Die Lizenz für die iOS-Version der App umfasst die Nutzung auf jedem Apple-Gerät, an dem Sie Eigentum haben oder über das Sie Kontrolle ausüben, im Rahmen der geltenden Nutzungsbedingungen des App Stores, wobei auch über andere Apple Accounts, die mit Ihrem Apple Account via Family Sharing oder Volumenkauf verbunden sind, auf die App zugegriffen und diese genutzt werden kann.</p>
+			<p>Sie dürfen im Rahmen von Datensicherungen Kopien der App anfertigen. Darüberhinausgehende Rechte an der App werden Ihnen nicht eingeräumt.</p>
 
-		<p>Bitte prüfen Sie in den Einstellungen ihres Endgeräts, ob diese Funktionen aktiviert und für die Verwendung der App freigegeben sind.</p>
+			<p><strong><em>Eigentum an der App</em></strong></p>
+			<p>Die App (einschließlich des Quellcodes) ist das alleinige und ausschließliche Eigentum von SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf („<strong>SAP</strong>“) oder deren Lizenzgebern, vorbehaltlich der Ihnen nach Ziffer 9 eingeräumten Rechte sowie sonstiger Rechte an der App, die SAP der Bundesrepublik Deutschland vertraglich eingeräumt hat.</p>
 
-		<p>Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android finden Sie unter https://www.coronawarn.app/de/. Die Anleitung dient lediglich der Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.</p>
+			<p><strong><em>Open Source-Lizenzhinweise</em></strong></p>
+			<p>Information über die Verwendung von Drittkomponenten in der App und die anwendbaren Lizenzbestimmungen finden Sie in den Open Source-Lizenzhinweisen in der App.</p>
+			<p>Der Quellcode der App ist unter den Lizenzbedingungen der "Apache 2.0 License" veröffentlicht und kann unter "<a>https://github.com/corona-warn-app</a>" heruntergeladen werden. Die Lizenzbedingungen der "Apache 2.0 License" sind unter "<a>https://www.apache.org/licenses/LICENSE-2.0</a>" abrufbar.</p>
+			<p>Die auf den Quellcode der App sowie auf in der App enthaltene Drittkomponenten jeweils anwendbaren Lizenzbestimmungen bleiben von der Rechteeinräumung nach dieser Ziffer 9 unberührt.</p>
 
-		<h3>Sie müssen immer die aktuelle Version der App verwenden</h3>
+			<p><strong><em>Was nicht erlaubt ist</em></strong></p>
+			<p>Sie dürfen die App nicht manipulieren oder verändern.</p>
+			<p>Sie dürfen die App und die Schnittstellen zu den CWA-Diensten nicht missbräuchlich verwenden. Sie dürfen die CWA-Dienste nicht für andere Zwecke nutzen als den bestimmungsgemäßen Betrieb der App auf Ihrem Endgerät. Sie dürfen auf die CWA-Dienste ausschließlich über die App zugreifen.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Das RKI wird von Zeit zu Zeit Updates der App zur Verfügung stellen. Sie müssen diese Updates unverzüglich installieren und immer die neueste verfügbare Version der App verwenden. Beim Verwenden älterer Versionen kann es zu Fehlfunktionen und Störungen kommen.</p>
 
-		<h3>Sie benötigen aktuelle Versionen von iOS bzw. Android</h3>
+		<!-- Wichtige Hinweise zu Verfügbarkeit und Änderungen -->
+		<section>
+			<h2>10. WICHTIGE HINWEISE ZU VERFÜGBARKEIT UND ÄNDERUNGEN</h2>
 
-		<p>Die App verwendet eigens von Apple in iOS und Google in Android implementierte Funktionen (<i>sog. Exposure Notification</i>). Diese stehen in iOS erst ab Version 13.5 und in Android erst ab Version 6.0 zur Verfügung. Die App funktioniert daher leider nicht mit früheren Versionen der beiden Betriebssysteme.</p>
+			<p><strong><em>Kein Anspruch auf bestimmte Funktionalität</em></strong></p>
+			<p>Die App wird Ihnen so zur Verfügung gestellt, wie sie vom RKI herausgegeben wird. Das RKI übernimmt keine Gewähr für die Funktionsfähigkeit der App oder der CWA-Dienste und vereinbart mit Ihnen keine bestimmte Beschaffenheit. Sie haben keinen Anspruch auf eine bestimmte Funktionalität oder anderweitige Beschaffenheit der App oder der CWA-Dienste. Das RKI kann die App jederzeit ändern und Funktionen ganz oder teilweise entfernen oder die App um zusätzliche Funktionen erweitern.</p>
 
-		<h2>8. Grenzen der App</h2>
+			<p><strong><em>Keine Verfügbarkeitszusage</em></strong></p>
+			<p>Das RKI kann den Betrieb der App und der CWA-Dienste jederzeit einschränken oder einstellen. Es besteht Ihrerseits kein Anspruch auf die weitergehende Verfügbarkeit der App oder der damit verbundenen Dienste und Systeme einschließlich der CWA-Dienste, weder in Bezug auf einzelne Funktionen noch in Bezug auf das System als Ganzes.</p>
+			<p>Das RKI macht keine Zusagen über die Verfügbarkeit oder Leistungsfähigkeit der CWA-Dienste. Diese können aufgrund von Wartungsarbeiten oder Störungen vorübergehend und ggf. auch für längere Zeiträume nicht zur Verfügung stehen. In diesen Fällen ist die Funktionalität der App ganz oder teilweise eingeschränkt.</p>
 
-		<p>Die App kann Sie dabei unterstützen, Risiko-Begegnungen mit Personen zu erkennen, die später positiv getestet wurden. Die App hat aber auch Grenzen, die berücksichtigt werden müssen.</p>
+			<p><strong><em>Änderung der Nutzungsbedingungen</em></strong></p>
+			<p>Das RKI behält sich vor, diese Nutzungsbedingungen zu ändern. In diesem Fall werden Sie beim Start der App aufgefordert, den geänderten Nutzungsbedingungen zuzustimmen. Wenn Sie den geänderten Nutzungsbedingungen nicht zustimmen, können Sie die App und die CWA- Dienste nicht mehr nutzen und müssen die App von Ihrem Endgerät löschen.</p>
 
-		<p>Eine dieser Grenzen ist, dass die App zwar laufend eigene Zufallscodes (<i>Rolling Proximity Identifiers</i>) aussendet, aber andere Zufallscodes nur in bestimmten Intervallen empfängt. Diese Empfangsfenster liegen derzeit noch bis zu fünf Minuten auseinander und sind nur als sehr kurz spezifiziert. In der App sind die Empfangsfenster vier Sekunden lang.</p>
+			<p><strong><em>Risk Score</em></strong></p>
+			<p>Das RKI behält sich ferner vor, die im Rahmen der Risikobewertung (<em>risk score</em>) verwendeten Parameter jederzeit zu ändern, um dadurch jeweils aktuellen Forschungsergebnissen zur Virusübertragung zu entsprechen. Das RKI bestimmt die verwendeten Parameter jeweils nach seinem Ermessen.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Für die Entfernungsmessung wird die Dämpfung des Bluetooth-Signals verwendet. Eine geringere Dämpfung bedeutet dabei grundsätzlich, dass das andere Endgerät näher ist. Eine höhere Dämpfung kann entweder bedeuten, dass das andere Endgerät weiter entfernt ist (also eine Entfernung von mehr als zwei Metern) oder dass sich zwischen den beiden Endgeräten etwas befindet, was das Signal blockiert. Das können Objekte wie eine Wand oder eine Tasche, in der sich das Endgerät befindet, sein, aber genauso Personen oder Tiere.</p>
 
-		<h2>9. Nutzungsrechte</h2>
+		<!-- Keine Gewährleistung -->
+		<section>
+			<h2>11. KEINE GEWÄHRLEISTUNG</h2>
 
-		<h3>Einfaches Nutzungsrecht</h3>
+			<p>Das RKI bestimmt die Funktionen der App und der CWA-Dienste sowie deren Ausgestaltung. Das RKI vereinbart mit Ihnen keine bestimmte Beschaffenheit und Sie haben keinen Anspruch darauf, dass die App bestimmte Funktionen hat oder diese in bestimmter Weise ausgestaltet sind. Die App wird in dem Zustand und mit den Funktionen zur Verfügung gestellt, wie sie beim Veröffentlichen der App im Apple App Store oder bei Google Play durch das RKI implementiert sind.</p>
 
-		<p>Hiermit wird Ihnen eine eingeschränkte, nicht ausschließliche, nicht übertragbare, nicht unterlizenzierbare, widerrufliche Lizenz zur Nutzung der App für Ihre persönlichen, nicht kommerziellen Zwecke gewährt.</p>
+			<p>Das RKI wird die App mit angemessener Sorgfalt zur Verfügung stellen und angemessene Sorgfalt hinsichtlich der CWA-Dienste anwenden. Das RKI gibt keine sonstigen Versprechen oder Zusicherungen im Hinblick auf die App oder die CWA-Dienste ab und gewährleistet insbesondere nicht, dass:</p>
 
-		<p>Die Lizenz für die iOS-Version der App umfasst die Nutzung auf jedem Apple-Gerät, an dem Sie Eigentum haben oder über das Sie Kontrolle ausüben, im Rahmen der geltenden Nutzungsbedingungen des App Stores, wobei auch über andere Apple Accounts, die mit Ihrem Apple Account via Family Sharing oder Volumenkauf verbunden sind, auf die App zugegriffen und diese genutzt werden kann.</p>
+			<ul>
+				<li>Ihre Nutzung der App oder der CWA-Dienste ohne Unterbrechung möglich oder fehlerfrei sein wird,</li>
+				<li>die App oder die CWA-Dienste frei von Verlusten, Korruption, Angriffen, Viren, Eingriffen, Hacking oder anderen sicherheitsrelevanten Störungen sein werden.</li>
+			</ul>
 
-		<p>Sie dürfen im Rahmen von Datensicherungen Kopien der App anfertigen. Darüberhinausgehende Rechte an der App werden Ihnen nicht eingeräumt.</p>
+			<p>Für die Datensicherung Ihres Endgeräts sowie ggf. damit verbundener Systeme sind Sie verantwortlich, inklusive der Datensicherung sämtlicher anderer Apps, welche auf Ihrem Endgerät gespeichert sind.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h3>Eigentum an der App</h3>
 
-		<p>Die App (einschließlich des Quellcodes) ist das alleinige und ausschließliche Eigentum von SAP SE,Dietmar Hopp Allee 16, 69190 Walldorf („<b>SAP</b>“) oder deren Lizenzgebern, vorbehaltlich der Ihnen nach Ziffer 9 eingeräumten Rechte sowie sonstiger Rechte an der App, die SAP der Bundesrepublik Deutschland vertraglich eingeräumt hat.</p>
+		<!-- Besondere Bedingungen für die iOS-Version der App -->
+		<section>
+			<h2>12. BESONDERE BEDINGUNGEN FÜR DIE IOS-VERSION DER APP</h2>
 
-		<h3>Open Source-Lizenzhinweise</h3>
+			<p>Die folgenden Bedingungen gelten für den Bezug der App über den Apple App Store und die Nutzung der App unter dem Betriebssystem iOS.</p>
 
-		<p>Information über die Verwendung von Drittkomponenten in der App und die anwendbaren Lizenzbestimmungen finden Sie in den Open Source-Lizenzhinweisen in der App.</p>
+			<p><strong><em>Einwilligung zur Nutzung von Daten</em></strong></p>
+			<p>Sie erklären sich damit einverstanden, dass das RKI technische Daten und zugehörige Informationen – insbesondere technische Informationen über Ihr Gerät, System und Ihre Anwendungssoftware sowie Peripheriegeräte – erheben und nutzen darf, die in regelmäßigen Abständen erfasst werden, um die Bereitstellung von Software-Aktualisierungen, Produkt-Support und anderen im Zusammenhang mit der App gegenüber Ihnen erbrachten Dienstleistungen (soweit gegeben) zu erleichtern. Das RKI darf diese Informationen nutzen, um seine Produkte zu verbessern oder Ihnen Dienstleistungen oder Technologien zur Verfügung zu stellen, solange dies in einer Form erfolgt, die Ihre Identität nicht preisgibt.</p>
 
-		<p>Der Quellcode der App ist unter den Lizenzbedingungen der 'Apache 2.0 License' veröffentlicht und kann unter 'https://github.com/corona-warn-app' heruntergeladen werden. Die Lizenzbedingungen der 'Apache 2.0 License' sind unter 'https://www.apache.org/licenses/LICENSE-2.0' abrufbar.</p>
+			<p><strong><em>Wartung und Support</em></strong></p>
+			<p>Das RKI ist als Herausgeber der App allein verantwortlich für Wartung und Support der App nach Maßgabe dieser Nutzungsbedingungen. Apple übernimmt keinerlei Verpflichtung zur Erbringung irgendwelcher Wartungs- und Supportleistungen in Bezug auf die App.</p>
 
-		<p>Die auf den Quellcode der App sowie auf in der App enthaltene Drittkomponenten jeweils anwendbaren Lizenzbestimmungen bleiben von der Rechteeinräumung nach dieser Ziffer 9 unberührt.</p>
+			<p><strong><em>Keine Haftung von Apple für Störungen</em></strong></p>
+			<p>Im Fall von Störungen der App steht es Ihnen frei, Apple hierüber zu informieren. Soweit gesetzlich zulässig hat Apple keine weitergehenden Pflichten wegen Störungen der App.</p>
 
-		<h3>Was nicht erlaubt ist</h3>
+			<p><strong><em>Produkthaftung</em></strong></p>
+			<p>Apple ist nicht verantwortlich für etwaige Ansprüche Ihrerseits oder von Dritten in Bezug auf die App oder deren Besitz oder Verwendung einschließlich</p>
+			<ul>
+				<li>Ansprüchen wegen Produkthaftung,</li>
+				<li>Ansprüchen auf der Basis, dass die App anwendbare gesetzliche oder regulatorische Anforderungen nicht erfüllt und</li>
+				<li>Ansprüchen unter Verbrauchschutz- und Datenschutzgesetzen oder ähnlichen Gesetzen,</li>
+			</ul>
+			<p>einschließlich im Zusammenhang mit der Nutzung der HealthKit und HomeKit-Frameworks.</p>
 
-		<p>Sie dürfen die App nicht manipulieren oder verändern.</p>
+			<p><strong><em>Verletzung von Schutzrechten Dritter</em></strong></p>
+			<p>Für den Fall, dass Dritte Ansprüche wegen der Verletzung von Schutzrechten durch die App oder den Besitz oder die Verwendung der App durch Sie geltend machen, ist Apple nicht verantwortlich für Untersuchungen, Verteidigung, Beilegung oder Erfüllung solcher Ansprüche wegen der Verletzung von Schutzrechten.</p>
 
-		<p>Sie dürfen die App und die Schnittstellen zu den CWA-Diensten nicht missbräuchlich verwenden. Sie dürfen dieCWA-Dienste nicht für andere Zwecke nutzen als den bestimmungsgemäßen Betrieb der App auf Ihrem Endgerät. Sie dürfen auf dieCWA-Dienste ausschließlich über die App zugreifen.</p>
+			<p><strong><em>US Embargos und Sanktionen</em></strong></p>
+			<p>Mit Anerkennen dieser Nutzungsbedingungen bestätigten Sie,</p>
+			<ul>
+				<li>dass Sie sich nicht in einem Land aufhalten, das einem Embargo der Regierung der Vereinigten Staaten von Amerika unterliegt oder von der Regierung der Vereinigten Staaten von Amerika als Unterstützer von Terroristen (<em>"terrorist supporting" country</em>) designiert wurde und</li>
+				<li>dass Sie nicht auf einer Liste der Regierung der Vereinigten Staaten von Amerika als sog. <em>Prohibited or Restricted Party</em> geführt werden.</li>
+			</ul>
 
-		<h2>10. Wichtige Hinweise zu Verfügbarkeit und Änderungen</h2>
+			<p><strong><em>Drittbegünstigung von Apple</em></strong></p>
+			<p>Sie erkennen an und erklären sich damit einverstanden, dass Apple ein Drittbegünstigter unter diesen Nutzungsbedingungen ist und Apple daher diese Nutzungsbedingungen Ihnen gegenüber durchsetzen kann. Die Änderung und Aufhebung dieser Nutzungsbedingungen einschließlich der Rechte von Apple hierunter bleibt den Vertragsparteien vorbehalten und bedarf nicht der Zustimmung von Apple.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<h3>Kein Anspruch auf bestimmte Funktionalität</h3>
 
-		<p>Die App wird Ihnen so zur Verfügung gestellt, wie sie vom RKI herausgegeben wird. Das RKI übernimmt keine Gewähr für die Funktionsfähigkeit der App oder derCWA-Dienste und vereinbart mit Ihnen keine bestimmte Beschaffenheit. Sie haben keinen Anspruch auf eine bestimmte Funktionalität oder anderweitige Beschaffenheit der App oder derCWA-Dienste. Das RKI kann die App jederzeit ändern und Funktionen ganz oder teilweise entfernen oder die App um zusätzliche Funktionen erweitern.</p>
+		<!-- Schlussbestimmungen -->
+		<section>
+			<h2>13. SCHLUSSBESTIMMUNGEN</h2>
 
-		<h3>Keine Verfügbarkeitszusage</h3>
+			<p><strong><em>Bestimmungsgemäße Nutzung / Sperrung bei missbräuchlicher Verwendung</em></strong></p>
+			<p>Sie dürfen die App und die CWA-Dienste nur bestimmungsgemäß nutzen. Das RKI behält sich vor, Sie bei missbräuchlicher Verwendung der App oder nicht bestimmungsgemäßem Zugriff auf die CWA-Dienste von der Nutzung der App und der CWA-Dienste auszuschließen.</p>
 
-		<p>Das RKI kann den Betrieb der App und der CWA-Dienste jederzeit einschränken oder einstellen. Es besteht Ihrerseits kein Anspruch auf die weitergehende Verfügbarkeit der App oder der damit verbundenen Dienste und Systeme einschließlich derCWA-Dienste, weder in Bezug auf einzelne Funktionen noch in Bezug auf das System als Ganzes.</p>
+			<p><strong><em>Dienste Dritter</em></strong></p>
+			<p>Sofern Sie im Zusammenhang mit der Nutzung der App Dienste Dritter in Anspruch nehmen, insbesondere die Dienste von Telekommunikationsdienstleistern für die Bereitstellung einer Datenverbindung, sind Sie für damit im Zusammenhang stehenden Kosten und die Einhaltung der jeweiligen Vertragsbedingungen selbst verantwortlich.</p>
 
-		<p>Das RKI macht keine Zusagen über die Verfügbarkeit oder Leistungsfähigkeit derCWA-Dienste. Diese können aufgrund von Wartungsarbeiten oder Störungen vorübergehend und ggf. auch für längere Zeiträume nicht zur Verfügung stehen. In diesen Fällen ist die Funktionalität der App ganz oder teilweise eingeschränkt.</p>
+			<p><strong><em>Anwendbares Recht</em></strong></p>
+			<p>Diese Nutzungsbedingungen unterliegen dem Recht der Bundesrepublik Deutschland. Das Übereinkommen der Vereinten Nationen über Verträge über den internationalen Warenkauf findet keine Anwendung. Die gesetzlichen Vorschriften zur Beschränkung der Rechtswahl und zur Anwendbarkeit zwingender Vorschriften insbesondere des Staates, in dem Sie als Verbraucher Ihren gewöhnlichen Aufenthalt haben, bleiben unberührt.</p>
 
-		<h3>Änderung der Nutzungsbedingungen</h3>
+			<p><strong><em>Teilunwirksamkeit</em></strong></p>
+			<p>Diese Nutzungsbedingungen bleiben auch bei rechtlicher Unwirksamkeit einzelner Punkte in ihren übrigen Teilen verbindlich. Anstelle der unwirksamen Punkte treten, soweit vorhanden, die gesetzlichen Vorschriften. Soweit dies für eine Vertragspartei eine unzumutbare Härte darstellen würde, werden die Nutzungsbedingungen jedoch im Ganzen unwirksam.</p>
+		</section>
+		<p>&nbsp;</p>
 
-		<p>Das RKI behält sich vor, diese Nutzungsbedingungen zu ändern. In diesem Fall werden Sie beim Start der App aufgefordert, den geänderten Nutzungsbedingungen zuzustimmen. Wenn Sie den geänderten Nutzungsbedingungen nicht zustimmen, können Sie die App und die CWA-Dienste nicht mehr nutzen und müssen die App von Ihrem Endgerät löschen.</p>
-
-		<h3>Risk Score</h3>
-
-		<p>Das RKI behält sich ferner vor, die im Rahmen der Risikobewertung (<i>risk score</i>) verwendeten Parameter jederzeit zu ändern, um dadurch jeweils aktuellen Forschungsergebnissen zur Virusübertragung zu entsprechen. Das RKI bestimmt die verwendeten Parameter jeweils nach seinem Ermessen.</p>
-
-		<h2>11. Keine Gewährleistung</h2>
-
-		<p>Das RKI bestimmt die Funktionen der App und der CWA-Dienste sowie deren Ausgestaltung. Das RKI vereinbart mit Ihnen keine bestimmte Beschaffenheit und Sie haben keinen Anspruch darauf, dass die App bestimmte Funktionen hat oder diese in bestimmter Weise ausgestaltet sind. Die App wird in dem Zustand und mit den Funktionen zur Verfügung gestellt, wie sie beim Veröffentlichen der App im Apple App&nbsp;Store oder bei Google Play durch das RKI implementiert sind.</p>
-
-		<p>Das RKI wird die App mit angemessener Sorgfalt zur Verfügung stellen und angemessene Sorgfalt hinsichtlich der CWA-Dienste anwenden. Das RKI gibt keine sonstigen Versprechen oder Zusicherungen im Hinblick auf die App oder die CWA-Dienste ab und gewährleistet insbesondere nicht, dass:</p>
-
-		<ul>
-			<li>Ihre Nutzung der App oder der CWA-Dienste ohne Unterbrechung möglich oder fehlerfrei sein wird,</li>
-			<li>die App oder die CWA-Dienste frei von Verlusten, Korruption, Angriffen, Viren, Eingriffen, Hacking oder anderen sicherheitsrelevanten Störungen sein werden.</li>
-		</ul>
-
-		<p>Für die Datensicherung Ihres Endgeräts sowie ggf. damit verbundener Systeme sind Sie verantwortlich, inklusive der Datensicherung sämtlicher anderer Apps, welche auf Ihrem Endgerät gespeichert sind.</p>
-
-		<h2>12. Besondere Bedingungen für die iOS-Version der App</h2>
-
-		<p>Die folgenden Bedingungen gelten für den Bezug der App über den Apple App&nbsp;Store und die Nutzung der App unter dem Betriebssystem iOS.</p>
-
-		<h3>Einwilligung zur Nutzung von Daten</h3>
-
-		<p>Sie erklären sich damit einverstanden, dass das RKI technische Daten und zugehörige Informationen – insbesondere technische Informationen über Ihr Gerät, System und Ihre Anwendungssoftware sowie Peripheriegeräte – erheben und nutzen darf, die in regelmäßigen Abständen erfasst werden, um die Bereitstellung von Software-Aktualisierungen, Produkt-Support und anderen im Zusammenhang mit der App gegenüber Ihnen erbrachten Dienstleistungen (soweit gegeben) zu erleichtern. Das RKI darf diese Informationen nutzen, um seine Produkte zu verbessern oder Ihnen Dienstleistungen oder Technologien zur Verfügung zu stellen, solange dies in einer Form erfolgt, die Ihre Identität nicht preisgibt.</p>
-
-		<h3>Wartung und Support</h3>
-
-		<p>Das RKI ist als Herausgeber der App allein verantwortlich für Wartung und Support der App nach Maßgabe dieser Nutzungsbedingungen. Apple übernimmt keinerlei Verpflichtung zur Erbringung irgendwelcher Wartungs- und Supportleistungen in Bezug auf die App.</p>
-
-		<h3>Keine Haftung von Apple für Störungen</h3>
-
-		<p>Im Fall von Störungen der App steht es Ihnen frei, Apple hierüber zu informieren. Soweit gesetzlich zulässig hat Apple keine weitergehenden Pflichten wegen Störungen der App.</p>
-
-		<h3>Produkthaftung</h3>
-
-		<p>Apple ist nicht verantwortlich für etwaige Ansprüche Ihrerseits oder von Dritten in Bezug auf die App oder deren Besitz oder Verwendung einschließlich</p>
-
-		<ul>
-			<li>Ansprüchen wegen Produkthaftung,</li>
-			<li>Ansprüchen auf der Basis, dass die App anwendbare gesetzliche oder regulatorische Anforderungen nicht erfüllt und</li>
-			<li>Ansprüchen unter Verbrauchschutz- und Datenschutzgesetzen oder ähnlichen Gesetzen,</li>
-		</ul>
-
-		<p>einschließlich im Zusammenhang mit der Nutzung der HealthKit und HomeKit-Frameworks.</p>
-
-		<h3>Verletzung von Schutzrechten Dritter</h3>
-
-		<p>Für den Fall, dass Dritte Ansprüche wegen der Verletzung von Schutzrechten durch die App oder den Besitz oder die Verwendung der App durch Sie geltend machen, ist Apple nicht verantwortlich für Untersuchungen, Verteidigung, Beilegung oder Erfüllung solcher Ansprüche wegen der Verletzung von Schutzrechten.</p>
-
-		<h3>US Embargos und Sanktionen</h3>
-
-		<p>Mit Anerkennen dieser Nutzungsbedingungen bestätigten Sie,</p>
-
-		<ul>
-			<li>dass Sie sich nicht in einem Land aufhalten, das einem Embargo der Regierung der Vereinigten Staaten von Amerika unterliegt oder von der Regierung der Vereinigten Staaten von Amerika als Unterstützer von Terroristen (<i>'terrorist supporting'country</i>) designiert wurde und</li>
-			<li>dass Sie nicht auf einer Liste der Regierung der Vereinigten Staaten von Amerika als sog. <i>Prohibited or Restricted Party</i> geführt werden.</li>
-		</ul>
-
-		<h3>Drittbegünstigung von Apple</h3>
-
-		<p>Sie erkennen an und erklären sich damit einverstanden, dass Apple ein Drittbegünstigter unter diesen Nutzungsbedingungen ist und Apple daher diese Nutzungsbedingungen Ihnen gegenüber durchsetzen kann. Die Änderung und Aufhebung dieser Nutzungsbedingungen einschließlich der Rechte von Apple hierunter bleibt den Vertragsparteien vorbehalten und bedarf nicht der Zustimmung von Apple.</p>
-
-		<h2>13. Schlussbestimmungen</h2>
-
-		<h3>Bestimmungsgemäße Nutzung / Sperrung bei missbräuchlicher Verwendung</h3>
-
-		<p>Sie dürfen die App und die CWA-Dienste nur bestimmungsgemäß nutzen. Das RKI behält sich vor, Sie bei missbräuchlicher Verwendung der App oder nicht bestimmungsgemäßem Zugriff auf die CWA-Dienste von der Nutzung der App und der CWA-Dienste auszuschließen.</p>
-
-		<h3>Dienste Dritter</h3>
-
-		<p>Sofern Sie im Zusammenhang mit der Nutzung der App Dienste Dritter in Anspruch nehmen, insbesondere die Dienste von Telekommunikationsdienstleistern für die Bereitstellung einer Datenverbindung, sind Sie für damit im Zusammenhang stehenden Kosten und die Einhaltung der jeweiligen Vertragsbedingungen selbst verantwortlich.</p>
-
-		<h3>Anwendbares Recht</h3>
-
-		<p>Diese Nutzungsbedingungen unterliegen dem Recht der Bundesrepublik Deutschland. Das Übereinkommen der Vereinten Nationen über Verträge über den internationalen Warenkauf findet keine Anwendung. Die gesetzlichen Vorschriften zur Beschränkung der Rechtswahl und zur Anwendbarkeit zwingender Vorschriften insbesondere des Staates, in dem Sie als Verbraucher Ihren gewöhnlichen Aufenthalt haben, bleiben unberührt.</p>
-
-		<h3>Teilunwirksamkeit</h3>
-
-		<p>Diese Nutzungsbedingungen bleiben auch bei rechtlicher Unwirksamkeit einzelner Punkte in ihren übrigen Teilen verbindlich. Anstelle der unwirksamen Punkte treten, soweit vorhanden, die gesetzlichen Vorschriften. Soweit dies für eine Vertragspartei eine unzumutbare Härte darstellen würde, werden die Nutzungsbedingungen jedoch im Ganzen unwirksam.</p>
 
 	</body>
-
 </html>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/usage.html
@@ -214,12 +214,12 @@
 			<p>
 			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Robert Koch-Institut<br>
 			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Nordufer 20<br>
-			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin ("<strong>RKI</strong>")
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin („<strong>RKI</strong>“)
 			</p>
 
 			<p>vertreten durch den Präsidenten. Für Fragen, Beschwerden und Ansprüche im Zusammenhang mit diesen Nutzungsbedingungen können Sie das RKI telefonisch unter +49 30 18754-5100 und per E-Mail unter CoronaWarnApp@rki.de erreichen.</p>
 
-			<p>Bitte lesen Sie diese Nutzungsbedingungen sorgfältig. Diese Nutzungsbedingungen regeln Ihre Nutzung der Corona Warn App einschließlich der Nutzung zukünftiger Versionen (Patches, Updates und Upgrades) ("<strong>App</strong>") und der Nutzung weiterer Dienste ("<strong>CWA-Dienste</strong>"), die derzeit oder zukünftig vom RKI im Zusammenhang mit der App bereitgestellt werden. Die separate Datenschutzerklärung (siehe <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-de.pdf</a>) ist Bestandteil dieser Nutzungsbedingungen. Bitte lesen Sie auch die Datenschutzerklärung sorgfältig.</p>
+			<p>Bitte lesen Sie diese Nutzungsbedingungen sorgfältig. Diese Nutzungsbedingungen regeln Ihre Nutzung der Corona Warn App einschließlich der Nutzung zukünftiger Versionen (Patches, Updates und Upgrades) („<strong>App</strong>“) und der Nutzung weiterer Dienste („<strong>CWA-Dienste</strong>“), die derzeit oder zukünftig vom RKI im Zusammenhang mit der App bereitgestellt werden. Die separate Datenschutzerklärung (siehe <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-de.pdf</a>) ist Bestandteil dieser Nutzungsbedingungen. Bitte lesen Sie auch die Datenschutzerklärung sorgfältig.</p>
 
 			<p>Die App ist für die Nutzung auf iOS-Geräten im Apple App Store verfügbar und für die Nutzung auf Android-Geräten bei Google Play. Allgemeine Nutzungsbedingungen für Applikationen von Apple oder Google finden im Verhältnis zum RKI keine Anwendung. Das RKI ist allein verantwortlich für die Inhalte der App sowie deren Wartung und Pflege und für Ansprüche, die Sie ggf. in Bezug auf die App haben.</p>
 
@@ -269,7 +269,7 @@
 		<section>
 			<h2>2. WAS BEDEUTET NIEDRIGES ODER ERHÖHTES RISIKO?</h2>
 
-			<p>Die App berechnet auf Basis der festgestellten Begegnungen ein indikatives individuelles Risiko. Hierbei werden Faktoren wie der Zeitraum seit der Begegnung (<em>days since exposure</em>), die Dauer der Begegnung (<em>exposure duration</em>), die ungefähre Nähe zur infizierten Person, basierend auf der gemessenen Dämpfung des Bluetooth-Signals (<em>signal attenuation</em>) sowie ggf. Übertragungsrisiken (<em>transmission</em>) risk berücksichtigt. Auf dieser Basis wird Ihnen in der App entweder ein "niedriges Risiko" oder ein "erhöhtes Risiko" angezeigt. Es handelt sich hierbei um einen rein indikativen Wert auf der Grundlage der erfassten Daten. <strong>Eine Aussage über das Vorliegen einer tatsächlichen Infektion mit SARS-CoV-2 ist hiermit nicht verbunden</strong>. Auch bei der Angabe eines "niedrigen Risikos" kann eine Infektion vorliegen, während auch bei Angabe eines "erhöhten Risikos" eine Infektion nicht gegeben sein kann.</p>
+			<p>Die App berechnet auf Basis der festgestellten Begegnungen ein indikatives individuelles Risiko. Hierbei werden Faktoren wie der Zeitraum seit der Begegnung (<em>days since exposure</em>), die Dauer der Begegnung (<em>exposure duration</em>), die ungefähre Nähe zur infizierten Person, basierend auf der gemessenen Dämpfung des Bluetooth-Signals (<em>signal attenuation</em>) sowie ggf. Übertragungsrisiken (<em>transmission</em>) risk berücksichtigt. Auf dieser Basis wird Ihnen in der App entweder ein „niedriges Risiko“ oder ein „erhöhtes Risiko“ angezeigt. Es handelt sich hierbei um einen rein indikativen Wert auf der Grundlage der erfassten Daten. <strong>Eine Aussage über das Vorliegen einer tatsächlichen Infektion mit SARS-CoV-2 ist hiermit nicht verbunden</strong>. Auch bei der Angabe eines „niedrigen Risikos“ kann eine Infektion vorliegen, während auch bei Angabe eines „erhöhten Risikos“ eine Infektion nicht gegeben sein kann.</p>
 
 			<p><strong>Andere Faktoren können Ihr persönliches Infektionsrisiko erheblich beeinflussen. Diese werden von der App nicht berücksichtigt.</strong> Das sind insbesondere Ihre persönlichen Umstände, die äußeren Umstände einer Risiko-Begegnung mit einer infizierten Person, Ihr persönliches Verhalten sowie Begegnungen mit Dritten, die von der App nicht erfasst wurden. Bitte beachten Sie die Hinweise in Ziffer 4.</p>
 		</section>
@@ -284,7 +284,7 @@
 
 			<p><strong>Innerhalb oder über die App erfolgt keinerlei medizinische Diagnose.</strong></p>
 
-			<p><strong>Die Benachrichtigung bedeutet nicht, dass Sie sich mit SARS-CoV-2 infiziert haben.</strong> Sie besagt lediglich, dass sie während der letzten 14 Tage eine Risiko-Begegnung mit einer anderen Person hatten, bei der eine SARS-CoV-2-Infektion positiv festgestellt wurde. Hieraus ergibt sich für Sie zunächst nur eine Möglichkeit, dass Sie sich ebenfalls infiziert haben könnten. Die Einstufung des diesbezüglichen Risikos als "niedrig" oder "erhöht" erfolgt allein auf der Basis der ermittelten Daten und lässt keine Aussage über das tatsächliche Vorliegen einer Infektion zu.</p>
+			<p><strong>Die Benachrichtigung bedeutet nicht, dass Sie sich mit SARS-CoV-2 infiziert haben.</strong> Sie besagt lediglich, dass sie während der letzten 14 Tage eine Risiko-Begegnung mit einer anderen Person hatten, bei der eine SARS-CoV-2-Infektion positiv festgestellt wurde. Hieraus ergibt sich für Sie zunächst nur eine Möglichkeit, dass Sie sich ebenfalls infiziert haben könnten. Die Einstufung des diesbezüglichen Risikos als „niedrig“ oder „erhöht“ erfolgt allein auf der Basis der ermittelten Daten und lässt keine Aussage über das tatsächliche Vorliegen einer Infektion zu.</p>
 
 			<p><strong>Die Benachrichtigung über eine Risiko-Begegnung kann unzutreffend sein.</strong> Die Risiko-Begegnung kann von Ihrem Endgerät beispielsweise zu einem Zeitpunkt registriert worden sein, zu dem Sie sich nicht in der Nähe Ihres Endgeräts aufgehalten haben oder während eine andere Person Ihr Endgerät verwendet hat. Die Risiko-Begegnung kann auch aufgrund bestehender Grenzen bei der Kontaktmessung fälschlicherweise registriert worden sein (siehe unten Ziffer 8).</p>
 		</section>
@@ -411,7 +411,7 @@
 
 			<h4>Open Source-Lizenzhinweise</h4>
 			<p>Information über die Verwendung von Drittkomponenten in der App und die anwendbaren Lizenzbestimmungen finden Sie in den Open Source-Lizenzhinweisen in der App.</p>
-			<p>Der Quellcode der App ist unter den Lizenzbedingungen der "Apache 2.0 License" veröffentlicht und kann unter "<a>https://github.com/corona-warn-app</a>" heruntergeladen werden. Die Lizenzbedingungen der "Apache 2.0 License" sind unter "<a>https://www.apache.org/licenses/LICENSE-2.0</a>" abrufbar.</p>
+			<p>Der Quellcode der App ist unter den Lizenzbedingungen der „Apache 2.0 License“ veröffentlicht und kann unter „<a>https://github.com/corona-warn-app</a>“ heruntergeladen werden. Die Lizenzbedingungen der „Apache 2.0 License“ sind unter „<a>https://www.apache.org/licenses/LICENSE-2.0</a>“ abrufbar.</p>
 			<p>Die auf den Quellcode der App sowie auf in der App enthaltene Drittkomponenten jeweils anwendbaren Lizenzbestimmungen bleiben von der Rechteeinräumung nach dieser Ziffer 9 unberührt.</p>
 
 			<h4>Was nicht erlaubt ist</h4>
@@ -489,7 +489,7 @@
 			<h4>US Embargos und Sanktionen</h4>
 			<p>Mit Anerkennen dieser Nutzungsbedingungen bestätigten Sie,</p>
 			<ul>
-				<li>dass Sie sich nicht in einem Land aufhalten, das einem Embargo der Regierung der Vereinigten Staaten von Amerika unterliegt oder von der Regierung der Vereinigten Staaten von Amerika als Unterstützer von Terroristen (<em>"terrorist supporting" country</em>) designiert wurde und</li>
+				<li>dass Sie sich nicht in einem Land aufhalten, das einem Embargo der Regierung der Vereinigten Staaten von Amerika unterliegt oder von der Regierung der Vereinigten Staaten von Amerika als Unterstützer von Terroristen (<em>„terrorist supporting“ country</em>) designiert wurde und</li>
 				<li>dass Sie nicht auf einer Liste der Regierung der Vereinigten Staaten von Amerika als sog. <em>Prohibited or Restricted Party</em> geführt werden.</li>
 			</ul>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -740,7 +740,7 @@
 "App_Information_Legal_Navigation" = "Legal Notices";
 
 /* App Information - Privacy */
-"App_Information_Privacy_Navigation" = "Data Privacy Information";
+"App_Information_Privacy_Navigation" = "Data Privacy";
 
 "App_Information_Legal_ImageDescription" = "One person is holding a device with a lot of text on the screen. Next to the text is a balance scale, which is the symbol for legal notices";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -17,6 +17,11 @@
 			}
 
 
+			a {
+				text-decoration: underline;
+			}
+
+
 			a[href] {
 				color: var(--ena-text-tint-color);
 			}
@@ -41,6 +46,11 @@
 			}
 
 
+			section {
+				margin-bottom: 3rem;
+			}
+
+
 			h1 {
 				/*font-size: 28px;*/
 				font-size: 1.6470588235rem;
@@ -59,6 +69,22 @@
 				/*font-size: 17px;*/
 				font-size: 1.0rem;
 				font-weight: 600;
+			}
+
+
+			h4 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: 600;
+				font-style: italic;
+			}
+
+
+			h5 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: normal;
+				text-decoration: underline;
 			}
 
 
@@ -83,13 +109,13 @@
 			}
 
 
-			ul {
-				list-style-type: disc;
+			li {
+				text-indent: 2em;
 			}
 
 
-			li {
-				text-indent: 2em;
+			ul > ul li {
+				text-indent: 4em;
 			}
 
 
@@ -108,214 +134,415 @@
 			}
 
 
+			h4 {
+				margin-bottom: 1rem;
+			}
+
+
+			h5 {
+				margin-bottom: 1rem;
+			}
+
+
 			p, ul, li {
 				margin-bottom: 1rem;
 			}
 
-				</style>
-			</head>
 
-	<body>
+			body.browser {
+				padding: 3rem;
+				width: 38.5rem;
+				margin: 0 auto;
+			}
 
-		<!-- <h2>Privacy notice</h2>-->
-		<!-- <h2>Corona-Warn-App</h2>-->
 
-		<p>This privacy notice explains what data is collected when you use the Corona-Warn-App, how that data is used, and your rights under data protection law.</p>
-		<p>To ensure that this privacy notice can be understood by all users, we have made every effort to make it simple and as non-technical as possible. </p>
-		<h2>1.	Who has provided you with this app?</h2>
-		<p>The Corona-Warn-App (the <b>“App”</b>) is provided by the Robert Koch Institute, Nordufer 20, 13353 Berlin (the <b>“RKI”</b>).</p>
-		<p>The RKI is also what is called the controller under data protection law, meaning it is responsible for the processing of App users’ data.</p>
-		<p>You can contact the RKI’s data protection officer at the above address (“FAO the data protection officer”) and by emailing: datenschutz@rki.de.</p>
-		<h2>2.	Is using the App voluntary?</h2>
-		<p>Using the App is entirely voluntary. It is your decision alone whether and how you use the App.</p>
-		<p>Although installing and using the App is voluntary, if you wish to use the exposure logging feature you still have to grant the RKI your consent to let the App process your personal data. You do this by tapping on the “Enable Exposure Logging” button the first time you open the App. If the App identifies a potential risk of infection for you, then your data also includes health data. Your consent is necessary because otherwise the App will not be able to access your smartphone’s exposure logging feature. You can, however, use the toggle switch in the App to disable the exposure logging feature at any time. Doing this will mean that you are unable to use the full functionality of the App. Separate consent is also required for the data processing performed for the following features:</p>
-		<ul>
-			<li>Registering a test (see 6 b.)</li>
-			<li>Sharing your test result (see 6 c.).</li>
-		</ul>
-		<p>The data processing performed in connection with these features is described in more detail in the following sections.</p>
-		<h2>3.	On what legal basis is your data processed?</h2>
-		<p>In principle, the RKI will process your personal data only on the basis of your consent granted pursuant to Article 6(1) Sentence 1(a) and Article 9(2)(a) of the General Data Protection Regulation (GDPR). If you have granted your consent, you can withdraw it at any time. Further information on your right of withdrawal and instructions on how to exercise this right can be found under 11.</p>
-		<h2>4.	Who is the App aimed at?</h2>
-		<p>The App is aimed at people who are resident in Germany and at least 16 years old. </p>
-		<h2>5.	What personal data is processed?</h2>
-		<p>The App is designed to process as little personal data as possible. This means, for example, that the App does not collect any data that would allow the RKI or other users to infer your identity, health status or location. In addition, the App deliberately refrains from using tracking tools to record or analyse how you use the App.</p>
-		<p>The data processed by the App can be grouped into the following categories:</p>
-		<h3>a.	Access data</h3>
-		<p>Access data is generated when you use or enable the following features:</p>
-		<ul>
-			<li>Exposure Logging</li>
-			<li>Registering a test</li>
-			<li>Sharing your test result.</li>
-		</ul>
-		<p>Each time data is retrieved from the App’s server system, your IP address (on the upstream load balancer) is masked and no longer used within the App’s server system. </p>
-		<p>The following data is also processed:</p>
-		<ul>
-			<li>Date and time of retrieval (time stamp)</li>
-			<li>Transmitted data volume (or packet length)</li>
-			<li>Notification of successful retrieval.</li>
-		</ul>
-		<p>This access data is only processed to secure and maintain the technical infrastructure. You are not identified personally as a user of the App and it is not possible to create a user profile. The IP address will not be saved beyond the end of the period of use.</p>
-		<h3>b.	Contact data</h3>
-		<p>If you enable exposure logging in your smartphone’s operating system, which serves to record encounters (contacts) with other users, then your smartphone will continuously send out randomly generated identification numbers (<b>“random IDs”</b>) via Bluetooth Low Energy, which other smartphones in your vicinity can receive if exposure logging is also enabled on them. Your smartphone, in turn, also receives the random IDs of the other smartphones. In addition to the random IDs received from other smartphones, your smartphone’s exposure logging functionality records and stores the following contact data:</p>
-		<ul>
-			<li>Date and time of the contact</li>
-			<li>Duration of the contact</li>
-			<li>Bluetooth signal strength of the contact</li>
-			<li>Encrypted metadata (protocol version and transmission strength).</li>
-		</ul>
-		<p>Your own random IDs and those received from other smartphones as well as the other contact data (date and time of the contact, duration of the contact, signal strength of the contact and encrypted metadata) are recorded by your smartphone in an exposure log and currently stored there for 14 days.</p>
-		<p>The functionality used to record encounters with other users is called “COVID-19 Exposure Notifications” on Android smartphones and “COVID-19 Exposure Logging” on iPhones. Please note that this exposure logging functionality is not part of the App, but an integral part of your smartphone's operating system. This means that the exposure logging functionality is provided to you by Apple (iPhones) or Google (Android smartphones) and is subject to these companies’ respective privacy policies. The RKI has no influence on data processing performed by the operating system in connection with exposure logging.</p>
-		<p>More information about the exposure logging functionality on Android smartphones is available at: <u>https://support.google.com/android/answer/9888358?hl=en</u>.</p>
-		<p>More information about Apple’s exposure logging functionality can be found in your iPhone’s settings under “Privacy” > “Health” > "COVID-19 Exposure Logging”. Please note that the exposure logging functionality is only available if iOS version 13.5 or higher is installed on your iPhone. </p>
-		<p>The App will only process the contact data generated and stored by your smartphone if the App’s exposure logging feature is enabled.</p>
-		<h3>c.	Health data</h3>
-		<p>Health data is any data containing information about the health of a particular individual. This includes not only information about past and current illnesses, but also about a person’s risk of illness (such as the risk that the person has been infected with the coronavirus).</p>
-		<p>The following cases involve processing health data:</p>
-		<ul>
-			<li>If the exposure logging feature detects that you may have been in contact with a person who has been infected with the coronavirus.</li>
-			<li>If you register your test.</li>
-			<li>If you share a positive test result.</li>
-		</ul>
-		<h2>6.	App features</h2>
-		<h3>a.	Exposure Logging</h3>
-		<p>The App’s core functionality is exposure logging. This serves to track possible contacts with other users of the App who are infected with the coronavirus, to evaluate the risk that you yourself have been infected, and – based on the risk identified – to provide you with health advice and recommendations for what to do next.</p>
-		<p>If you enable the exposure logging feature, then several times a day while the App runs in the background (or when you tap on “Update”), the App will retrieve a list from the App’s server system of random IDs from users who have tested positive and shared their own random IDs. The App shares these random IDs with your smartphone’s exposure logging functionality, which then compares them with the random IDs stored in your smartphone’s exposure log. If your smartphone’s exposure logging functionality detects a match, it transfers the contact data (date, duration, signal strength) to the App, but not the random ID of the contact in question.</p>
-		<p>In the event of a contact, the App analyses the contact data provided by the exposure logging functionality in order to determine your individual risk of infection. The evaluation algorithm which determines how the contact data is interpreted (for example, how the duration of a contact influences the risk of infection) is based on current scientific findings. To account for new findings as and when they arise, the RKI can update the evaluation algorithm by adjusting its settings. The settings for the evaluation algorithm are sent to the App together with the list of random IDs of infected users.</p>
-		<p>The identification of your risk of infection is only carried out locally on your smartphone, meaning that the data is processed offline. Once identified, the risk of infection is also only stored in the App and is not passed on to any other recipients (including the RKI, Apple, Google and other third parties).</p>
-		<p>The legal basis for the processing of your access data, contact data and, if applicable, health data (if the App determines that you may have been infected) described above is your consent which you gave when enabling the exposure logging feature.</p>
-		<h3>b.	Registering a test</h3>
-		<p>If you have been tested for the coronavirus, you can register the test in the App by scanning the QR code which you received from your doctor or the testing facility. The app will then inform you as soon as the test result is available from the laboratory.</p>
-		<p>For this to work, the testing laboratory needs to be connected to the App’s server system and, as part of the testing procedure, you must have agreed separately to the laboratory transmitting your test result to the App’s server system (test result database). Test results from laboratories that are not connected to the App’s server system cannot be displayed in the App. If you have not received a QR code, the testing laboratory is not connected. In this case you will not be able to use this feature.</p>
-		<p><u>Registering a test</u></p>
-		<p>To receive the test result in the App, you must first register the test you have taken in the App. For this purpose, your doctor or the testing facility will provide you with a QR code when taking the sample. This QR code contains a code number which can be read with a QR code scanner. To register your test, you will need to scan the QR code in the App using your smartphone’s camera.</p>
-		<p>The code number read from the QR code is then hashed by the App, which means that the App performs a certain mathematical procedure in order to convert the code number in such a way that it can no longer be recognised. As soon as your smartphone is connected to the internet, the App will transmit the hashed code number to the App’s server system. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. The token is linked to the hashed code number on the server system. The App then deletes the hashed code number on your smartphone. The server system will only issue a token once for each hashed code number. This ensures that your QR code cannot be used by other users of the App to retrieve test results. </p>
-		<p>This completes the registration of your test.</p>
-		<p><u>Filing of the test result</u></p>
-		<p>As soon as the testing laboratory receives the test result, it stores the result in the RKI’s test result database, indicating the hashed code number. The test result database is operated by the RKI on a special server within the App’s server system. Based on the code number contained in the QR code issued to you, the testing laboratory also generates the hashed code number using the same mathematical procedure as the App.</p>
-		<p><u>Retrieval of the test result</u></p>
-		<p>Using the token, the App regularly requests the status of the registered test from the App’s server system. The server system then assigns the token to the hashed code number and transfers it to the test result database. If the test result has now been stored there, the test result database sends the test result back to the server system, which forwards it to the App without gaining any knowledge of the content.</p>
-		<p>If the test result is positive, the App uses the token again to request a TAN (transaction number) from the server system. The server system reassigns the token to the hashed code number and requests confirmation from the test result database that a positive test result exists for the hashed code number. If the test result database confirms this, the server system generates the TAN and transmits it to the App. A copy of the TAN remains on the server system.</p>
-		<p>The TAN is required to ensure that no false information is distributed to other users in the event of a positive test result being transmitted.</p>
-		<p>The legal basis for the processing described above of the data mentioned above is your consent to using the test registration feature.</p>
-		<h3>c.	Sharing your test result</h3>
-		<p>If you use the feature for sharing your test result in order to warn other users, the App will transfer the random IDs generated and stored by your smartphone from the last 14 days and the TAN to the App’s server system. The server system first checks whether the TAN is valid and then adds your random IDs to the list of random IDs of users who have shared a positive test result. Your random IDs can now be downloaded by other users as part of the exposure logging process.</p>
-		<p><u>If you have not retrieved your test result in the App:</u></p>
-		<p>Even if you have not retrieved a positive test result in the app, you can share the test result via the App to warn other users. In this case, the App prompts you to enter a so-called TeleTAN, which acts as a TAN.</p>
-		<p>To obtain a TeleTAN, please call the Corona-Warn-App hotline on +49 (0)800 7540002. The operator will first ask you some questions over the phone to check the plausibility of your call. These questions serve to prevent fraudulent reports of infections and any resulting incorrect warnings and  risk status. Once you have answered these questions sufficiently, you will be asked for your mobile/telephone number. This is so that you can be called back later and given a TeleTAN to enter in the App. Your mobile/telephone number will only be temporarily stored for this purpose and deleted within one hour at the latest.</p>
-		<p>After your call, the hotline employee will generate a TeleTAN via a special access to the App’s server system and then call you to tell you the TeleTAN. If you enter the TeleTAN in the App, the TeleTAN will be sent back from the App to the App’s server system for comparison and verification. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. Using this token, the App then requests a TAN from the server system.</p>
-		<p>The legal basis for this processing of your access data and health data (random IDs, test result, TAN and, if applicable, TeleTAN) is your consent to using the feature for sharing your test result.</p>
-		<h3>d.	Using the App for information purposes only</h3>
-		<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as <u>www.bundesregierung.de</u>, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting. </p>
-		<h2>7.	What permissions and functionality does the App require?</h2>
-		<p>The App requires access to a number of your smartphone’s features and interfaces. For this purpose, you need to grant the App certain permissions. Permissions are programmed differently by different manufacturers. For example, individual permissions may be combined into permission categories, where you can only agree to the permission category as a whole. Please note that if the App is denied access, you will not be able to use any or all of the App’s features.</p>
-		<h3>a.	Technical requirements (all smartphones)</h3>
-		<ul>
-			<li>Internet<br/>
-			The App requires an internet connection for the exposure logging feature, and so that it can receive and transmit test results, so that it can communicate with the App’s server system.
-		</li>
-		</ul>
-		<ul>
-			<li>Bluetooth<br/>
-			Your smartphone’s Bluetooth interface must be enabled for your smartphone to record random IDs from other smartphones and store them in the device’s exposure log.</li>
-		</ul>
-		<ul>
-			<li>Camera<br/>
-			Your smartphone requires a camera to be able to scan a QR code when registering a test.
-		</li>
-		</ul>
-		<ul>
-			<li>Background operation<br/>
-			The App runs in the background (i.e. when you are not actively using the App) in order to be able to automatically identify your risk and query the status of a registered test. If you deny the App permission to run in the background in your smartphone’s operating system, then you must start all actions in the App itself. 
-		</li>
-		</ul>
-		<h3>b.	Android smartphones</h3>
-		<p>If you are using an Android device, the following system features must also be enabled:</p>
-		<ul>
-			<li>COVID-19 Exposure Notifications<br/>
-			The App’s exposure logging feature requires this functionality. Otherwise, no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.
-		</li>
-		</ul>
-		<ul>
-			<li>Location<br/>
-			Your smartphone’s location service must be enabled for your device to search for Bluetooth signals from other smartphones. Please note that no location data is collected in this process.
-		</li>
-		</ul>
-		<ul>
-			<li>Notification<br/>
-			The user is notified locally of the identified risk and available test results. The necessary notification function is already enabled in the operating system.
-		</li>
-		</ul>
-		<p>The App also requires the following permissions:</p>
-		<ul>
-			<li>Camera<br/>
-			The App requires access to the camera to read the QR code when registering a test.
-		</li>
-		</ul>
-		<h3>c.	iPhones (Apple iOS)</h3>
-		<p>If you are using an iPhone, the following system features must be enabled:</p>
-		<ul>
-			<li>COVID-19 Exposure Logging</li>
-		</ul>
-		<p>The App’s exposure logging feature requires this functionality, otherwise no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.</p>
-		<ul>
-			<li>Notifications</li>
-		</ul>
-		<p>The user is notified locally of the identified risk and available test results. Notifications must be enabled for this.</p>
-		<p>The App also requires the following permissions:</p>
-		<ul>
-			<li>Camera</li>
-		</ul>
-		<p>The App requires access to the camera to read the QR code when registering a test.</p>
+			body.browser,
+			body.browser,
+			body.browser table {
+				font-family: "Times New Roman", serif !important;
+			}
 
-		<h2>8.	When will data be deleted?</h2>
-		<p>All data stored in the App is deleted as soon as it is no longer needed for the App features:</p>
-		<h3>a.	Exposure Logging</h3>
-		<ul>
-			<li>The list of random IDs of users who have shared a positive test result will be deleted from the App immediately, and also automatically deleted from your smartphone’s exposure log after 14 days.</li>
-			<li>The RKI has no way of influencing the deletion of contact data in your smartphone’s exposure log (including your own random IDs) and contact data on other smartphones, as this functionality is provided by Apple or Google. In this case, the deletion depends on what Apple or Google has determined. Currently, the data is automatically deleted after 14 days. It may also be possible, using the functionality provided by Apple and Google, to manually delete data in your device’s system settings.</li>
-			<li>The risk status displayed in the App will be deleted as soon as a new risk status has been determined. A new risk status is usually determined after the App has received a new list of random IDs.</li>
-		</ul>
-		<p>b. Registering a test </p>
-		<ul>
-			<li>The hashed code number will be deleted from the App’s server system after 21 days.</li>
-			<li>In the event of a negative test result, the hashed code number and the test result will be deleted from the test result database immediately after the test result is retrieved; and in the event of a positive test result, they will be deleted immediately after the copy of the TAN stored on the server system is deleted (see below).</li>
-			<li>The token stored on the server system will be deleted after 21 days.</li>
-			<li>The token stored in the app will be deleted from the smartphone after the App is deleted or after using the feature for sharing the test result.</li>
-		</ul>
-		<p>c. Sharing your test result</p>
-		<ul>
-			<li>Your smartphone’s own random IDs which are shared in the App will be deleted from the server system after 14 days.</li>
-			<li>The copy of the TAN stored on the server system will be deleted after 21 days.</li>
-			<li>The TAN stored in the App will be deleted after the test result has been shared.</li>
-			<li>The TeleTAN stored in the App will be deleted after the test result has been shared.</li>
-			<li>The TeleTAN stored on the server system will be deleted after 21 days.</li>
-			<li>The TeleTAN sent to the hotline employee will be deleted there immediately after it has been passed on to you by telephone.</li>
-			<li>The token stored on the server system will be deleted after 21 days.</li>
-			<li>The token stored in the App will be deleted after the test result has been shared.</li>
-		</ul>
 
-		<h2>9.	Who will receive your data?</h2>
-		<p>If you share a test result to warn other users, your random IDs from the last 14 days will be passed on to the App on other users’ smartphones.</p>
-		<p>The RKI has commissioned T-Systems International GmbH and SAP Deutschland SE & Co. KG to operate and maintain part of the technical infrastructure of the App (e.g. server system, hotline), meaning that these two companies are processors under data protection law and acting on the RKI’s behalf (Article 28 GDPR).</p>
-		<p>Otherwise, the RKI will only pass on personal data collected in connection with your use of the App to third parties if the RKI is legally obliged to do so or if this is necessary for legal action or criminal prosecution in the case of attacks on the App’s technical infrastructure. In other cases, personal data will not generally be passed on. </p>
-		<h2>10.	Is data transferred to a third country?</h2>
-		<p>The data generated when the App is used is processed exclusively on servers in Germany or in another EU or EEA member state.</p>
-		<h2>11.	Withdrawal of consent</h2>
-		<p>You have the right to withdraw any consent you granted the RKI in the App at any time with effect for the future. Please note that this will not affect the lawfulness of the processing before the withdrawal.</p>
-		<p>To withdraw your consent to the exposure logging feature, you can disable the feature using the toggle switch in the App or delete the App. If you decide to use the exposure logging feature again, you can toggle the feature back on or reinstall the App.</p>
-		<p>To withdraw your consent to the test registration feature, you can delete the test registration in the App. The token for retrieving the test result will then be deleted from your device. Neither the RKI nor the testing laboratory can then assign the transmitted data to your App or smartphone. If you wish to register another test, you will be asked to grant your consent again.</p>
-		<p>To withdraw your consent to the sharing of your test result, you must delete the App. All of your random IDs stored in the App will then be removed and can no longer be assigned to your smartphone. If you wish to report another test result, you can reinstall the App and grant your consent again. Alternatively, you may be able to delete your own random IDs in the exposure log in your smartphone’s system settings. Please note that, once transmitted, the RKI has no way of deleting your random IDs from the lists and from other users’ smartphones.</p>
-		<h2>12.	Your other rights under data protection law</h2>
-		<p>If the RKI processes your personal data, you also have the following data protection rights:</p>
-		<ul>
-			<li>the rights under Articles 15, 16, 17, 18, 20 and 21 GDPR,</li>
-			<li>the right to contact the official <u>RKI data protection officer</u> and raise your concerns (Article 38(4) GDPR) and</li>
-			<li>the right to lodge a complaint with a competent data protection authority. To do so, you can either contact your local supervisory authority or the competent authority at the RKI’s headquarters. The competent supervisory authority for the RKI is the Federal Commissioner for Data Protection and Freedom of Information, Graurheindorfer Straße 153, 53117 Bonn.</li>
-		</ul>
-		<p>Please note that the RKI can only fulfil the rights mentioned above if the data on which your claim is based can be clearly assigned to you. This would only be possible if the RKI were to collect further personal data that would allow the data mentioned above to be clearly assigned to you or your smartphone. Since this is not necessary – and not intended – for the purposes of the App, the RKI is not obliged to collect such additional data (Article 11(2) GDPR). Moreover, this would run counter to the stated objective of keeping the amount of data processed for the App as low as possible. Against this backdrop, it will not normally be possible to directly fulfil the above data protection rights under Articles 15, 16, 17, 18, 20 and 21 GDPR, as doing so would require additional information about you which is not available to the RKI.</p>
+			body.browser p {
+				text-align: justify;
+			}
+			</style>
+	</head>
+
+	<body class="browser">
+
+
+		<!-- Templates -->
+
+		<!--<h1>Title 1</h1>-->
+		<!--<h2>Title 2</h2>-->
+		<!--<h3>Headline</h3>-->
+		<!--<p>Body</p>-->
+		<!--<span>Subheadline</span>-->
+		<!--<aside>Footnote</aside>-->
+
+
+		<!-- Document: "CWA Privacy Notice DE.docx" -->
+		<!-- Updated: 13.06.20 -->
+
+
+		<!-- Präambel -->
+		<section>
+			<p>This privacy notice explains what data is collected when you use the Corona-Warn-App, how that data is used, and your rights under data protection law.</p>
+			<p>To ensure that this privacy notice can be understood by all users, we have made every effort to make it simple and as non-technical as possible. </p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 1. Wer stellt Ihnen diese App zur Verfügung? -->
+		<section>
+			<h2>1.	Who has provided you with this app?</h2>
+			<p>The Corona-Warn-App (the “<strong>App</strong>”) is provided by the Robert Koch Institute, Nordufer 20, 13353 Berlin (the “<strong>RKI</strong>”).</p>
+			<p>The RKI is also what is called the controller under data protection law, meaning it is responsible for the processing of App users’ data.</p>
+			<p>You can contact the RKI’s data protection officer at the above address (“FAO the data protection officer”) and by emailing: datenschutz@rki.de.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 2. Ist die Nutzung der App freiwillig? -->
+		<section>
+			<h2>2.	Is using the App voluntary?</h2>
+
+			<p>Using the App is entirely voluntary. It is your decision alone whether and how you use the App.</p>
+
+			<p>Although installing and using the App is voluntary, if you wish to use the exposure logging feature you still have to grant the RKI your consent to let the App process your personal data. You do this by tapping on the “Enable Exposure Logging” button the first time you open the App. If the App identifies a potential risk of infection for you, then your data also includes health data. Your consent is necessary because otherwise the App will not be able to access your smartphone’s exposure logging feature. You can, however, use the toggle switch in the App to disable the exposure logging feature at any time. Doing this will mean that you are unable to use the full functionality of the App. Separate consent is also required for the data processing performed for the following features:</p>
+
+			<ul>
+				<li>Registering a test (see 6 b.)</li>
+				<li>Sharing your test result (see 6 c.).</li>
+			</ul>
+
+			<p>The data processing performed in connection with these features is described in more detail in the following sections.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 3. Auf welcher Rechtsgrundlage werden Ihre Daten verarbeitet? -->
+		<section>
+			<h2>3.	On what legal basis is your data processed?</h2>
+			<p>In principle, the RKI will process your personal data only on the basis of your consent granted pursuant to Article 6(1) Sentence 1(a) and Article 9(2)(a) of the General Data Protection Regulation (GDPR). If you have granted your consent, you can withdraw it at any time. Further information on your right of withdrawal and instructions on how to exercise this right can be found under 11.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 4. An wen richtet sich die App? -->
+		<section>
+			<h2>4.	Who is the App aimed at?</h2>
+			<p>The App is aimed at people who are resident in Germany and at least 16 years old. </p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 5. Welche personenbezogenen Daten werden verarbeitet? -->
+		<section>
+			<h2>5.	What personal data is processed?</h2>
+			<p>The App is designed to process as little personal data as possible. This means, for example, that the App does not collect any data that would allow the RKI or other users to infer your identity, health status or location. In addition, the App deliberately refrains from using tracking tools to record or analyse how you use the App.</p>
+			<p>The data processed by the App can be grouped into the following categories:</p>
+
+			<div>
+				<h3>a.	Access data</h3>
+
+				<p>Access data is generated when you use or enable the following features:</p>
+
+				<ul>
+					<li>Exposure Logging</li>
+					<li>Registering a test</li>
+					<li>Sharing your test result.</li>
+				</ul>
+
+				<p>Each time data is retrieved from the App’s server system, your IP address (on the upstream load balancer) is masked and no longer used within the App’s server system. </p>
+
+				<p>The following data is also processed:</p>
+
+				<ul>
+					<li>Date and time of retrieval (time stamp)</li>
+					<li>Transmitted data volume (or packet length)</li>
+					<li>Notification of successful retrieval.</li>
+				</ul>
+
+				<p>This access data is only processed to secure and maintain the technical infrastructure. You are not identified personally as a user of the App and it is not possible to create a user profile. The IP address will not be saved beyond the end of the period of use.</p>
+			</div>
+
+			<div>
+				<h3>b.	Contact data</h3>
+
+				<p>If you enable exposure logging in your smartphone’s operating system, which serves to record encounters (contacts) with other users, then your smartphone will continuously send out randomly generated identification numbers (“<strong>random IDs</strong>”) via Bluetooth Low Energy, which other smartphones in your vicinity can receive if exposure logging is also enabled on them. Your smartphone, in turn, also receives the random IDs of the other smartphones. In addition to the random IDs received from other smartphones, your smartphone’s exposure logging functionality records and stores the following contact data:</p>
+
+				<ul>
+					<li>Date and time of the contact</li>
+					<li>Duration of the contact</li>
+					<li>Bluetooth signal strength of the contact</li>
+					<li>Encrypted metadata (protocol version and transmission strength).</li>
+				</ul>
+
+				<p>Your own random IDs and those received from other smartphones as well as the other contact data (date and time of the contact, duration of the contact, signal strength of the contact and encrypted metadata) are recorded by your smartphone in an exposure log and currently stored there for 14 days.</p>
+
+				<p>The functionality used to record encounters with other users is called “COVID-19 Exposure Notifications” on Android smartphones and “COVID-19 Exposure Logging” on iPhones. Please note that this exposure logging functionality is not part of the App, but an integral part of your smartphone's operating system. This means that the exposure logging functionality is provided to you by Apple (iPhones) or Google (Android smartphones) and is subject to these companies’ respective privacy policies. The RKI has no influence on data processing performed by the operating system in connection with exposure logging.</p>
+
+				<p>More information about the exposure logging functionality on Android smartphones is available at: <a>https://support.google.com/android/answer/9888358?hl=en</a>.</p>
+
+				<p>More information about Apple’s exposure logging functionality can be found in your iPhone’s settings under “Privacy” > “Health” > "COVID-19 Exposure Logging”. Please note that the exposure logging functionality is only available if iOS version 13.5 or higher is installed on your iPhone. </p>
+
+				<p>The App will only process the contact data generated and stored by your smartphone if the App’s exposure logging feature is enabled.</p>
+			</div>
+
+			<div>
+				<h3>c.	Health data</h3>
+
+				<p>Health data is any data containing information about the health of a particular individual. This includes not only information about past and current illnesses, but also about a person’s risk of illness (such as the risk that the person has been infected with the coronavirus).</p>
+
+				<p>The following cases involve processing health data:</p>
+
+				<ul>
+					<li>If the exposure logging feature detects that you may have been in contact with a person who has been infected with the coronavirus.</li>
+					<li>If you register your test.</li>
+					<li>If you share a positive test result.</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 6. Funktionen der App -->
+		<section>
+			<h2>6.	App features</h2>
+
+			<div>
+				<h3>a.	Exposure Logging</h3>
+
+				<p>The App’s core functionality is exposure logging. This serves to track possible contacts with other users of the App who are infected with the coronavirus, to evaluate the risk that you yourself have been infected, and – based on the risk identified – to provide you with health advice and recommendations for what to do next.</p>
+
+				<p>If you enable the exposure logging feature, then several times a day while the App runs in the background (or when you tap on “Update”), the App will retrieve a list from the App’s server system of random IDs from users who have tested positive and shared their own random IDs. The App shares these random IDs with your smartphone’s exposure logging functionality, which then compares them with the random IDs stored in your smartphone’s exposure log. If your smartphone’s exposure logging functionality detects a match, it transfers the contact data (date, duration, signal strength) to the App, but not the random ID of the contact in question.</p>
+
+				<p>In the event of a contact, the App analyses the contact data provided by the exposure logging functionality in order to determine your individual risk of infection. The evaluation algorithm which determines how the contact data is interpreted (for example, how the duration of a contact influences the risk of infection) is based on current scientific findings. To account for new findings as and when they arise, the RKI can update the evaluation algorithm by adjusting its settings. The settings for the evaluation algorithm are sent to the App together with the list of random IDs of infected users.</p>
+
+				<p>The identification of your risk of infection is only carried out locally on your smartphone, meaning that the data is processed offline. Once identified, the risk of infection is also only stored in the App and is not passed on to any other recipients (including the RKI, Apple, Google and other third parties).</p>
+
+				<p>The legal basis for the processing of your access data, contact data and, if applicable, health data (if the App determines that you may have been infected) described above is your consent which you gave when enabling the exposure logging feature.</p>
+			</div>
+
+			<div>
+				<h3>b.	Registering a test</h3>
+
+				<p>If you have been tested for the coronavirus, you can register the test in the App by scanning the QR code which you received from your doctor or the testing facility. The app will then inform you as soon as the test result is available from the laboratory.</p>
+				<p>For this to work, the testing laboratory needs to be connected to the App’s server system and, as part of the testing procedure, you must have agreed separately to the laboratory transmitting your test result to the App’s server system (test result database). Test results from laboratories that are not connected to the App’s server system cannot be displayed in the App. If you have not received a QR code, the testing laboratory is not connected. In this case you will not be able to use this feature.</p>
+
+				<h5>Registering a test</h5>
+				<p>To receive the test result in the App, you must first register the test you have taken in the App. For this purpose, your doctor or the testing facility will provide you with a QR code when taking the sample. This QR code contains a code number which can be read with a QR code scanner. To register your test, you will need to scan the QR code in the App using your smartphone’s camera.</p>
+				<p>The code number read from the QR code is then hashed by the App, which means that the App performs a certain mathematical procedure in order to convert the code number in such a way that it can no longer be recognised. As soon as your smartphone is connected to the internet, the App will transmit the hashed code number to the App’s server system. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. The token is linked to the hashed code number on the server system. The App then deletes the hashed code number on your smartphone. The server system will only issue a token once for each hashed code number. This ensures that your QR code cannot be used by other users of the App to retrieve test results. </p>
+				<p>This completes the registration of your test.</p>
+
+				<h5>Filing of the test result</h5>
+				<p>As soon as the testing laboratory receives the test result, it stores the result in the RKI’s test result database, indicating the hashed code number. The test result database is operated by the RKI on a special server within the App’s server system. Based on the code number contained in the QR code issued to you, the testing laboratory also generates the hashed code number using the same mathematical procedure as the App.</p>
+
+				<h5>Retrieval of the test result</h5>
+				<p>Using the token, the App regularly requests the status of the registered test from the App’s server system. The server system then assigns the token to the hashed code number and transfers it to the test result database. If the test result has now been stored there, the test result database sends the test result back to the server system, which forwards it to the App without gaining any knowledge of the content.</p>
+				<p>If the test result is positive, the App uses the token again to request a TAN (transaction number) from the server system. The server system reassigns the token to the hashed code number and requests confirmation from the test result database that a positive test result exists for the hashed code number. If the test result database confirms this, the server system generates the TAN and transmits it to the App. A copy of the TAN remains on the server system.</p>
+				<p>The TAN is required to ensure that no false information is distributed to other users in the event of a positive test result being transmitted.</p>
+				<p>The legal basis for the processing described above of the data mentioned above is your consent to using the test registration feature.</p>
+			</div>
+
+			<div>
+				<h3>c.	Sharing your test result</h3>
+
+				<p>If you use the feature for sharing your test result in order to warn other users, the App will transfer the random IDs generated and stored by your smartphone from the last 14 days and the TAN to the App’s server system. The server system first checks whether the TAN is valid and then adds your random IDs to the list of random IDs of users who have shared a positive test result. Your random IDs can now be downloaded by other users as part of the exposure logging process.</p>
+
+				<h5>If you have not retrieved your test result in the App:</h5>
+				<p>Even if you have not retrieved a positive test result in the app, you can share the test result via the App to warn other users. In this case, the App prompts you to enter a so-called TeleTAN, which acts as a TAN.</p>
+				<p>To obtain a TeleTAN, please call the Corona-Warn-App hotline on +49 (0)800 7540002. The operator will first ask you some questions over the phone to check the plausibility of your call. These questions serve to prevent fraudulent reports of infections and any resulting incorrect warnings and  risk status. Once you have answered these questions sufficiently, you will be asked for your mobile/telephone number. This is so that you can be called back later and given a TeleTAN to enter in the App. Your mobile/telephone number will only be temporarily stored for this purpose and deleted within one hour at the latest.</p>
+				<p>After your call, the hotline employee will generate a TeleTAN via a special access to the App’s server system and then call you to tell you the TeleTAN. If you enter the TeleTAN in the App, the TeleTAN will be sent back from the App to the App’s server system for comparison and verification. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. Using this token, the App then requests a TAN from the server system.</p>
+				<p>The legal basis for this processing of your access data and health data (random IDs, test result, TAN and, if applicable, TeleTAN) is your consent to using the feature for sharing your test result.</p>
+			</div>
+
+			<div>
+				<h3>d.	Using the App for information purposes only</h3>
+				<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as www.bundesregierung.de, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting. </p>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 7. Welche Berechtigungen und Funktionen benötigt die App? -->
+		<section>
+			<h2>7.	What permissions and functionality does the App require?</h2>
+			<p>The App requires access to a number of your smartphone’s features and interfaces. For this purpose, you need to grant the App certain permissions. Permissions are programmed differently by different manufacturers. For example, individual permissions may be combined into permission categories, where you can only agree to the permission category as a whole. Please note that if the App is denied access, you will not be able to use any or all of the App’s features.</p>
+
+			<div>
+				<h3>a.	Technical requirements (all smartphones)</h3>
+
+				<ul>
+					<li>
+						<p>Internet</p>
+						<p>The App requires an internet connection for the exposure logging feature, and so that it can receive and transmit test results, so that it can communicate with the App’s server system.</p>
+					</li>
+					<li>
+						<p>Bluetooth</p>
+						<p>Your smartphone’s Bluetooth interface must be enabled for your smartphone to record random IDs from other smartphones and store them in the device’s exposure log.</p>
+					</li>
+					<li>
+						<p>Camera</p>
+						<p>Your smartphone requires a camera to be able to scan a QR code when registering a test.</p>
+					</li>
+					<li>
+						<p>Background operation</p>
+						<p>The App runs in the background (i.e. when you are not actively using the App) in order to be able to automatically identify your risk and query the status of a registered test. If you deny the App permission to run in the background in your smartphone’s operating system, then you must start all actions in the App itself. </p>
+					</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>b.	Android smartphones</h3>
+
+				<p>If you are using an Android device, the following system features must also be enabled:</p>
+
+				<ul>
+					<li>
+						<p>COVID-19 Exposure Notifications</p>
+						<p>The App’s exposure logging feature requires this functionality. Otherwise, no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.</p>
+					</li>
+					<li>
+						<p>Location</p>
+						<p>Your smartphone’s location service must be enabled for your device to search for Bluetooth signals from other smartphones. Please note that no location data is collected in this process.</p>
+					</li>
+					<li>
+						<p>Notification</p>
+						<p>The user is notified locally of the identified risk and available test results. The necessary notification function is already enabled in the operating system.</p>
+					</li>
+				</ul>
+
+				<p>The App also requires the following permissions:</p>
+
+				<ul>
+					<li>
+						<p>Camera</p>
+						<p>The App requires access to the camera to read the QR code when registering a test.</p>
+					</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>c. iPhones (Apple iOS)</h3>
+
+				<p>If you are using an iPhone, the following system features must be enabled:</p>
+
+				<ul>
+					<li>
+						<p>COVID-19 Exposure Logging</p>
+						<p>The App’s exposure logging feature requires this functionality, otherwise no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.</p>
+					</li>
+					<li>
+						<p>Notifications</p>
+						<p>The user is notified locally of the identified risk and available test results. Notifications must be enabled for this.</p>
+					</li>
+				</ul>
+
+				<p>The App also requires the following permissions:</p>
+
+				<ul>
+					<li>
+						<p>Camera</p>
+						<p>The App requires access to the camera to read the QR code when registering a test.</p>
+					</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 8. Wann werden die Daten gelöscht? -->
+		<section>
+			<h2>8.	When will data be deleted?</h2>
+
+			<p>All data stored in the App is deleted as soon as it is no longer needed for the App features:</p>
+
+			<div>
+				<h3>a.	Exposure Logging</h3>
+				<ul>
+					<li>The list of random IDs of users who have shared a positive test result will be deleted from the App immediately, and also automatically deleted from your smartphone’s exposure log after 14 days.</li>
+					<li>The RKI has no way of influencing the deletion of contact data in your smartphone’s exposure log (including your own random IDs) and contact data on other smartphones, as this functionality is provided by Apple or Google. In this case, the deletion depends on what Apple or Google has determined. Currently, the data is automatically deleted after 14 days. It may also be possible, using the functionality provided by Apple and Google, to manually delete data in your device’s system settings.</li>
+					<li>The risk status displayed in the App will be deleted as soon as a new risk status has been determined. A new risk status is usually determined after the App has received a new list of random IDs.</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>b.	Registering a test </h3>
+				<ul>
+					<li>The hashed code number will be deleted from the App’s server system after 21 days.</li>
+					<li>In the event of a negative test result, the hashed code number and the test result will be deleted from the test result database immediately after the test result is retrieved; and in the event of a positive test result, they will be deleted immediately after the copy of the TAN stored on the server system is deleted (see below).</li>
+					<li>The token stored on the server system will be deleted after 21 days.</li>
+					<li>The token stored in the app will be deleted from the smartphone after the App is deleted or after using the feature for sharing the test result.</li>
+				</ul>
+			</div>
+
+			<div>
+				<h3>c.	Sharing your test result</h3>
+				<ul>
+					<li>Your smartphone’s own random IDs which are shared in the App will be deleted from the server system after 14 days.</li>
+					<li>The copy of the TAN stored on the server system will be deleted after 21 days.</li>
+					<li>The TAN stored in the App will be deleted after the test result has been shared.</li>
+					<li>The TeleTAN stored in the App will be deleted after the test result has been shared.</li>
+					<li>The TeleTAN stored on the server system will be deleted after 21 days.</li>
+					<li>The TeleTAN sent to the hotline employee will be deleted there immediately after it has been passed on to you by telephone.</li>
+					<li>The token stored on the server system will be deleted after 21 days.</li>
+					<li>The token stored in the App will be deleted after the test result has been shared.</li>
+				</ul>
+			</div>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 9. An wen werden Ihre Daten weitergegeben? -->
+		<section>
+			<h2>9.	Who will receive your data?</h2>
+			<p>If you share a test result to warn other users, your random IDs from the last 14 days will be passed on to the App on other users’ smartphones.</p>
+			<p>The RKI has commissioned T-Systems International GmbH and SAP Deutschland SE & Co. KG to operate and maintain part of the technical infrastructure of the App (e.g. server system, hotline), meaning that these two companies are processors under data protection law and acting on the RKI’s behalf (Article 28 GDPR).</p>
+			<p>Otherwise, the RKI will only pass on personal data collected in connection with your use of the App to third parties if the RKI is legally obliged to do so or if this is necessary for legal action or criminal prosecution in the case of attacks on the App’s technical infrastructure. In other cases, personal data will not generally be passed on. </p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 10. Werden Daten in ein Drittland übermittelt? -->
+		<section>
+			<h2>10.	Is data transferred to a third country?</h2>
+			<p>The data generated when the App is used is processed exclusively on servers in Germany or in another EU or EEA member state.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 11. Widerruf von Einwilligungen -->
+		<section>
+			<h2>11.	Withdrawal of consent</h2>
+			<p>You have the right to withdraw any consent you granted the RKI in the App at any time with effect for the future. Please note that this will not affect the lawfulness of the processing before the withdrawal.</p>
+			<p>To withdraw your consent to the exposure logging feature, you can disable the feature using the toggle switch in the App or delete the App. If you decide to use the exposure logging feature again, you can toggle the feature back on or reinstall the App.</p>
+			<p>To withdraw your consent to the test registration feature, you can delete the test registration in the App. The token for retrieving the test result will then be deleted from your device. Neither the RKI nor the testing laboratory can then assign the transmitted data to your App or smartphone. If you wish to register another test, you will be asked to grant your consent again.</p>
+			<p>To withdraw your consent to the sharing of your test result, you must delete the App. All of your random IDs stored in the App will then be removed and can no longer be assigned to your smartphone. If you wish to report another test result, you can reinstall the App and grant your consent again. Alternatively, you may be able to delete your own random IDs in the exposure log in your smartphone’s system settings. Please note that, once transmitted, the RKI has no way of deleting your random IDs from the lists and from other users’ smartphones.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!--  -->
+		<section>
+			<h2>12.	Your other rights under data protection law</h2>
+
+			<p>If the RKI processes your personal data, you also have the following data protection rights:</p>
+
+			<ul>
+				<li>the rights under Articles 15, 16, 17, 18, 20 and 21 GDPR,</li>
+				<li>the right to contact the official RKI data protection officer and raise your concerns (Article 38(4) GDPR) and</li>
+				<li>the right to lodge a complaint with a competent data protection authority. To do so, you can either contact your local supervisory authority or the competent authority at the RKI’s headquarters. The competent supervisory authority for the RKI is the Federal Commissioner for Data Protection and Freedom of Information, Graurheindorfer Straße 153, 53117 Bonn.</li>
+			</ul>
+
+			<p>Please note that the RKI can only fulfil the rights mentioned above if the data on which your claim is based can be clearly assigned to you. This would only be possible if the RKI were to collect further personal data that would allow the data mentioned above to be clearly assigned to you or your smartphone. Since this is not necessary – and not intended – for the purposes of the App, the RKI is not obliged to collect such additional data (Article 11(2) GDPR). Moreover, this would run counter to the stated objective of keeping the amount of data processed for the App as low as possible. Against this backdrop, it will not normally be possible to directly fulfil the above data protection rights under Articles 15, 16, 17, 18, 20 and 21 GDPR, as doing so would require additional information about you which is not available to the RKI.</p>
+		</section>
+		<p>&nbsp;</p>
 
 		<aside>Last amended: 12 June 2020</aside>
+
 
 	</body>
 </html>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -377,19 +377,19 @@
 
 				<ul>
 					<li>
-						<p>Internet</p>
+						<p>Internet<br></p>
 						<p>The App requires an internet connection for the exposure logging feature, and so that it can receive and transmit test results, so that it can communicate with the App’s server system.</p>
 					</li>
 					<li>
-						<p>Bluetooth</p>
+						<p>Bluetooth<br></p>
 						<p>Your smartphone’s Bluetooth interface must be enabled for your smartphone to record random IDs from other smartphones and store them in the device’s exposure log.</p>
 					</li>
 					<li>
-						<p>Camera</p>
+						<p>Camera<br></p>
 						<p>Your smartphone requires a camera to be able to scan a QR code when registering a test.</p>
 					</li>
 					<li>
-						<p>Background operation</p>
+						<p>Background operation<br></p>
 						<p>The App runs in the background (i.e. when you are not actively using the App) in order to be able to automatically identify your risk and query the status of a registered test. If you deny the App permission to run in the background in your smartphone’s operating system, then you must start all actions in the App itself.</p>
 					</li>
 				</ul>
@@ -402,15 +402,15 @@
 
 				<ul>
 					<li>
-						<p>COVID-19 Exposure Notifications</p>
+						<p>COVID-19 Exposure Notifications<br></p>
 						<p>The App’s exposure logging feature requires this functionality. Otherwise, no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.</p>
 					</li>
 					<li>
-						<p>Location</p>
+						<p>Location<br></p>
 						<p>Your smartphone’s location service must be enabled for your device to search for Bluetooth signals from other smartphones. Please note that no location data is collected in this process.</p>
 					</li>
 					<li>
-						<p>Notification</p>
+						<p>Notification<br></p>
 						<p>The user is notified locally of the identified risk and available test results. The necessary notification function is already enabled in the operating system.</p>
 					</li>
 				</ul>
@@ -419,7 +419,7 @@
 
 				<ul>
 					<li>
-						<p>Camera</p>
+						<p>Camera<br></p>
 						<p>The App requires access to the camera to read the QR code when registering a test.</p>
 					</li>
 				</ul>
@@ -432,11 +432,11 @@
 
 				<ul>
 					<li>
-						<p>COVID-19 Exposure Logging</p>
+						<p>COVID-19 Exposure Logging<br></p>
 						<p>The App’s exposure logging feature requires this functionality, otherwise no exposure log with the random IDs of your contacts will be available. The functionality must be enabled within the App to allow the App to access the exposure log.</p>
 					</li>
 					<li>
-						<p>Notifications</p>
+						<p>Notifications<br></p>
 						<p>The user is notified locally of the identified risk and available test results. Notifications must be enabled for this.</p>
 					</li>
 				</ul>
@@ -445,7 +445,7 @@
 
 				<ul>
 					<li>
-						<p>Camera</p>
+						<p>Camera<br></p>
 						<p>The App requires access to the camera to read the QR code when registering a test.</p>
 					</li>
 				</ul>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -361,7 +361,7 @@
 
 			<div>
 				<h3>d.	Using the App for information purposes only</h3>
-				<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as www.bundesregierung.de, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting. </p>
+				<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as <a>www.bundesregierung.de</a>, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting. </p>
 			</div>
 		</section>
 		<p>&nbsp;</p>
@@ -533,7 +533,7 @@
 
 			<ul>
 				<li>the rights under Articles 15, 16, 17, 18, 20 and 21 GDPR,</li>
-				<li>the right to contact the official RKI data protection officer and raise your concerns (Article 38(4) GDPR) and</li>
+				<li>the right to contact the official <u>RKI data protection officer</u> and raise your concerns (Article 38(4) GDPR) and</li>
 				<li>the right to lodge a complaint with a competent data protection authority. To do so, you can either contact your local supervisory authority or the competent authority at the RKI’s headquarters. The competent supervisory authority for the RKI is the Federal Commissioner for Data Protection and Freedom of Information, Graurheindorfer Straße 153, 53117 Bonn.</li>
 			</ul>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 
-			<title>Data Protection &bull; Corona-Warn-App</title>
+			<title>Privacy Notice &bull; Corona-Warn-App</title>
 
 			<style>
 				body {
@@ -169,7 +169,7 @@
 			</style>
 	</head>
 
-	<body class="browser">
+	<body>
 
 
 		<!-- Templates -->
@@ -182,21 +182,21 @@
 		<!--<aside>Footnote</aside>-->
 
 
-		<!-- Document: "CWA Privacy Notice DE.docx" -->
+		<!-- Document: "CWA Privacy Notice EN.docx" -->
 		<!-- Updated: 13.06.20 -->
 
 
 		<!-- Präambel -->
 		<section>
 			<p>This privacy notice explains what data is collected when you use the Corona-Warn-App, how that data is used, and your rights under data protection law.</p>
-			<p>To ensure that this privacy notice can be understood by all users, we have made every effort to make it simple and as non-technical as possible. </p>
+			<p>To ensure that this privacy notice can be understood by all users, we have made every effort to make it simple and as non-technical as possible.</p>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 1. Wer stellt Ihnen diese App zur Verfügung? -->
+		<!-- 1. Who has provided you with this app? -->
 		<section>
-			<h2>1.	Who has provided you with this app?</h2>
+			<h2>1. Who has provided you with this app?</h2>
 			<p>The Corona-Warn-App (the “<strong>App</strong>”) is provided by the Robert Koch Institute, Nordufer 20, 13353 Berlin (the “<strong>RKI</strong>”).</p>
 			<p>The RKI is also what is called the controller under data protection law, meaning it is responsible for the processing of App users’ data.</p>
 			<p>You can contact the RKI’s data protection officer at the above address (“FAO the data protection officer”) and by emailing: datenschutz@rki.de.</p>
@@ -204,9 +204,9 @@
 		<p>&nbsp;</p>
 
 
-		<!-- 2. Ist die Nutzung der App freiwillig? -->
+		<!-- 2. Is using the App voluntary? -->
 		<section>
-			<h2>2.	Is using the App voluntary?</h2>
+			<h2>2. Is using the App voluntary?</h2>
 
 			<p>Using the App is entirely voluntary. It is your decision alone whether and how you use the App.</p>
 
@@ -222,30 +222,30 @@
 		<p>&nbsp;</p>
 
 
-		<!-- 3. Auf welcher Rechtsgrundlage werden Ihre Daten verarbeitet? -->
+		<!-- 3. On what legal basis is your data processed? -->
 		<section>
-			<h2>3.	On what legal basis is your data processed?</h2>
+			<h2>3. On what legal basis is your data processed?</h2>
 			<p>In principle, the RKI will process your personal data only on the basis of your consent granted pursuant to Article 6(1) Sentence 1(a) and Article 9(2)(a) of the General Data Protection Regulation (GDPR). If you have granted your consent, you can withdraw it at any time. Further information on your right of withdrawal and instructions on how to exercise this right can be found under 11.</p>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 4. An wen richtet sich die App? -->
+		<!-- 4. Who is the App aimed at? -->
 		<section>
-			<h2>4.	Who is the App aimed at?</h2>
-			<p>The App is aimed at people who are resident in Germany and at least 16 years old. </p>
+			<h2>4. Who is the App aimed at?</h2>
+			<p>The App is aimed at people who are resident in Germany and at least 16 years old.</p>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 5. Welche personenbezogenen Daten werden verarbeitet? -->
+		<!-- 5. What personal data is processed? -->
 		<section>
-			<h2>5.	What personal data is processed?</h2>
+			<h2>5. What personal data is processed?</h2>
 			<p>The App is designed to process as little personal data as possible. This means, for example, that the App does not collect any data that would allow the RKI or other users to infer your identity, health status or location. In addition, the App deliberately refrains from using tracking tools to record or analyse how you use the App.</p>
 			<p>The data processed by the App can be grouped into the following categories:</p>
 
 			<div>
-				<h3>a.	Access data</h3>
+				<h3>a. Access data</h3>
 
 				<p>Access data is generated when you use or enable the following features:</p>
 
@@ -255,7 +255,7 @@
 					<li>Sharing your test result.</li>
 				</ul>
 
-				<p>Each time data is retrieved from the App’s server system, your IP address (on the upstream load balancer) is masked and no longer used within the App’s server system. </p>
+				<p>Each time data is retrieved from the App’s server system, your IP address (on the upstream load balancer) is masked and no longer used within the App’s server system.</p>
 
 				<p>The following data is also processed:</p>
 
@@ -269,7 +269,7 @@
 			</div>
 
 			<div>
-				<h3>b.	Contact data</h3>
+				<h3>b. Contact data</h3>
 
 				<p>If you enable exposure logging in your smartphone’s operating system, which serves to record encounters (contacts) with other users, then your smartphone will continuously send out randomly generated identification numbers (“<strong>random IDs</strong>”) via Bluetooth Low Energy, which other smartphones in your vicinity can receive if exposure logging is also enabled on them. Your smartphone, in turn, also receives the random IDs of the other smartphones. In addition to the random IDs received from other smartphones, your smartphone’s exposure logging functionality records and stores the following contact data:</p>
 
@@ -286,13 +286,13 @@
 
 				<p>More information about the exposure logging functionality on Android smartphones is available at: <a>https://support.google.com/android/answer/9888358?hl=en</a>.</p>
 
-				<p>More information about Apple’s exposure logging functionality can be found in your iPhone’s settings under “Privacy” > “Health” > "COVID-19 Exposure Logging”. Please note that the exposure logging functionality is only available if iOS version 13.5 or higher is installed on your iPhone. </p>
+				<p>More information about Apple’s exposure logging functionality can be found in your iPhone’s settings under “Privacy” > “Health” > “COVID-19 Exposure Logging”. Please note that the exposure logging functionality is only available if iOS version 13.5 or higher is installed on your iPhone.</p>
 
 				<p>The App will only process the contact data generated and stored by your smartphone if the App’s exposure logging feature is enabled.</p>
 			</div>
 
 			<div>
-				<h3>c.	Health data</h3>
+				<h3>c. Health data</h3>
 
 				<p>Health data is any data containing information about the health of a particular individual. This includes not only information about past and current illnesses, but also about a person’s risk of illness (such as the risk that the person has been infected with the coronavirus).</p>
 
@@ -308,12 +308,12 @@
 		<p>&nbsp;</p>
 
 
-		<!-- 6. Funktionen der App -->
+		<!-- 6. App features -->
 		<section>
-			<h2>6.	App features</h2>
+			<h2>6. App features</h2>
 
 			<div>
-				<h3>a.	Exposure Logging</h3>
+				<h3>a. Exposure Logging</h3>
 
 				<p>The App’s core functionality is exposure logging. This serves to track possible contacts with other users of the App who are infected with the coronavirus, to evaluate the risk that you yourself have been infected, and – based on the risk identified – to provide you with health advice and recommendations for what to do next.</p>
 
@@ -327,14 +327,14 @@
 			</div>
 
 			<div>
-				<h3>b.	Registering a test</h3>
+				<h3>b. Registering a test</h3>
 
 				<p>If you have been tested for the coronavirus, you can register the test in the App by scanning the QR code which you received from your doctor or the testing facility. The app will then inform you as soon as the test result is available from the laboratory.</p>
 				<p>For this to work, the testing laboratory needs to be connected to the App’s server system and, as part of the testing procedure, you must have agreed separately to the laboratory transmitting your test result to the App’s server system (test result database). Test results from laboratories that are not connected to the App’s server system cannot be displayed in the App. If you have not received a QR code, the testing laboratory is not connected. In this case you will not be able to use this feature.</p>
 
 				<h5>Registering a test</h5>
 				<p>To receive the test result in the App, you must first register the test you have taken in the App. For this purpose, your doctor or the testing facility will provide you with a QR code when taking the sample. This QR code contains a code number which can be read with a QR code scanner. To register your test, you will need to scan the QR code in the App using your smartphone’s camera.</p>
-				<p>The code number read from the QR code is then hashed by the App, which means that the App performs a certain mathematical procedure in order to convert the code number in such a way that it can no longer be recognised. As soon as your smartphone is connected to the internet, the App will transmit the hashed code number to the App’s server system. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. The token is linked to the hashed code number on the server system. The App then deletes the hashed code number on your smartphone. The server system will only issue a token once for each hashed code number. This ensures that your QR code cannot be used by other users of the App to retrieve test results. </p>
+				<p>The code number read from the QR code is then hashed by the App, which means that the App performs a certain mathematical procedure in order to convert the code number in such a way that it can no longer be recognised. As soon as your smartphone is connected to the internet, the App will transmit the hashed code number to the App’s server system. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. The token is linked to the hashed code number on the server system. The App then deletes the hashed code number on your smartphone. The server system will only issue a token once for each hashed code number. This ensures that your QR code cannot be used by other users of the App to retrieve test results.</p>
 				<p>This completes the registration of your test.</p>
 
 				<h5>Filing of the test result</h5>
@@ -348,32 +348,32 @@
 			</div>
 
 			<div>
-				<h3>c.	Sharing your test result</h3>
+				<h3>c. Sharing your test result</h3>
 
 				<p>If you use the feature for sharing your test result in order to warn other users, the App will transfer the random IDs generated and stored by your smartphone from the last 14 days and the TAN to the App’s server system. The server system first checks whether the TAN is valid and then adds your random IDs to the list of random IDs of users who have shared a positive test result. Your random IDs can now be downloaded by other users as part of the exposure logging process.</p>
 
 				<h5>If you have not retrieved your test result in the App:</h5>
 				<p>Even if you have not retrieved a positive test result in the app, you can share the test result via the App to warn other users. In this case, the App prompts you to enter a so-called TeleTAN, which acts as a TAN.</p>
-				<p>To obtain a TeleTAN, please call the Corona-Warn-App hotline on +49 (0)800 7540002. The operator will first ask you some questions over the phone to check the plausibility of your call. These questions serve to prevent fraudulent reports of infections and any resulting incorrect warnings and  risk status. Once you have answered these questions sufficiently, you will be asked for your mobile/telephone number. This is so that you can be called back later and given a TeleTAN to enter in the App. Your mobile/telephone number will only be temporarily stored for this purpose and deleted within one hour at the latest.</p>
+				<p>To obtain a TeleTAN, please call the Corona-Warn-App hotline on +49 (0)800 7540002. The operator will first ask you some questions over the phone to check the plausibility of your call. These questions serve to prevent fraudulent reports of infections and any resulting incorrect warnings and risk status. Once you have answered these questions sufficiently, you will be asked for your mobile/telephone number. This is so that you can be called back later and given a TeleTAN to enter in the App. Your mobile/telephone number will only be temporarily stored for this purpose and deleted within one hour at the latest.</p>
 				<p>After your call, the hotline employee will generate a TeleTAN via a special access to the App’s server system and then call you to tell you the TeleTAN. If you enter the TeleTAN in the App, the TeleTAN will be sent back from the App to the App’s server system for comparison and verification. In return, the App receives a token from the server system, i.e. a digital access key that is stored in the App. Using this token, the App then requests a TAN from the server system.</p>
 				<p>The legal basis for this processing of your access data and health data (random IDs, test result, TAN and, if applicable, TeleTAN) is your consent to using the feature for sharing your test result.</p>
 			</div>
 
 			<div>
-				<h3>d.	Using the App for information purposes only</h3>
-				<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as <a>www.bundesregierung.de</a>, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting. </p>
+				<h3>d. Using the App for information purposes only</h3>
+				<p>As long as you use the App for information purposes only, i.e. do not use any of the App features mentioned above and do not enter any data, then processing only takes place locally on your smartphone and no personal data is generated. Websites linked in the app, such as <a>www.bundesregierung.de</a>, will open in your smartphone’s standard browser. The data processed here depends on the browser used, your browser settings, and the data processing practices of the website you are visiting.</p>
 			</div>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 7. Welche Berechtigungen und Funktionen benötigt die App? -->
+		<!-- 7. What permissions and functionality does the App require? -->
 		<section>
-			<h2>7.	What permissions and functionality does the App require?</h2>
+			<h2>7. What permissions and functionality does the App require?</h2>
 			<p>The App requires access to a number of your smartphone’s features and interfaces. For this purpose, you need to grant the App certain permissions. Permissions are programmed differently by different manufacturers. For example, individual permissions may be combined into permission categories, where you can only agree to the permission category as a whole. Please note that if the App is denied access, you will not be able to use any or all of the App’s features.</p>
 
 			<div>
-				<h3>a.	Technical requirements (all smartphones)</h3>
+				<h3>a. Technical requirements (all smartphones)</h3>
 
 				<ul>
 					<li>
@@ -390,13 +390,13 @@
 					</li>
 					<li>
 						<p>Background operation</p>
-						<p>The App runs in the background (i.e. when you are not actively using the App) in order to be able to automatically identify your risk and query the status of a registered test. If you deny the App permission to run in the background in your smartphone’s operating system, then you must start all actions in the App itself. </p>
+						<p>The App runs in the background (i.e. when you are not actively using the App) in order to be able to automatically identify your risk and query the status of a registered test. If you deny the App permission to run in the background in your smartphone’s operating system, then you must start all actions in the App itself.</p>
 					</li>
 				</ul>
 			</div>
 
 			<div>
-				<h3>b.	Android smartphones</h3>
+				<h3>b. Android smartphones</h3>
 
 				<p>If you are using an Android device, the following system features must also be enabled:</p>
 
@@ -454,14 +454,14 @@
 		<p>&nbsp;</p>
 
 
-		<!-- 8. Wann werden die Daten gelöscht? -->
+		<!-- 8. When will data be deleted? -->
 		<section>
-			<h2>8.	When will data be deleted?</h2>
+			<h2>8. When will data be deleted?</h2>
 
 			<p>All data stored in the App is deleted as soon as it is no longer needed for the App features:</p>
 
 			<div>
-				<h3>a.	Exposure Logging</h3>
+				<h3>a. Exposure Logging</h3>
 				<ul>
 					<li>The list of random IDs of users who have shared a positive test result will be deleted from the App immediately, and also automatically deleted from your smartphone’s exposure log after 14 days.</li>
 					<li>The RKI has no way of influencing the deletion of contact data in your smartphone’s exposure log (including your own random IDs) and contact data on other smartphones, as this functionality is provided by Apple or Google. In this case, the deletion depends on what Apple or Google has determined. Currently, the data is automatically deleted after 14 days. It may also be possible, using the functionality provided by Apple and Google, to manually delete data in your device’s system settings.</li>
@@ -470,7 +470,7 @@
 			</div>
 
 			<div>
-				<h3>b.	Registering a test </h3>
+				<h3>b. Registering a test</h3>
 				<ul>
 					<li>The hashed code number will be deleted from the App’s server system after 21 days.</li>
 					<li>In the event of a negative test result, the hashed code number and the test result will be deleted from the test result database immediately after the test result is retrieved; and in the event of a positive test result, they will be deleted immediately after the copy of the TAN stored on the server system is deleted (see below).</li>
@@ -480,7 +480,7 @@
 			</div>
 
 			<div>
-				<h3>c.	Sharing your test result</h3>
+				<h3>c. Sharing your test result</h3>
 				<ul>
 					<li>Your smartphone’s own random IDs which are shared in the App will be deleted from the server system after 14 days.</li>
 					<li>The copy of the TAN stored on the server system will be deleted after 21 days.</li>
@@ -496,27 +496,27 @@
 		<p>&nbsp;</p>
 
 
-		<!-- 9. An wen werden Ihre Daten weitergegeben? -->
+		<!-- 9. Who will receive your data? -->
 		<section>
-			<h2>9.	Who will receive your data?</h2>
+			<h2>9. Who will receive your data?</h2>
 			<p>If you share a test result to warn other users, your random IDs from the last 14 days will be passed on to the App on other users’ smartphones.</p>
 			<p>The RKI has commissioned T-Systems International GmbH and SAP Deutschland SE & Co. KG to operate and maintain part of the technical infrastructure of the App (e.g. server system, hotline), meaning that these two companies are processors under data protection law and acting on the RKI’s behalf (Article 28 GDPR).</p>
-			<p>Otherwise, the RKI will only pass on personal data collected in connection with your use of the App to third parties if the RKI is legally obliged to do so or if this is necessary for legal action or criminal prosecution in the case of attacks on the App’s technical infrastructure. In other cases, personal data will not generally be passed on. </p>
+			<p>Otherwise, the RKI will only pass on personal data collected in connection with your use of the App to third parties if the RKI is legally obliged to do so or if this is necessary for legal action or criminal prosecution in the case of attacks on the App’s technical infrastructure. In other cases, personal data will not generally be passed on.</p>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 10. Werden Daten in ein Drittland übermittelt? -->
+		<!-- 10. Is data transferred to a third country? -->
 		<section>
-			<h2>10.	Is data transferred to a third country?</h2>
+			<h2>10. Is data transferred to a third country?</h2>
 			<p>The data generated when the App is used is processed exclusively on servers in Germany or in another EU or EEA member state.</p>
 		</section>
 		<p>&nbsp;</p>
 
 
-		<!-- 11. Widerruf von Einwilligungen -->
+		<!-- 11. Withdrawal of consent -->
 		<section>
-			<h2>11.	Withdrawal of consent</h2>
+			<h2>11. Withdrawal of consent</h2>
 			<p>You have the right to withdraw any consent you granted the RKI in the App at any time with effect for the future. Please note that this will not affect the lawfulness of the processing before the withdrawal.</p>
 			<p>To withdraw your consent to the exposure logging feature, you can disable the feature using the toggle switch in the App or delete the App. If you decide to use the exposure logging feature again, you can toggle the feature back on or reinstall the App.</p>
 			<p>To withdraw your consent to the test registration feature, you can delete the test registration in the App. The token for retrieving the test result will then be deleted from your device. Neither the RKI nor the testing laboratory can then assign the transmitted data to your App or smartphone. If you wish to register another test, you will be asked to grant your consent again.</p>
@@ -525,9 +525,9 @@
 		<p>&nbsp;</p>
 
 
-		<!--  -->
+		<!-- 12. Your other rights under data protection law -->
 		<section>
-			<h2>12.	Your other rights under data protection law</h2>
+			<h2>12. Your other rights under data protection law</h2>
 
 			<p>If the RKI processes your personal data, you also have the following data protection rights:</p>
 
@@ -540,6 +540,7 @@
 			<p>Please note that the RKI can only fulfil the rights mentioned above if the data on which your claim is based can be clearly assigned to you. This would only be possible if the RKI were to collect further personal data that would allow the data mentioned above to be clearly assigned to you or your smartphone. Since this is not necessary – and not intended – for the purposes of the App, the RKI is not obliged to collect such additional data (Article 11(2) GDPR). Moreover, this would run counter to the stated objective of keeping the amount of data processed for the App as low as possible. Against this backdrop, it will not normally be possible to directly fulfil the above data protection rights under Articles 15, 16, 17, 18, 20 and 21 GDPR, as doing so would require additional information about you which is not available to the RKI.</p>
 		</section>
 		<p>&nbsp;</p>
+
 
 		<aside>Last amended: 12 June 2020</aside>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -214,7 +214,7 @@
 		<p>You will need to ensure that you are using the latest version of the App</p>
 		<p>The RKI will publish occasional updates for the App. You will need to install these updates as soon as possible and ensure that you are always using the newest version of the App. Using older versions of the App may lead to technical issues or disruptions.</p>
 		<h3>You will need to have the latest versions of iOS or Android</h3>
-		<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version [x] and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
+		<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6.0 and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
 		<h2>8.  LIMITATIONS OF THE APP</h2>
 		<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations. </p>
 		<p>One of these is that, while the App is constantly sending out random IDs (rolling proximity identifiers), it only receives random IDs from other devices at specific intervals. The windows for receiving data in the App are currently up to five minutes apart and are only very short, namely [two to four] seconds. </p>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -1,574 +1,522 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
+	<head>
+		<meta charset="utf-8">
 
-            <title>Terms of Use &bull; Corona-Warn-App</title>
+			<title>Terms of Use &bull; Corona-Warn-App</title>
 
-            <style>
-                body {
-                    --ena-text-primary-1-color: #17191a;
-                    --ena-text-tint-color: #409cc8;
-                }
+			<style>
+				body {
+					--ena-text-primary-1-color: #17191a;
+					--ena-text-tint-color: #409cc8;
+				}
 
 
-            body {
-                color: var(--ena-text-primary-1-color);
-            }
+			body {
+				color: var(--ena-text-primary-1-color);
+			}
 
 
-            a {
-                text-decoration: underline;
-            }
+			a {
+				text-decoration: underline;
+			}
 
 
-            a[href] {
-                color: var(--ena-text-tint-color);
-            }
+			a[href] {
+				color: var(--ena-text-tint-color);
+			}
 
 
-            * {
-                margin: 0;
-                padding: 0;
-            }
+			* {
+				margin: 0;
+				padding: 0;
+			}
 
 
-            html, body, table {
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
-                "Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
-            }
+			html, body, table {
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+				"Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
+			}
 
 
-            @supports (font: -apple-system-body) {
-                html, body, table {
-                    font: -apple-system-body !important;
-                }
-            }
+			@supports (font: -apple-system-body) {
+				html, body, table {
+					font: -apple-system-body !important;
+				}
+			}
 
 
-            section {
-                margin-bottom: 3rem;
-            }
+			section {
+				margin-bottom: 3rem;
+			}
 
 
-            h1 {
-                /*font-size: 28px;*/
-                font-size: 1.6470588235rem;
-                font-weight: bold;
-            }
+			h1 {
+				/*font-size: 28px;*/
+				font-size: 1.6470588235rem;
+				font-weight: bold;
+			}
 
 
-            h2 {
-                /*font-size: 22px;*/
-                font-size: 1.2941176471rem;
-                font-weight: bold;
-            }
+			h2 {
+				/*font-size: 22px;*/
+				font-size: 1.2941176471rem;
+				font-weight: bold;
+			}
 
 
-            h3 {
-                /*font-size: 17px;*/
-                font-size: 1.0rem;
-                font-weight: 600;
-            }
+			h3 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: 600;
+			}
 
 
-            h4 {
-                /*font-size: 17px;*/
-                font-size: 1.0rem;
-                font-weight: 600;
-                font-style: italic;
-            }
+			h4 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: 600;
+				font-style: italic;
+			}
 
 
-            p, ul {
-                /*font-size: 17px;*/
-                font-size: 1.0rem;
-                font-weight: normal;
-            }
+			h5 {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: normal;
+				text-decoration: underline;
+			}
 
 
-            span {
-                /*font-size: 15px;*/
-                font-size: 0.8823529412rem;
-                font-weight: normal;
-            }
+			p, ul {
+				/*font-size: 17px;*/
+				font-size: 1.0rem;
+				font-weight: normal;
+			}
 
 
-            aside {
-                /*font-size: 13px;*/
-                font-size: 0.7647058824rem;
-                font-weight: normal;
-            }
+			span {
+				/*font-size: 15px;*/
+				font-size: 0.8823529412rem;
+				font-weight: normal;
+			}
 
 
-            li {
-                text-indent: 2em;
-            }
+			aside {
+				/*font-size: 13px;*/
+				font-size: 0.7647058824rem;
+				font-weight: normal;
+			}
 
 
-            ul > ul li {
-                text-indent: 4em;
-            }
+			li {
+				text-indent: 2em;
+			}
 
 
-            h1 {
-                margin-bottom: 1rem;
-            }
+			ul > ul li {
+				text-indent: 4em;
+			}
 
 
-            h2 {
-                margin-bottom: 1rem;
-            }
+			h1 {
+				margin-bottom: 1rem;
+			}
 
 
-            h3 {
-                margin-bottom: 1rem;
-            }
+			h2 {
+				margin-bottom: 1rem;
+			}
 
 
-            h4 {
-                margin-bottom: 1rem;
-            }
+			h3 {
+				margin-bottom: 1rem;
+			}
 
 
-            p, ul, li {
-                margin-bottom: 1rem;
-            }
+			h4 {
+				margin-bottom: 1rem;
+			}
 
 
-            body.browser {
-                padding: 3rem;
-                width: 38.5rem;
-                margin: 0 auto;
-            }
+			h5 {
+				margin-bottom: 1rem;
+			}
 
 
-            body.browser,
-            body.browser,
-            body.browser table {
-                font-family: "Times New Roman", serif !important;
-            }
+			p, ul, li {
+				margin-bottom: 1rem;
+			}
 
 
-            body.browser p {
-                text-align: justify;
-            }
-            </style>
-            </head>
+			body.browser {
+				padding: 3rem;
+				width: 38.5rem;
+				margin: 0 auto;
+			}
 
-    <body>
 
+			body.browser,
+			body.browser,
+			body.browser table {
+				font-family: "Times New Roman", serif !important;
+			}
 
-        <!-- Templates -->
 
-        <!--<h1>Title 1</h1>-->
-        <!--<h2>Title 2</h2>-->
-        <!--<h3>Headline</h3>-->
-        <!--<p>Body</p>-->
-        <!--<span>Subheadline</span>-->
-        <!--<aside>Footnote</aside>-->
+			body.browser p {
+				text-align: justify;
+			}
+			</style>
+	</head>
 
+	<body>
 
-        <!-- Document: "CWA EULA DE.docx" -->
-        <!-- Updated: 13.06.20 -->
 
-        <!-- Inhalt -->
-        <section>
-            <h2>TABLE OF CONTENTS</h2>
+		<!-- Templates -->
 
-            <p>1.  What features does the App have?</p>
-            <p>2.  What does low or elevated risk mean?</p>
-            <p>3.  What do I do if I have been exposed to a confirmed case?</p>
-            <p>4.  The App does not protect you against infection</p>
-            <p>5.  Accessing test results</p>
-            <p>6.  Warning feature</p>
-            <p>7.  Technical requirements</p>
-            <p>8.  Limitations of the App</p>
-            <p>9.  User rights</p>
-            <p>10. Important information on availability and changes</p>
-            <p>11. No warranty</p>
-            <p>12. Special terms for the iOS version of the App</p>
-            <p>13. Final provisions</p>
-        </section>
-        <p>&nbsp;</p>
+		<!--<h1>Title 1</h1>-->
+		<!--<h2>Title 2</h2>-->
+		<!--<h3>Headline</h3>-->
+		<!--<p>Body</p>-->
+		<!--<span>Subheadline</span>-->
+		<!--<aside>Footnote</aside>-->
 
 
-        <!-- Preambel -->
-        <section>
-            <p>The app is published by</p>
+		<!-- Document: "CWA EULA EN.docx" -->
+		<!-- Updated: 13.06.20 -->
 
-            <p>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Robert Koch-Institut<br>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Nordufer 20<br>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin ("<strong>RKI</strong>")
-            </p>
 
-            <p>represented by its President. Please call the RKI on +49 30 187 545 100 or email us at CoronaWarnApp@rki.de if you have any questions relating to these Terms of Use or if you wish to submit any complaints or legal claims.</p>
+		<!-- Table of Contents -->
+		<section>
+			<h2>TABLE OF CONTENTS</h2>
 
-            <p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("CWA") and any future versions thereof (patches, updates and upgrades) ("<strong>App</strong>") and the use of any other services ("<strong>CWA Services</strong>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf</a>) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
+			<p>1. What features does the App have?</p>
+			<p>2. What does low or elevated risk mean?</p>
+			<p>3. What do I do if I have been exposed to a confirmed case?</p>
+			<p>4. The App does not protect you against infection</p>
+			<p>5. Accessing test results</p>
+			<p>6. Warning feature</p>
+			<p>7. Technical requirements</p>
+			<p>8. Limitations of the App</p>
+			<p>9. User rights</p>
+			<p>10. Important information on availability and changes</p>
+			<p>11. No warranty</p>
+			<p>12. Special terms for the iOS version of the App</p>
+			<p>13. Final provisions</p>
+		</section>
+		<p>&nbsp;</p>
 
-            <p>The App is available from the Apple App Store for all iOS devices and from Google Play for all Android devices. The general terms and conditions for apps available from Apple or Google do not apply with respect to the RKI. The RKI is solely responsible for the content and maintenance of the App and for any legal claims you may have in respect of the App.</p>
 
-            <p>You confirm that you agree to these Terms of Use when you install and use the App. If you do not agree to these Terms of Use, you may not install or use the App (or you will need to uninstall it) and you will not be able to use any of the related services or systems. This will not affect any rights under any open source licences relating to the App's source code.</p>
+		<!-- Preambel -->
+		<section>
+			<p>The app is published by</p>
 
-            <p>You are still responsible for complying with these Terms of Use if you give the device on which the App is installed to a third party and they use the App.</p>
+			<p>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Robert Koch-Institut<br>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Nordufer 20<br>
+			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin ("<strong>RKI</strong>")
+			</p>
 
-            <p>The App is intended for use by anyone who is 16 or over. Anyone under 16 may only use the App with the permission of their parent or guardian (<em>Sorgeberechtigte</em>).</p>
-        </section>
-        <p>&nbsp;</p>
+			<p>represented by its President. Please call the RKI on +49 30 187 545 100 or email us at CoronaWarnApp@rki.de if you have any questions relating to these Terms of Use or if you wish to submit any complaints or legal claims.</p>
 
+			<p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("CWA") and any future versions thereof (patches, updates and upgrades) ("<strong>App</strong>") and the use of any other services ("<strong>CWA Services</strong>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf</a>) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
 
-        <!-- Welche Funktionen hat die App? -->
-        <section>
-            <h2>1.	WHAT FEATURES DOES THE APP HAVE?</h2>
+			<p>The App is available from the Apple App Store for all iOS devices and from Google Play for all Android devices. The general terms and conditions for apps available from Apple or Google do not apply with respect to the RKI. The RKI is solely responsible for the content and maintenance of the App and for any legal claims you may have in respect of the App.</p>
+
+			<p>You confirm that you agree to these Terms of Use when you install and use the App. If you do not agree to these Terms of Use, you may not install or use the App (or you will need to uninstall it) and you will not be able to use any of the related services or systems. This will not affect any rights under any open source licences relating to the App's source code.</p>
+
+			<p>You are still responsible for complying with these Terms of Use if you give the device on which the App is installed to a third party and they use the App.</p>
+
+			<p>The App is intended for use by anyone who is 16 or over. Anyone under 16 may only use the App with the permission of their parent or guardian (<em>Sorgeberechtigte</em>).</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- Welche Funktionen hat die App? -->
+		<section>
+			<h2>1. WHAT FEATURES DOES THE APP HAVE?</h2>
 
 			<p>The aim of the Corona Warning App is to disrupt chains of infection of SARS-CoV-2 at an early stage. The intention is to notify people quickly and reliably about any contact they may have had with infected individuals and any potential exposure to the virus. This will allow people to self-isolate and limit the spread of the SARS-CoV-2 pandemic.</p>
-	
 			<p>The key features of the App are set out below. The details provided are solely for your information. They do not constitute legally binding specifications or any agreement that certain features must be available. Please also consult the information and conditions contained in Section 10.</p>
 
-            <h3>Background app</h3>
-            
-            <p>The App runs in the background on your device and automatically stores and encrypts random IDs (rolling proximity identifiers) produced by other nearby devices. The App regularly collects a list of random IDs (temporary exposure keys) via the CWA Services for those individuals who have voluntarily registered themselves as being infected. It then compares these against the random IDs already stored on the device and identifies any situation where an infection could have been passed on.</p>
-			
-			<p>The App is only able to identify and register encounters with other persons if the App is equally installed on a device carried on  by such person and if such person meets all the conditions for using the App (see Section 7 below). The App is not able to register whether the user has had contact with other people as such.</p>
+			<h3>Background app</h3>
+			<p>The App runs in the background on your device and automatically stores and encrypts random IDs (rolling proximity identifiers) produced by other nearby devices. The App regularly collects a list of random IDs (temporary exposure keys) via the CWA Services for those individuals who have voluntarily registered themselves as being infected. It then compares these against the random IDs already stored on the device and identifies any situation where an infection could have been passed on.</p>
+			<p>The App is only able to identify and register encounters with other persons if the App is equally installed on a device carried on by such person and if such person meets all the conditions for using the App (see Section 7 below). The App is not able to register whether the user has had contact with other people as such.</p>
 
-            <h3>Exposure notification</h3>
-            <p>You will receive a notification if you have had exposure to someone who has a confirmed infection. This notification will include instructions on what you should do next. This may include contacting a medical professional or the local public health department (<em>Gesundheitsamt</em>) and/or self-isolating at home.</p>
+			<h3>Exposure notification</h3>
+			<p>You will receive a notification if you have had exposure to someone who has a confirmed infection. This notification will include instructions on what you should do next. This may include contacting a medical professional or the local public health department (<em>Gesundheitsamt</em>) and/or self-isolating at home.</p>
 
-            <h3>Notification of test results</h3>
-            
-            <p>As soon as you have been tested for a SARS-CoV-2 infection, you can use the App to start the digital test notification process. You will then receive a notification of your test result in due course. The App is only able to provide the test result from the relevant lab. The RKI is not responsible for the performance of the test or the content of the test result.</p>
+			<h3>Notification of test results</h3>
+			<p>As soon as you have been tested for a SARS-CoV-2 infection, you can use the App to start the digital test notification process. You will then receive a notification of your test result in due course. The App is only able to provide the test result from the relevant lab. The RKI is not responsible for the performance of the test or the content of the test result.</p>
 
-            <h3>Positive result</h3>
-            
-            <p>If your SARS-CoV-2 test is positive, you may use the App to voluntarily publish your own random IDs registered by the App for the last 14 days as diagnosis keys. This will enable other App users to check on their own devices whether they may have had exposure to you during that period.</p>
+			<h3>Positive result</h3>
+			<p>If your SARS-CoV-2 test is positive, you may use the App to voluntarily publish your own random IDs registered by the App for the last 14 days as diagnosis keys. This will enable other App users to check on their own devices whether they may have had exposure to you during that period.</p>
 
-            <h3>Technical specifications of the App</h3>
-            
-            <p>Details of the technical features of the App and the related services and systems are available at:</p>
-			
+			<h3>Technical specifications of the App</h3>
+			<p>Details of the technical features of the App and the related services and systems are available at:</p>
 			<p><a>https://github.com/Corona-Warn-App</a></p>
-			
-			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement  regarding the quality or specifications for the App. </p>
+			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement regarding the quality or specifications for the App. </p>
 
-            <h3>Further information</h3>
-			
+			<h3>Further information</h3>
 			<p>Further information on the App is available at: <a>https://www.coronawarn.app/en/</a></p>
-			
 			<p>Further information on the SARS-CoV-2 pandemic is available at: <a>https://www.zusammengegencorona.de/</a></p>
-			
 			<p>The above information is for information purposes only and does not form part of these Terms of Use.</p>
-
-        </section>
-        <p>&nbsp;</p>
-
-
-        <!-- Was bedeutet niedriges oder erhöhtes Risiko -->
-        <section>
-            <h2>2.	WHAT DOES LOW OR ELEVATED RISK MEAN?</h2>
-
-            <p>The App uses any confirmed exposures to calculate the user's indicative individual risk. It uses factors such as days since exposure, exposure duration, the proximity to a confirmed case based on the Bluetooth signal attenuation and any transmission risk. The App will then tell your whether you are at "low risk" or "elevated risk". This is a purely indicative assessment based on the data collected. <strong>The App cannot tell you whether you are actually infected with SARS-CoV-2.</strong> You may still be infected if you are categorised as "low risk" and you may not be infected even if you are placed in the "elevated risk" category.</p>
-
-            <p><strong>There are a number of other factors which may affect your own personal risk of infection.</strong> The App will not take those factors into account. They include your own personal circumstances, the external circumstances of any exposure to a confirmed case, your own behaviour and any contact with anyone who is not registered with the App. See also Section 4.</p>
-        </section>
-        <p>&nbsp;</p>
+		</section>
+		<p>&nbsp;</p>
 
 
-        <!-- Risiko-Begegnung - Was tun? -->
-        <section>
-            <h2>3.	WHAT DO I DO IF I HAVE BEEN EXPOSED TO A CONFIRMED CASE?</h2>
+		<!-- 2. What does low or elevated risk mean? -->
+		<section>
+			<h2>2. WHAT DOES LOW OR ELEVATED RISK MEAN?</h2>
 
-            <p>If the App notifies you that you have been exposed to a confirmed case, you will also receive information on what to do next. These instructions are not legally binding, but the RKI does recommend that you follow them. The recommendations referred to above do not affect any applicable legal or contractual obligations or any official requirements on what to do in the event of any exposure to a confirmed case. You must still comply with any such obligations or requirements.</p>
+			<p>The App uses any confirmed exposures to calculate the user's indicative individual risk. It uses factors such as days since exposure, exposure duration, the proximity to a confirmed case based on the Bluetooth signal attenuation and any transmission risk. The App will then tell your whether you are at "low risk" or "elevated risk". This is a purely indicative assessment based on the data collected. <strong>The App cannot tell you whether you are actually infected with SARS-CoV-2.</strong> You may still be infected if you are categorised as "low risk" and you may not be infected even if you are placed in the "elevated risk" category.</p>
 
-            <p><strong>The App does not and cannot be used to provide any form of medical diagnosis.</strong></p>
-
-            <p><strong>The notification does not mean that you have SARS-CoV-2.</strong> It simply means that you have been exposed to someone with a confirmed case of SARS-CoV-2 during the last 14 days and that you may also potentially have been infected. The classification of risk as "low" or "elevated" is based solely on the available data and does not indicate whether you have actually been infected.</p>
-
-            <p><strong>You may receive an exposure notification which is not accurate.</strong> Your device may, for example, register an exposure at a time when you are not close to your device or while someone else is using it. Exposures may also be wrongly registered due to existing limitations in contact/proximity measurement (see Section 8).</p>
-        </section>
-        <p>&nbsp;</p>
+			<p><strong>There are a number of other factors which may affect your own personal risk of infection.</strong> The App will not take those factors into account. They include your own personal circumstances, the external circumstances of any exposure to a confirmed case, your own behaviour and any contact with anyone who is not registered with the App. See also Section 4.</p>
+		</section>
+		<p>&nbsp;</p>
 
 
-        <!-- Kein Infektionsschutz durch die App -->
-        <section>
-            <h2>4.	THE APP DOES NOT PROTECT YOU AGAINST INFECTION</h2>
+		<!-- 3. What do I do if I have been exposed to a confirmed case? -->
+		<section>
+			<h2>3. WHAT DO I DO IF I HAVE BEEN EXPOSED TO A CONFIRMED CASE?</h2>
 
-            <p>The App serves to disrupt chains of infection.</p>
+			<p>If the App notifies you that you have been exposed to a confirmed case, you will also receive information on what to do next. These instructions are not legally binding, but the RKI does recommend that you follow them. The recommendations referred to above do not affect any applicable legal or contractual obligations or any official requirements on what to do in the event of any exposure to a confirmed case. You must still comply with any such obligations or requirements.</p>
 
-            <ul>
-                <li><strong>The App will not protect you against infection with SARS-CoV-2. </strong></li>
-                <li><strong>The App does not reduce your own personal risk of infection. </strong></li>
-                <li><strong>You can still catch SARS-CoV-2 without the App notifying you of the exposure to the person who may have infected you:</strong></li>
-                <ul>
-                    <li>The App does not register all your contact with other people. This may be because other people are not using the App, you do not always have your device on you or you do not have the App activated at all times. There are also certain limitations in terms of contact/proximity measurement (see Section 8 below).</li>
-                    <li>The App only notifies you of potential exposures to confirmed cases. The App needs to have registered your contact with a confirmed case and the infected individual needs to have activated the App's warning feature. Activating the warning feature is voluntary and not all infected individuals may do so.</li>
-                </ul>
-            </ul>
+			<p><strong>The App does not and cannot be used to provide any form of medical diagnosis.</strong></p>
 
-            <p>Please use the App in conjunction with the other relevant precautions and official requirements. Reliable information on the SARS-CoV-2 pandemic and the precautions you should take is available at:</p>
+			<p><strong>The notification does not mean that you have SARS-CoV-2.</strong> It simply means that you have been exposed to someone with a confirmed case of SARS-CoV-2 during the last 14 days and that you may also potentially have been infected. The classification of risk as "low" or "elevated" is based solely on the available data and does not indicate whether you have actually been infected.</p>
 
-            <p><a>www.infektionsschutz.de/coronavirus</a></p>
-
-            <p><a>www.zusammengegencorona.de</a></p>
-
-            <p><a>www.rki.de/covid-19</a></p>
-
-            <p>The above is purely for your information and does not form part of these Terms of Use.</p>
-
-            <p>Always follow these <strong>rules</strong>, including when you are using the App:</p>
-            
-            <p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Practice social distancing (at least 1.5m)</p>
-            
-            <p><strong>H</strong>&nbsp;&nbsp;&nbsp;- Wash your hands regularly for at least 20 seconds</p>
-            
-            <p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Always wear a face mask when you go shopping and on public transport</p>
-            
-            <p>This is the best way to protect yourself and others against the virus.</p>
-        </section>
-        <p>&nbsp;</p>
+			<p><strong>You may receive an exposure notification which is not accurate.</strong> Your device may, for example, register an exposure at a time when you are not close to your device or while someone else is using it. Exposures may also be wrongly registered due to existing limitations in contact/proximity measurement (see Section 8).</p>
+		</section>
+		<p>&nbsp;</p>
 
 
-        <!-- Abrufen von Testergebnissen -->
-        <section>
-        
-            <h2>5.	ACCESSING TEST RESULTS</h2>
+		<!-- 4. The app does not protect you against infection -->
+		<section>
+			<h2>4. THE APP DOES NOT PROTECT YOU AGAINST INFECTION</h2>
 
-            <p>You may only access your <u>own</u> test results via the App.</p>
+			<p>The App serves to disrupt chains of infection.</p>
+			<ul>
+				<li><strong>The App will not protect you against infection with SARS-CoV-2. </strong></li>
+				<li><strong>The App does not reduce your own personal risk of infection. </strong></li>
+				<li><strong>You can still catch SARS-CoV-2 without the App notifying you of the exposure to the person who may have infected you:</strong></li>
+				<ul>
+					<li>The App does not register all your contact with other people. This may be because other people are not using the App, you do not always have your device on you or you do not have the App activated at all times. There are also certain limitations in terms of contact/proximity measurement (see Section 8 below).</li>
+					<li>The App only notifies you of potential exposures to confirmed cases. The App needs to have registered your contact with a confirmed case and the infected individual needs to have activated the App's warning feature. Activating the warning feature is voluntary and not all infected individuals may do so.</li>
+				</ul>
+			</ul>
 
-            <p>If you are waiting for test results and the CWA Services are not available or you cannot access your results via the App for any other reason, please use alternative means to obtain your result (e.g. contact the test provider such as your GP or the local public health department (<em>Gesundheitsamt</em>). Do not wait until the App is available again.</p>
-        
-        </section>
-        <p>&nbsp;</p>
+			<p>Please use the App in conjunction with the other relevant precautions and official requirements. Reliable information on the SARS-CoV-2 pandemic and the precautions you should take is available at:</p>
+			<p><a>www.infektionsschutz.de/coronavirus</a></p>
+			<p><a>www.zusammengegencorona.de</a></p>
+			<p><a>www.rki.de/covid-19</a></p>
+			<p>The above is purely for your information and does not form part of these Terms of Use.</p>
 
-
-        <!-- Auslösen einer Warnung -->
-        <section>
-            <h2>6.	WARNING FEATURE</h2>
-
-            <p>You can use the App to warn other people you have had contact with that you have tested positive for SARS-CoV-2. <strong>You may only activate the warning feature if your positive test result came from an approved testing lab.</strong></p>
-
-            <p>If the approved test lab is not linked to the CWA Services, your infection status will be verified via a verification hotline set up by the RKI. You may not activate the warning feature on the basis of a reporting of positive test result only.</p>
-
-            <p><strong><em>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</em></strong></p>
-
-            <p>If you are not sure whether or not you have been infected, contact your GP or the local public health department (<em>Gesundheitsamt</em>) before activating the warning feature. They will be able to advise you what to do and you may be able to get yourself tested if necessary. In the meantime, make sure you follow the general recommendations for what to do in the event that you think you may be infected with SARS-CoV-2.</p>
-
-            <h4>Use of the warning feature without good reason</h4>
-
-            <p><strong>You may not activate the warning feature without good reason and doing so may have serious consequences.</strong> You may, for example, be liable for damages towards any other affected individuals. </p>
-
-            <p>In the event of any use of the App which is not in line with these Terms of Use, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
-        
-        </section>
-        <p>&nbsp;</p>
+			<p>Always follow these <strong>rules</strong>, including when you are using the App:</p>
+			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Practice social distancing (at least 1.5m)</p>
+			<p><strong>H</strong>&nbsp;&nbsp;&nbsp;- Wash your hands regularly for at least 20 seconds</p>
+			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Always wear a face mask when you go shopping and on public transport</p>
+			<p>This is the best way to protect yourself and others against the virus.</p>
+		</section>
+		<p>&nbsp;</p>
 
 
-        <!-- Voraussetzungen für die Nutzung der App -->
-        <section>
-            <h2>7.	TECHNICAL REQUIREMENTS</h2>
+		<!-- 5. Accessing test results -->
+		<section>
+			<h2>5. ACCESSING TEST RESULTS</h2>
 
-            <p>The following technical requirements need to be met in order to use the App</p>
+			<p>You may only access your <u>own</u> test results via the App.</p>
 
-            <h4>You will need a data connection</h4>
+			<p>If you are waiting for test results and the CWA Services are not available or you cannot access your results via the App for any other reason, please use alternative means to obtain your result (e.g. contact the test provider such as your GP or the local public health department (<em>Gesundheitsamt</em>). Do not wait until the App is available again.</p>
+		</section>
+		<p>&nbsp;</p>
 
-            <p>Certain features of the App are based on central services and systems provided via the CWA Services. These features are therefore only available if your device has an internet data connection, e.g. via UMTS, LTE or WiFi, enabling access to the CWA Services. Some or all of the features of the App will not be available if you do not have a data connection. The same will apply when your device is turned off or in flight mode.</p>
 
-            <h4>The App must be running and activated</h4>
+		<!-- 6. Warning feature -->
+		<section>
+			<h2>6. WARNING FEATURE</h2>
 
-            <p>The App muss must be running on your device (in the foreground or background) and must be activated. You will need to launch the App for this. If you fail to launch the App, or deactivate or quit the App, it will not register any encounters with other people and will not generate any random IDs which can be stored by other devices. You will need to relaunch the App if you restart your device (e.g. after turning it off, when the battery runs out or following an operating system update).</p>
+			<p>You can use the App to warn other people you have had contact with that you have tested positive for SARS-CoV-2. <strong>You may only activate the warning feature if your positive test result came from an approved testing lab.</strong></p>
 
-            <h4>Settings on your device</h4>
+			<p>If the approved test lab is not linked to the CWA Services, your infection status will be verified via a verification hotline set up by the RKI. You may not activate the warning feature on the basis of a reporting of positive test result only.</p>
 
+			<p><strong><em>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</em></strong></p>
+
+			<p>If you are not sure whether or not you have been infected, contact your GP or the local public health department (<em>Gesundheitsamt</em>) before activating the warning feature. They will be able to advise you what to do and you may be able to get yourself tested if necessary. In the meantime, make sure you follow the general recommendations for what to do in the event that you think you may be infected with SARS-CoV-2.</p>
+
+			<h4>Use of the warning feature without good reason</h4>
+
+			<p><strong>You may not activate the warning feature without good reason and doing so may have serious consequences.</strong> You may, for example, be liable for damages towards any other affected individuals. </p>
+
+			<p>In the event of any use of the App which is not in line with these Terms of Use, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
+		</section>
+		<p>&nbsp;</p>
+
+
+		<!-- 7. Technical requirements -->
+		<section>
+			<h2>7. TECHNICAL REQUIREMENTS</h2>
+
+			<p>The following technical requirements need to be met in order to use the App</p>
+
+			<h4>You will need a data connection</h4>
+			<p>Certain features of the App are based on central services and systems provided via the CWA Services. These features are therefore only available if your device has an internet data connection, e.g. via UMTS, LTE or WiFi, enabling access to the CWA Services. Some or all of the features of the App will not be available if you do not have a data connection. The same will apply when your device is turned off or in flight mode.</p>
+
+			<h4>The App must be running and activated</h4>
+			<p>The App muss must be running on your device (in the foreground or background) and must be activated. You will need to launch the App for this. If you fail to launch the App, or deactivate or quit the App, it will not register any encounters with other people and will not generate any random IDs which can be stored by other devices. You will need to relaunch the App if you restart your device (e.g. after turning it off, when the battery runs out or following an operating system update).</p>
+
+			<h4>Settings on your device</h4>
 			<p>You will also need to activate the Bluetooth (BLE) functions on your device and allow the App to access them.</p>
-
 			<p>The RKI also recommends activating the following functions on your device and allowing the App to access them, although you will still be able to use the basic features of the App without them:</p>
-
-            <ul>
-                <li>notifications</li>
-                <li>camera</li>
-            </ul>
-
+			<ul>
+				<li>notifications</li>
+				<li>camera</li>
+			</ul>
 			<p>Please check the settings on your device to see whether these functions are activated and may be accessed by the App. </p>
-
 			<p>Detailed instructions on how to set up the App for iOS and Android are available at <a>https://www.coronawarn.app/en/</a>. These instructions are for information purposes only and do not form part of these Terms of Use.</p>
 
-            <h4>You will need to ensure that you are using the latest version of the App</h4>
-
+			<h4>You will need to ensure that you are using the latest version of the App</h4>
 			<p>The RKI will publish occasional updates for the App. You will need to install these updates as soon as possible and ensure that you are always using the newest version of the App. Using older versions of the App may lead to technical issues or disruptions.</p>
 
 			<h4>You will need to have the latest versions of iOS or Android</h4>
-
 			<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6 and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-			<p>&nbsp;</p>
 
-        <!-- Grenzen der App -->
-        <section>
-            <h2>8.	LIMITATIONS OF THE APP</h2>
+		<!-- 8. Limitations of the app -->
+		<section>
+			<h2>8. LIMITATIONS OF THE APP</h2>
 
 			<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations. </p>
 
 			<p>One of these is that, while the App is constantly sending out random IDs (rolling proximity identifiers), it only receives random IDs from other devices at specific intervals. The windows for receiving data in the App are currently up to five minutes apart and are only very short.. All these functionalities are based on the underlying Exposure Notification Framework from Apple and Google and can be changed by these companies at any time.</p>
 
 			<p>The Bluetooth signal attenuation is used for the proximity measurement. A lower signal attenuation essentially means that the other device is closer. A higher signal attenuation means that either the other device is further away (i.e. a distance of more than two metres) or there is something between the two devices blocking the signal. This might include something like a wall or a bag containing the device, but could just as easily be people or animals.</p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-        <p>&nbsp;</p>
 
-
-        <!-- Nutzungsrechte -->
-        <section>
-            <h2>9.	USER RIGHTS</h2>
+		<!-- 9. User rights -->
+		<section>
+			<h2>9. USER RIGHTS</h2>
 
 			<h4>Simple user right</h4>
-			
 			<p>You are hereby granted a limited, non-exclusive, non-transferable and revocable licence, which may not be sub-licensed, to use the App for your own personal, non-commercial purposes. </p>
-			
 			<p>The licence for the iOS version der App covers use on any Apple device owned or controlled by you, subject to the applicable terms and conditions of the App Store. You may also access and use the App via other Apple accounts linked to your own Apple account via Family Sharing or the purchase of bulk licences.</p>
-			
 			<p>You are entitled to make copies of the App for your own backup purposes. You are not entitled to any other rights in respect of the App.</p>
-			
+
 			<h4>Ownership of the App</h4>
-			
 			<p>The App (including the source code) is the sole, exclusive property of SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf, Germany ("<strong>SAP</strong>") or its licensors, subject to the rights granted to you under Section 9 and any other rights to the App which have been contractually granted to the Federal Republic of Germany by SAP.</p>
-			
+
 			<h4>Open source licensing notes</h4>
-			
 			<p>Information on the use of third-party components contained in the App and the applicable licensing provisions can be found in the open source licensing notes in the App.</p>
-
 			<p>The source code for the App is published under the "Apache 2.0 Licence" licence conditions and may be downloaded at "<a>https://github.com/corona-warn-app</a>". The licence conditions for the "Apache 2.0 Licence" are available at "<a>https://www.apache.org/licenses/LICENSE-2.0</a>".</p>
-
 			<p>The licensing provisions which apply to the source code for the App and the third-party components contained in the App are not affected by the rights granted under this Section 9.</p>
 
 			<h4>What you are not allowed to do</h4>
-
 			<p>You may not manipulate or change the App.</p>
-
 			<p>You may not use the App or the interfaces to the CWA Services for any purpose which is not in line with these Terms of Use. You may not use the CWA Services for any purpose other than the intended use of the App on your device. You may only access the CWA Services via the App.</p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-        <p>&nbsp;</p>
 
-
-        <!-- Wichtige Hinweise zu Verfügbarkeit und Änderungen -->
-        <section>
-            <h2>10.	IMPORTANT INFORMATION ON AVAILABILITY AND CHANGES</h2>
+		<!-- 10. Important information on availability -->
+		<section>
+			<h2>10. IMPORTANT INFORMATION ON AVAILABILITY AND CHANGES</h2>
 
 			<h4>No claim to a specific functionality</h4>
-
 			<p>The App is made available to you in the form in which it is published by the RKI. The RKI does not accept any responsibility for the operability of the App or the CWA Services and does not agree any specific properties or qualities with you. You are not entitled to any claim to a specific functionality or constitution of the App or the CWA Services. The RKI is entitled to make changes to the App at any time and to remove entire features or parts thereof or to add extra features to the App.</p>
 
 			<h4>No guarantee of availability</h4>
-
 			<p>The RKI may restrict or suspend the operation of the App and the CWA Services at any time. You do not have any claim to the continued availability of the App or any of the associated services and systems, including the CWA Services, either as regards individual features or the system as a whole.</p>
-
 			<p>The RKI does not guarantee the availability or performance of the CWA Services. The CWA Services may be temporarily unavailable due to maintenance or a fault. This may last for some time in certain cases. The functionality of the App will be restricted or completely unavailable during such periods.</p>
 
 			<h4>Changes to these Terms of Use</h4>
-
 			<p>The RKI reserves the right to make changes to these Terms of Use. You will be asked to agree to any such changes when you launch the App. If you do not agree to the changes, you will no longer be able to use the App and the CWA Services and you will need to uninstall the App from your device.</p>
 
 			<h4>Risk score</h4>
-
 			<p>The RKI also reserves the right to change the parameters used to determine the risk score at any time to take account of the latest research findings relating to the transmission and spread of the virus. The RKI may determine these parameters at its own discretion.</p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-        <p>&nbsp;</p>
 
-
-        <!-- Keine Gewährleistung -->
-        <section>
-            <h2>11.	NO WARRANTY</h2>
+		<!-- 11. No warranty -->
+		<section>
+			<h2>11. NO WARRANTY</h2>
 
 			<p>The RKI determines both the features and the design of the App and the CWA Services. In this respect, the RKI does not agree any specific properties or qualities with you and you have no right to the incorporation of specific features in the App or to these being designed in a specific way. The App is provided in the condition and with the features implemented by the RKI when it was published in the Apple App Store or Google Play.</p>
-			
+
 			<p>The RKI will exercise reasonable care in providing the App and the CWA Services. The RKI does not make any other promises or assurances regarding the App or the CWA Services and, in particular, does not warrant that:</p>
 
-            <ul>
+			<ul>
 				<li>you will be able to use the App or the CWA Services without any interruption or that these will be free from errors,</li>
 				<li>the App and the CWA Services will not be subject to any losses, corruption, attacks, viruses, interference, hacking or other security-related issues.</li>
-            </ul>
+			</ul>
 
-            <p>You have sole responsibility for data security on your device and any systems connected to it, including the data security of all other apps installed on your device.</p>
-        </section>
-        <p>&nbsp;</p>
+			<p>You have sole responsibility for data security on your device and any systems connected to it, including the data security of all other apps installed on your device.</p>
+		</section>
+		<p>&nbsp;</p>
 
 
-        <!-- Besondere Bedingungen für die iOS-Version der App -->
-        <section>
-            <h2>12.	SPECIAL TERMS FOR THE IOS VERSION OF THE APP</h2>
+		<!-- 12. Special terms for the iOS version of the app -->
+		<section>
+			<h2>12. SPECIAL TERMS FOR THE IOS VERSION OF THE APP</h2>
 
 			<p>The following terms apply if you obtain the App from the Apple App Store and use it with the iOS operating system.</p>
-			
+
 			<h4>Consent to data usage</h4>
-			
 			<p>You consent to the RKI collecting and using technical data and associated information (particularly technical information on your device, system and application software and your peripherals) at regular intervals in order to facilitate the provision of software updates, product support and any other services provided to you in connection with the App. The RKI may use this information to improve its products or offer you services or technology, provided this is done without disclosing your identity.</p>
-			
+
 			<h4>Maintenance and support</h4>
-			
 			<p>As publisher of the App, the RKI has sole responsibility for maintenance and support services for the App in line with these Terms of Use. Apple assumes no obligation whatsoever to provide any maintenance or support services in respect of the App. </p>
-			
+
 			<h4>Apple not liable for service interruptions</h4>
-			
 			<p>You may notify Apple in the event of service interruptions affecting the App. To the extent legally permissible, Apple has no further obligations in the event of such service interruptions. </p>
-			
+
 			<h4>Product liability</h4>
-			
 			<p>Apple is not liable for any claims by you or third parties in relation to the App or to the use or possession of the App. This includes </p>
-
-            <ul>
-                <li>product liability claims</li>
-                <li>claims based on the App not meeting statutory or regulatory requirements and</li>
-                <li>claims under consumer protection and data protection or any similar laws, </li>
-            </ul>
-
+			<ul>
+				<li>product liability claims</li>
+				<li>claims based on the App not meeting statutory or regulatory requirements and</li>
+				<li>claims under consumer protection and data protection or any similar laws,</li>
+			</ul>
 			<p>including claims in connection with use of the HealthKit and HomeKit frameworks.</p>
-			
-			<h4>Infringement of third-party IP rights</h4>
-			
-			<p>In the event that third parties assert claims due to the infringement of intellectual property rights by the App or your possession or use of the App, Apple shall not be responsible for the investigation, defence, resolution or fulfilment of such claims due to the infringement of intellectual property rights.</p>
-			
-			<h4>US embargoes and sanctions</h4>
-			
-			<p>In acknowledging these Terms of Use, you confirm that</p>
 
-            <ul>
-				<li>you are not in a country subject to an embargo by the government of the United States of America or deemed by the government of the United States of America to be a terrorist supporting country and </li>
+			<h4>Infringement of third-party IP rights</h4>
+			<p>In the event that third parties assert claims due to the infringement of intellectual property rights by the App or your possession or use of the App, Apple shall not be responsible for the investigation, defence, resolution or fulfilment of such claims due to the infringement of intellectual property rights.</p>
+
+			<h4>US embargoes and sanctions</h4>
+			<p>In acknowledging these Terms of Use, you confirm that</p>
+			<ul>
+				<li>you are not in a country subject to an embargo by the government of the United States of America or deemed by the government of the United States of America to be a terrorist supporting country and</li>
 				<li>you have not been placed on a list of prohibited or restricted parties kept by the government of the United States of America.</li>
-            </ul>
+			</ul>
 
 			<h4>Apple's rights as a third-party beneficiary</h4>
-			
 			<p>You acknowledge and accept that Apple is a third-party beneficiary under these Terms of Use and that Apple can therefore enforce these Terms of Use against you. The contracting parties retain the right to modify or terminate these Terms of Use, including Apple's rights. This does not require Apple's consent.</p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-        <p>&nbsp;</p>
 
-
-        <!-- Schlussbestimmungen -->
-        <section>
-            <h2>13.	FINAL PROVISIONS</h2>
+		<!-- 13. Final provisions -->
+		<section>
+			<h2>13. FINAL PROVISIONS</h2>
 
 			<h4>Proper use of the App / blocking users in the event of misuse</h4>
-			
 			<p>You may use the App and the CWA Services only in line with their intended used. In the event of misuse of the App or the CWA Services, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
-			
+
 			<h4>Third-party services</h4>
-			
 			<p>If you use third-party services in connection with accessing the App, including telecoms services to obtain a data connection, you are responsible for covering the associated costs and complying with the relevant terms and conditions.</p>
-			
+
 			<h4>Applicable law</h4>
-			
 			<p>These Terms of Use are governed by the laws of the Federal Republic of Germany. The United Nations Convention on Contracts for the International Sale of Goods is excluded. This does not affect the statutory provisions on restriction of the choice of law and on the applicability of mandatory provisions, including those in the country in which you as a consumer are resident.</p>
-			
+
 			<h4>Severability</h4>
-			
 			<p>Should any of these Terms of Use be or become legally invalid, this will not affect the remaining provisions. The invalid provisions shall be replaced by any applicable statutory provisions. If this would constitute unreasonable hardship for one of the parties, the entire Terms of Use shall be cease to be valid.</p>
+		</section>
+		<p>&nbsp;</p>
 
-        </section>
-        <p>&nbsp;</p>
 
-
-    </body>
+	</body>
 </html>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -419,7 +419,7 @@
 
         <!-- Nutzungsrechte -->
         <section>
-            <p>9.	USER RIGHTS</p>
+            <h2>9.	USER RIGHTS</h2>
 
 			<h4>Simple user right</h4>
 			
@@ -431,7 +431,7 @@
 			
 			<h4>Ownership of the App</h4>
 			
-			<p>The App (including the source code) is the sole, exclusive property of SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf, Germany ("SAP") or its licensors, subject to the rights granted to you under Section 9 and any other rights to the App which have been contractually granted to the Federal Republic of Germany by SAP.</p>
+			<p>The App (including the source code) is the sole, exclusive property of SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf, Germany ("<strong>SAP</strong>") or its licensors, subject to the rights granted to you under Section 9 and any other rights to the App which have been contractually granted to the Federal Republic of Germany by SAP.</p>
 			
 			<h4>Open source licensing notes</h4>
 			
@@ -535,7 +535,7 @@
 
             <ul>
 				<li>you are not in a country subject to an embargo by the government of the United States of America or deemed by the government of the United States of America to be a terrorist supporting country and </li>
-				<li>you have not been place on a list of prohibited or restricted parties kept by the government of the United States of America.</li>
+				<li>you have not been placed on a list of prohibited or restricted parties kept by the government of the United States of America.</li>
             </ul>
 
 			<h4>Apple's rights as a third-party beneficiary</h4>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -1,292 +1,574 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-			<title>Terms of Use &bull; Corona-Warn-App</title>
-			<style>
-				body {
-					--ena-text-primary-1-color: #17191a;
-					--ena-text-tint-color: #409cc8;
-				}
+    <head>
+        <meta charset="utf-8">
 
-			body {
-				color: var(--ena-text-primary-1-color);
-			}
+            <title>Terms of Use &bull; Corona-Warn-App</title>
 
-			a[href] {
-				color: var(--ena-text-tint-color);
-			}
+            <style>
+                body {
+                    --ena-text-primary-1-color: #17191a;
+                    --ena-text-tint-color: #409cc8;
+                }
 
-			* {
-				margin: 0;
-				padding: 0;
-			}
 
-			html, body, table {
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
-				"Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
-			}
+            body {
+                color: var(--ena-text-primary-1-color);
+            }
 
-			@supports (font: -apple-system-body) {
-				html, body, table {
-					font: -apple-system-body !important;
-				}
-			}
 
-			h1 {
-				/*font-size: 28px;*/
-				font-size: 1.6470588235rem;
-				font-weight: bold;
-			}
+            a {
+                text-decoration: underline;
+            }
 
-			h2 {
-				/*font-size: 22px;*/
-				font-size: 1.2941176471rem;
-				font-weight: bold;
-			}
 
-			h3 {
-				/*font-size: 17px;*/
-				font-size: 1.0rem;
-				font-weight: 600;
-			}
+            a[href] {
+                color: var(--ena-text-tint-color);
+            }
 
-			p, ul {
-				/*font-size: 17px;*/
-				font-size: 1.0rem;
-				font-weight: normal;
-			}
 
-			span {
-				/*font-size: 15px;*/
-				font-size: 0.8823529412rem;
-				font-weight: normal;
-			}
+            * {
+                margin: 0;
+                padding: 0;
+            }
 
-			aside {
-				/*font-size: 13px;*/
-				font-size: 0.7647058824rem;
-				font-weight: normal;
-			}
 
-			ul {
-				list-style-type: disc;
-			}
+            html, body, table {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                "Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
+            }
 
-			li {
-				text-indent: 2em;
-			}
 
-			h1 {
-				margin-bottom: 1rem;
-			}
+            @supports (font: -apple-system-body) {
+                html, body, table {
+                    font: -apple-system-body !important;
+                }
+            }
 
-			h2 {
-				margin-bottom: 1rem;
-			}
 
-			h3 {
-				margin-bottom: 1rem;
-			}
+            section {
+                margin-bottom: 3rem;
+            }
 
-			p, ul, li {
-				margin-bottom: 1rem;
-			}
-			</style>
-			</head>
-	<body>
 
-		<!--<h1>Corona-Warn-App</h1>-->
-		<!--<h1>Terms of Use</h1>-->
-		<!--
-		Clifford Chance draft as per 6 June 2020
+            h1 {
+                /*font-size: 28px;*/
+                font-size: 1.6470588235rem;
+                font-weight: bold;
+            }
 
-		DRAFT VERSION NOT APPROVED FOR USE
-		FOR INTERNAL USE - TO BE AGREED WITH RKI / BMG / SAP
-		-->
 
-		<h2>TABLE OF CONTENTS</h2>
-		<h3>1.  What features does the App have?</h3>
-		<h3>2.  What does low or elevated risk mean?</h3>
-		<h3>3.  What do I do if I have been exposed to a confirmed case?</h3>
-		<h3>4.  The App does not protect you against infection </h3>
-		<h3>5.  Accessing test results </h3>
-		<h3>6.  Warning feature </h3>
-		<h3>7.  Technical requirements </h3>
-		<h3>8.  Limitations of the App </h3>
-		<h3>9.  User rights </h3>
-		<h3>10. Important information on availability and changes </h3>
-		<h3>11. No warranty </h3>
-		<h3>12. Special terms for the iOS version of the App </h3>
-		<h3>13. Final provisions </h3>
+            h2 {
+                /*font-size: 22px;*/
+                font-size: 1.2941176471rem;
+                font-weight: bold;
+            }
 
-		<p></p>
 
-		<p>The app is published by </p>
+            h3 {
+                /*font-size: 17px;*/
+                font-size: 1.0rem;
+                font-weight: 600;
+            }
 
-		<p>
-		Robert Koch-Institut<br>
-		Nordufer 20<br>
-		13353 Berlin ('<b>RKI</b>')
-		</p>
 
-		<p>represented by its President. Please call the RKI on +49&nbsp;30&nbsp;187&nbsp;545&nbsp;100 or email us at CoronaWarnApp@rki.de if you have any questions relating to these Terms of Use or if you wish to submit any complaints or legal claims.</p>
-		<p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("<b>CWA</b>") and any future versions thereof (patches, updates and upgrades) ("<b>App</b>") and the use of any other services ("<b>CWA Services</b>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
-		<p>The App is available from the Apple App Store for all iOS devices and from Google Play for all Android devices. The general terms and conditions for apps available from Apple or Google do not apply with respect to the RKI. The RKI is solely responsible for the content and maintenance of the App and for any legal claims you may have in respect of the App.</p>
-		<p>You confirm that you agree to these Terms of Use when you install and use the App. If you do not agree to these Terms of Use, you may not install or use the App (or you will need to uninstall it) and you will not be able to use any of the related services or systems. This will not affect any rights under any open source licences relating to the App's source code.</p>
-		<p>You are still responsible for complying with these Terms of Use if you give the device on which the App is installed to a third party and they use the App. </p>
-		<p>The App is intended for use by anyone who is 16 or over. Anyone under 16 may only use the App with the permission of their parent or guardian (Sorgeberechtigte).</p>
-		<h2>1.  WHAT FEATURES DOES THE APP HAVE?</h2>
-		<p>The aim of the Corona Warning App is to disrupt chains of infection of SARS-CoV-2 at an early stage. The intention is to notify people quickly and reliably about any contact they may have had with infected individuals and any potential exposure to the virus. This will allow people to self-isolate and limit the spread of the SARS-CoV-2 pandemic.</p>
-		<p>The key features of the App are set out below. The details provided are solely for your information. They do not constitute legally binding specifications or any agreement that certain features must be available. Please also consult the information and conditions contained in Section 10.</p>
-		<h3>Background app</h3>
-		<p>The App runs in the background on your device and automatically stores and encrypts random IDs (rolling proximity identifiers) produced by other nearby devices. The App regularly collects a list of random IDs (temporary exposure keys) via the CWA Services for those individuals who have voluntarily registered themselves as being infected. It then compares these against the random IDs already stored on the device and identifies any situation where an infection could have been passed on.</p>
-		<p>The App is only able to identify and register encounters with other persons if the App is equally installed on a device carried on  by such person and if such person meets all the conditions for using the App (see Section 7 below). The App is not able to register whether the user has had contact with other people as such.</p>
-		<h3>Exposure notification</h3>
-		<p>You will receive a notification if you have had exposure to someone who has a confirmed infection. This notification will include instructions on what you should do next. This may include contacting a medical professional or the local public health department (Gesundheitsamt) and/or self-isolating at home.</p>
-		<h3>Notification of test results</h3>
-		<p>As soon as you have been tested for a SARS-CoV-2 infection, you can use the App to start the digital test notification process. You will then receive a notification of your test result in due course. The App is only able to provide the test result from the relevant lab. The RKI is not responsible for the performance of the test or the content of the test result.</p>
-		<h3>Positive result</h3>
-		<p>If your SARS-CoV-2 test is positive, you may use the App to voluntarily publish your own random IDs registered by the App for the last 14 days as diagnosis keys. This will enable other App users to check on their own devices whether they may have had exposure to you during that period.</p>
-		<h3>Technical specifications of the App</h3>
-		<p>Details of the technical features of the App and the related services and systems are available at:</p>
-		<p>https://github.com/Corona-Warn-App</p>
-		<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement  regarding the quality or specifications for the App. </p>
-		<h3>Further information</h3>
-		<p>Further information on the App is available at: https://www.coronawarn.app/en/</p>
-		<p>Further information on the SARS-CoV-2 pandemic is available at: https://www.zusammengegencorona.de/</p>
-		<p>The above information is for information purposes only and does not form part of these Terms of Use.</p>
-		<h2>2.  WHAT DOES LOW OR ELEVATED RISK MEAN?</h2>
-		<p>The App uses any confirmed exposures to calculate the user's indicative individual risk. It uses factors such as days since exposure, exposure duration, the proximity to a confirmed case based on the Bluetooth signal attenuation and any transmission risk. The App will then tell your whether you are at "low risk" or "elevated risk". This is a purely indicative assessment based on the data collected. The App cannot tell you whether you are actually infected with SARS-CoV-2. You may still be infected if you are categorised as "low risk" and you may not be infected even if you are placed in the "elevated risk" category.</p>
-		<p>There are a number of other factors which may affect your own personal risk of infection. The App will not take those factors into account. They include your own personal circumstances, the external circumstances of any exposure to a confirmed case, your own behaviour and any contact with anyone who is not registered with the App. See also Section 4.</p>
-		<h2>3.  WHAT DO I DO IF I HAVE BEEN EXPOSED TO A CONFIRMED CASE?</h2>
-		<p>If the App notifies you that you have been exposed to a confirmed case, you will also receive information on what to do next. These instructions are not legally binding, but the RKI does recommend that you follow them. The recommendations referred to above do not affect any applicable legal or contractual obligations or any official requirements on what to do in the event of any exposure to a confirmed case. You must still comply with any such obligations or requirements.</p>
-		<p>The App does not and cannot be used to provide any form of medical diagnosis.</p>
-		<p>The notification does not mean that you have SARS-CoV-2. It simply means that you have been exposed to someone with a confirmed case of SARS-CoV-2 during the last 14 days and that you may also potentially have been infected. The classification of risk as "low" or "elevated" is based solely on the available data and does not indicate whether you have actually been infected.</p>
-		<p>You may receive an exposure notification which is not accurate. Your device may, for example, register an exposure at a time when you are not close to your device or while someone else is using it. Exposures may also be wrongly registered due to existing limitations in contact/proximity measurement (see Section 8).</p>
-		<h2>4.  THE APP DOES NOT PROTECT YOU AGAINST INFECTION</h2>
-		<p>The App serves to disrupt chains of infection.</p>
-		<ul>
-			<li>The App will not protect you against infection with SARS-CoV-2. </li>
-			<li>The App does not reduce your own personal risk of infection. </li>
-			<li>You can still catch SARS-CoV-2 without the App notifying you of the exposure to the person who may have infected you:</li>
-			<ul>
-				<li>The App does not register all your contact with other people. This may be because other people are not using the App, you do not always have your device on you or you do not have the App activated at all times. There are also certain limitations in terms of contact/proximity measurement (see Section 8 below).</li>
-				<li>The App only notifies you of potential exposures to confirmed cases. The App needs to have registered your contact with a confirmed case and the infected individual needs to have activated the App's warning feature. Activating the warning feature is voluntary and not all infected individuals may do so.</li>
-			</ul>
-		</ul>
-		<p>Please use the App in conjunction with the other relevant precautions and official requirements. Reliable information on the SARS-CoV-2 pandemic and the precautions you should take is available at:</p>
-		<p>www.infektionsschutz.de/coronavirus</p>
-		<p>www.zusammengegencorona.de</p>
-		<p>www.rki.de/covid-19</p>
-		<p>The above is purely for your information and does not form part of these Terms of Use.</p>
-		<p>Always follow these rules, including when you are using the App:</p>
-		<p>✋   -   Practice social distancing (at least 1.5m) </p>
-		<p>�   -   Wash your hands regularly for at least 20 seconds </p>
-		<p>�   -   Always wear a face mask when you go shopping and on public transport</p>
-		<p>This is the best way to protect yourself and others against the virus.</p>
-		<h2>5.  ACCESSING TEST RESULTS</h2>
-		<p>You may only access your own test results via the App.</p>
-		<p>If you are waiting for test results and the CWA Services are not available or you cannot access your results via the App for any other reason, please use alternative means to obtain your result (e.g. contact the test provider such as your GP or the local public health department (Gesundheitsamt). Do not wait until the App is available again. </p>
-		<h2>6.  WARNING FEATURE</h2>
-		<p>You can use the App to warn other people you have had contact with that you have tested positive for SARS-CoV-2. You may only activate the warning feature if your positive test result came from an approved testing lab.</p>
-		<p>If the approved test lab is not linked to the CWA Services, your infection status will be verified via a verification hotline set up by the RKI. You may not activate the warning feature on the basis of a reporting of positive test result only.</p>
-		<p>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</p>
-		<p>If you are not sure whether or not you have been infected, contact your GP or the local public health department (Gesundheitsamt) before activating the warning feature. They will be able to advise you what to do and you may be able to get yourself tested if necessary. In the meantime, make sure you follow the general recommendations for what to do in the event that you think you may be infected with SARS-CoV-2.</p>
-		<p>Use of the warning feature without good reason</p>
-		<p>You may not activate the warning feature without good reason and doing so may have serious consequences. You may, for example, be liable for damages towards any other affected individuals. </p>
-		<p>In the event of any use of the App which is not in line with these Terms of Use, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
-		<h2>7.  TECHNICAL REQUIREMENTS</h2>
-		<p>The following technical requirements need to be met in order to use the App:</p>
-		<p>You will need a data connection</p>
-		<p>Certain features of the App are based on central services and systems provided via the CWA Services. These features are therefore only available if your device has an internet data connection, e.g. via UMTS, LTE or WiFi, enabling access to the CWA Services. Some or all of the features of the App will not be available if you do not have a data connection. The same will apply when your device is turned off or in flight mode.</p>
-		<p>The App must be running and activated</p>
-		<p>The App muss must be running on your device (in the foreground or background) and must be activated. You will need to launch the App for this. If you fail to launch the App, or deactivate or quit the App, it will not register any encounters with other people and will not generate any random IDs which can be stored by other devices. You will need to relaunch the App if you restart your device (e.g. after turning it off, when the battery runs out or following an operating system update).</p>
-		<p>Settings on your device</p>
-		<p>You will also need to activate the Bluetooth (BLE) functions on your device and allow the App to access them.</p>
-		<p>The RKI also recommends activating the following functions on your device and allowing the App to access them, although you will still be able to use the basic features of the App without them: </p>
-		<ul>
-			<li>notifications</li>
-			<li>camera</li>
-		</ul>
-		<p>Please check the settings on your device to see whether these functions are activated and may be accessed by the App. </p>
-		<p>Detailed instructions on how to set up the App for iOS and Android are available at https://www.coronawarn.app/en/. These instructions are for information purposes only and do not form part of these Terms of Use.</p>
-		<p>You will need to ensure that you are using the latest version of the App</p>
-		<p>The RKI will publish occasional updates for the App. You will need to install these updates as soon as possible and ensure that you are always using the newest version of the App. Using older versions of the App may lead to technical issues or disruptions.</p>
-		<h3>You will need to have the latest versions of iOS or Android</h3>
-		<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6.0 and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
-		<h2>8.  LIMITATIONS OF THE APP</h2>
-		<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations. </p>
-		<p>One of these is that, while the App is constantly sending out random IDs (rolling proximity identifiers), it only receives random IDs from other devices at specific intervals. The windows for receiving data in the App are currently up to five minutes apart and are only very short, namely [two to four] seconds. </p>
-		<p>The Bluetooth signal attenuation is used for the proximity measurement. A lower signal attenuation essentially means that the other device is closer. A higher signal attenuation means that either the other device is further away (i.e. a distance of more than two metres) or there is something between the two devices blocking the signal. This might include something like a wall or a bag containing the device, but could just as easily be people or animals.</p>
-		<h2>9.  USER RIGHTS</h2>
-		<h3>Simple user right</h3>
-		<p>You are hereby granted a limited, non-exclusive, non-transferable and revocable licence, which may not be sub-licensed, to use the App for your own personal, non-commercial purposes. </p>
-		<p>The licence for the iOS version der App covers use on any Apple device owned or controlled by you, subject to the applicable terms and conditions of the App Store. You may also access and use the App via other Apple accounts linked to your own Apple account via Family Sharing or the purchase of bulk licences.</p>
-		<p>You are entitled to make copies of the App for your own backup purposes. You are not entitled to any other rights in respect of the App.</p>
-		<h3>Ownership of the App</h3>
-		<p>The App (including the source code) is the sole, exclusive property of SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf, Germany <b>("SAP")</b> or its licensors, subject to the rights granted to you under Section 9 and any other rights to the App which have been contractually granted to the Federal Republic of Germany by SAP.</p>
-		<h3>Open source licensing notes</h3>
-		<p>Information on the use of third-party components contained in the App and the applicable licensing provisions can be found in the open source licensing notes in the App.</p>
-		<p>The source code for the App is published under the "Apache 2.0 Licence" licence conditions and may be downloaded at "https://github.com/corona-warn-app. The licence conditions for the "Apache 2.0 Licence" are available at "https://www.apache.org/licenses/LICENSE-2.0.</p>
-		<p>The licensing provisions which apply to the source code for the App and the third-party components contained in the App are not affected by the rights granted under this Section 9.</p>
-		<h3>What you are not allowed to do</h3>
-		<p>You may not manipulate or change the App.</p>
-		<p>You may not use the App or the interfaces to the CWA Services for any purpose which is not in line with these Terms of Use. You may not use the CWA Services for any purpose other than the intended use of the App on your device. You may only access the CWA Services via the App.</p>
-		<h2>10. IMPORTANT INFORMATION ON AVAILABILITY AND CHANGES</h2>
-		<h3>No claim to a specific functionality</h3>
-		<p>The App is made available to you in the form in which it is published by the RKI. The RKI does not accept any responsibility for the operability of the App or the CWA Services and does not agree any specific properties or qualities with you. You are not entitled to any claim to a specific functionality or constitution of the App or the CWA Services. The RKI is entitled to make changes to the App at any time and to remove entire features or parts thereof or to add extra features to the App.</p>
-		<h3>No guarantee of availability</h3>
-		<p>The RKI may restrict or suspend the operation of the App and the CWA Services at any time. You do not have any claim to the continued availability of the App or any of the associated services and systems, including the CWA Services, either as regards individual features or the system as a whole.</p>
-		<p>The RKI does not guarantee the availability or performance of the CWA Services. The CWA Services may be temporarily unavailable due to maintenance or a fault. This may last for some time in certain cases. The functionality of the App will be restricted or completely unavailable during such periods.</p>
-		<h3>Changes to these Terms of Use</h3>
-		<p>The RKI reserves the right to make changes to these Terms of Use. You will be asked to agree to any such changes when you launch the App. If you do not agree to the changes, you will no longer be able to use the App and the CWA Services and you will need to uninstall the App from your device.</p>
-		<h3>Risk score</h3>
-		<p>The RKI also reserves the right to change the parameters used to determine the risk score at any time to take account of the latest research findings relating to the transmission and spread of the virus. The RKI may determine these parameters at its own discretion.</p>
-		<h2>11. NO WARRANTY</h2>
-		<p>The RKI determines both the features and the design of the App and the CWA Services. In this respect, the RKI does not agree any specific properties or qualities with you and you have no right to the incorporation of specific features in the App or to these being designed in a specific way. The App is provided in the condition and with the features implemented by the RKI when it was published in the Apple App Store or Google Play.</p>
-		<p>The RKI will exercise reasonable care in providing the App and the CWA Services. The RKI does not make any other promises or assurances regarding the App or the CWA Services and, in particular, does not warrant that:</p>
-		<ul>
-			<li>you will be able to use the App or the CWA Services without any interruption or that these will be free from errors,</li>
-			<li>the App and the CWA Services will not be subject to any losses, corruption, attacks, viruses, interference, hacking or other security-related issues.</li>
-		</ul>
-		<p>You have sole responsibility for data security on your device and any systems connected to it, including the data security of all other apps installed on your device.</p>
-		<h2>12. SPECIAL TERMS FOR THE IOS VERSION OF THE APP</h2>
-		<p>The following terms apply if you obtain the App from the Apple App Store and use it with the iOS operating system.</p>
-		<h3>Consent to data usage </h3>
-		<p>You consent to the RKI collecting and using technical data and associated information (particularly technical information on your device, system and application software and your peripherals) at regular intervals in order to facilitate the provision of software updates, product support and any other services provided to you in connection with the App. The RKI may use this information to improve its products or offer you services or technology, provided this is done without disclosing your identity.</p>
-		<h3>Maintenance and support</h3>
-		<p>As publisher of the App, the RKI has sole responsibility for maintenance and support services for the App in line with these Terms of Use. Apple assumes no obligation whatsoever to provide any maintenance or support services in respect of the App. </p>
-		<h3>Apple not liable for service interruptions</h3>
-		<p>You may notify Apple in the event of service interruptions affecting the App. To the extent legally permissible, Apple has no further obligations in the event of such service interruptions. </p>
-		<h3>Product liability</h3>
-		<p>Apple is not liable for any claims by you or third parties in relation to the App or to the use or possession of the App. This includes </p>
-		<ul>
-			<li>product liability claims</li>
-			<li>claims based on the App not meeting statutory or regulatory requirements and</li>
-			<li>claims under consumer protection and data protection or any similar laws, </li>
-		</ul>
-		<p>including claims in connection with use of the HealthKit and HomeKit frameworks. </p>
-		<h3>Infringement of third-party IP rights</h3>
-		<p>In the event that third parties assert claims due to the infringement of intellectual property rights by the App or your possession or use of the App, Apple shall not be responsible for the investigation, defence, resolution or fulfilment of such claims due to the infringement of intellectual property rights.</p>
-		<h3>US embargoes and sanctions</h3>
-		<p>In acknowledging these Terms of Use, you confirm that </p>
-		<ul>
-			<li>you are not in a country subject to an embargo by the government of the United States of America or deemed by the government of the United States of America to be a terrorist supporting country and </li>
-			<li>you have not been place on a list of prohibited or restricted parties kept by the government of the United States of America.</li>
-		</ul>
-		<h3>Apple's rights as a third-party beneficiary</h3>
-		<p>You acknowledge and accept that Apple is a third-party beneficiary under these Terms of Use and that Apple can therefore enforce these Terms of Use against you. The contracting parties retain the right to modify or terminate these Terms of Use, including Apple's rights. This does not require Apple's consent.</p>
-		<h2>13. FINAL PROVISIONS</h2>
-		<h3>Proper use of the App / blocking users in the event of misuse</h3>
-		<p>You may use the App and the CWA Services only in line with their intended used. In the event of misuse of the App or the CWA Services, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
-		<h3>Third-party services</h3>
-		<p>If you use third-party services in connection with accessing the App, including telecoms services to obtain a data connection, you are responsible for covering the associated costs and complying with the relevant terms and conditions.</p>
-		<h3>Applicable law</h3>
-		<p>These Terms of Use are governed by the laws of the Federal Republic of Germany. The United Nations Convention on Contracts for the International Sale of Goods is excluded. This does not affect the statutory provisions on restriction of the choice of law and on the applicability of mandatory provisions, including those in the country in which you as a consumer are resident.</p>
-		<h3>Severability</h3>
-		<p>Should any of these Terms of Use be or become legally invalid, this will not affect the remaining provisions. The invalid provisions shall be replaced by any applicable statutory provisions. If this would constitute unreasonable hardship for one of the parties, the entire Terms of Use shall be cease to be valid.</p>
+            h4 {
+                /*font-size: 17px;*/
+                font-size: 1.0rem;
+                font-weight: 600;
+                font-style: italic;
+            }
 
-	</body>
 
+            p, ul {
+                /*font-size: 17px;*/
+                font-size: 1.0rem;
+                font-weight: normal;
+            }
+
+
+            span {
+                /*font-size: 15px;*/
+                font-size: 0.8823529412rem;
+                font-weight: normal;
+            }
+
+
+            aside {
+                /*font-size: 13px;*/
+                font-size: 0.7647058824rem;
+                font-weight: normal;
+            }
+
+
+            li {
+                text-indent: 2em;
+            }
+
+
+            ul > ul li {
+                text-indent: 4em;
+            }
+
+
+            h1 {
+                margin-bottom: 1rem;
+            }
+
+
+            h2 {
+                margin-bottom: 1rem;
+            }
+
+
+            h3 {
+                margin-bottom: 1rem;
+            }
+
+
+            h4 {
+                margin-bottom: 1rem;
+            }
+
+
+            p, ul, li {
+                margin-bottom: 1rem;
+            }
+
+
+            body.browser {
+                padding: 3rem;
+                width: 38.5rem;
+                margin: 0 auto;
+            }
+
+
+            body.browser,
+            body.browser,
+            body.browser table {
+                font-family: "Times New Roman", serif !important;
+            }
+
+
+            body.browser p {
+                text-align: justify;
+            }
+            </style>
+            </head>
+
+    <body>
+
+
+        <!-- Templates -->
+
+        <!--<h1>Title 1</h1>-->
+        <!--<h2>Title 2</h2>-->
+        <!--<h3>Headline</h3>-->
+        <!--<p>Body</p>-->
+        <!--<span>Subheadline</span>-->
+        <!--<aside>Footnote</aside>-->
+
+
+        <!-- Document: "CWA EULA DE.docx" -->
+        <!-- Updated: 13.06.20 -->
+
+        <!-- Inhalt -->
+        <section>
+            <h2>TABLE OF CONTENTS</h2>
+
+            <p>1.  What features does the App have?</p>
+            <p>2.  What does low or elevated risk mean?</p>
+            <p>3.  What do I do if I have been exposed to a confirmed case?</p>
+            <p>4.  The App does not protect you against infection</p>
+            <p>5.  Accessing test results</p>
+            <p>6.  Warning feature</p>
+            <p>7.  Technical requirements</p>
+            <p>8.  Limitations of the App</p>
+            <p>9.  User rights</p>
+            <p>10. Important information on availability and changes</p>
+            <p>11. No warranty</p>
+            <p>12. Special terms for the iOS version of the App</p>
+            <p>13. Final provisions</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Preambel -->
+        <section>
+            <p>The app is published by</p>
+
+            <p>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Robert Koch-Institut<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Nordufer 20<br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;13353 Berlin ("<strong>RKI</strong>")
+            </p>
+
+            <p>represented by its President. Please call the RKI on +49 30 187 545 100 or email us at CoronaWarnApp@rki.de if you have any questions relating to these Terms of Use or if you wish to submit any complaints or legal claims.</p>
+
+            <p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("CWA") and any future versions thereof (patches, updates and upgrades) ("<strong>App</strong>") and the use of any other services ("<strong>CWA Services</strong>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf</a>) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
+
+            <p>The App is available from the Apple App Store for all iOS devices and from Google Play for all Android devices. The general terms and conditions for apps available from Apple or Google do not apply with respect to the RKI. The RKI is solely responsible for the content and maintenance of the App and for any legal claims you may have in respect of the App.</p>
+
+            <p>You confirm that you agree to these Terms of Use when you install and use the App. If you do not agree to these Terms of Use, you may not install or use the App (or you will need to uninstall it) and you will not be able to use any of the related services or systems. This will not affect any rights under any open source licences relating to the App's source code.</p>
+
+            <p>You are still responsible for complying with these Terms of Use if you give the device on which the App is installed to a third party and they use the App.</p>
+
+            <p>The App is intended for use by anyone who is 16 or over. Anyone under 16 may only use the App with the permission of their parent or guardian (<em>Sorgeberechtigte</em>).</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Welche Funktionen hat die App? -->
+        <section>
+            <h2>1.	WHAT FEATURES DOES THE APP HAVE?</h2>
+
+			<p>The aim of the Corona Warning App is to disrupt chains of infection of SARS-CoV-2 at an early stage. The intention is to notify people quickly and reliably about any contact they may have had with infected individuals and any potential exposure to the virus. This will allow people to self-isolate and limit the spread of the SARS-CoV-2 pandemic.</p>
+	
+			<p>The key features of the App are set out below. The details provided are solely for your information. They do not constitute legally binding specifications or any agreement that certain features must be available. Please also consult the information and conditions contained in Section 10.</p>
+
+            <h3>Background app</h3>
+            
+            <p>The App runs in the background on your device and automatically stores and encrypts random IDs (rolling proximity identifiers) produced by other nearby devices. The App regularly collects a list of random IDs (temporary exposure keys) via the CWA Services for those individuals who have voluntarily registered themselves as being infected. It then compares these against the random IDs already stored on the device and identifies any situation where an infection could have been passed on.</p>
+			
+			<p>The App is only able to identify and register encounters with other persons if the App is equally installed on a device carried on  by such person and if such person meets all the conditions for using the App (see Section 7 below). The App is not able to register whether the user has had contact with other people as such.</p>
+
+            <h3>Exposure notification</h3>
+            <p>You will receive a notification if you have had exposure to someone who has a confirmed infection. This notification will include instructions on what you should do next. This may include contacting a medical professional or the local public health department (<em>Gesundheitsamt</em>) and/or self-isolating at home.</p>
+
+            <h3>Notification of test results</h3>
+            
+            <p>As soon as you have been tested for a SARS-CoV-2 infection, you can use the App to start the digital test notification process. You will then receive a notification of your test result in due course. The App is only able to provide the test result from the relevant lab. The RKI is not responsible for the performance of the test or the content of the test result.</p>
+
+            <h3>Positive result</h3>
+            
+            <p>If your SARS-CoV-2 test is positive, you may use the App to voluntarily publish your own random IDs registered by the App for the last 14 days as diagnosis keys. This will enable other App users to check on their own devices whether they may have had exposure to you during that period.</p>
+
+            <h3>Technical specifications of the App</h3>
+            
+            <p>Details of the technical features of the App and the related services and systems are available at:</p>
+			
+			<p><a>https://github.com/Corona-Warn-App</a></p>
+			
+			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement  regarding the quality or specifications for the App. </p>
+
+            <h3>Further information</h3>
+			
+			<p>Further information on the App is available at: <a>https://www.coronawarn.app/en/</a></p>
+			
+			<p>Further information on the SARS-CoV-2 pandemic is available at: <a>https://www.zusammengegencorona.de/</a></p>
+			
+			<p>The above information is for information purposes only and does not form part of these Terms of Use.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Was bedeutet niedriges oder erhöhtes Risiko -->
+        <section>
+            <h2>2.	WHAT DOES LOW OR ELEVATED RISK MEAN?</h2>
+
+            <p>The App uses any confirmed exposures to calculate the user's indicative individual risk. It uses factors such as days since exposure, exposure duration, the proximity to a confirmed case based on the Bluetooth signal attenuation and any transmission risk. The App will then tell your whether you are at "low risk" or "elevated risk". This is a purely indicative assessment based on the data collected. <strong>The App cannot tell you whether you are actually infected with SARS-CoV-2.</strong> You may still be infected if you are categorised as "low risk" and you may not be infected even if you are placed in the "elevated risk" category.</p>
+
+            <p><strong>There are a number of other factors which may affect your own personal risk of infection.</strong> The App will not take those factors into account. They include your own personal circumstances, the external circumstances of any exposure to a confirmed case, your own behaviour and any contact with anyone who is not registered with the App. See also Section 4.</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Risiko-Begegnung - Was tun? -->
+        <section>
+            <h2>3.	WHAT DO I DO IF I HAVE BEEN EXPOSED TO A CONFIRMED CASE?</h2>
+
+            <p>If the App notifies you that you have been exposed to a confirmed case, you will also receive information on what to do next. These instructions are not legally binding, but the RKI does recommend that you follow them. The recommendations referred to above do not affect any applicable legal or contractual obligations or any official requirements on what to do in the event of any exposure to a confirmed case. You must still comply with any such obligations or requirements.</p>
+
+            <p><strong>The App does not and cannot be used to provide any form of medical diagnosis.</strong></p>
+
+            <p><strong>The notification does not mean that you have SARS-CoV-2.</strong> It simply means that you have been exposed to someone with a confirmed case of SARS-CoV-2 during the last 14 days and that you may also potentially have been infected. The classification of risk as "low" or "elevated" is based solely on the available data and does not indicate whether you have actually been infected.</p>
+
+            <p><strong>You may receive an exposure notification which is not accurate.</strong> Your device may, for example, register an exposure at a time when you are not close to your device or while someone else is using it. Exposures may also be wrongly registered due to existing limitations in contact/proximity measurement (see Section 8).</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Kein Infektionsschutz durch die App -->
+        <section>
+            <h2>4.	THE APP DOES NOT PROTECT YOU AGAINST INFECTION</h2>
+
+            <p>The App serves to disrupt chains of infection.</p>
+
+            <ul>
+                <li><strong>The App will not protect you against infection with SARS-CoV-2. </strong></li>
+                <li><strong>The App does not reduce your own personal risk of infection. </strong></li>
+                <li><strong>You can still catch SARS-CoV-2 without the App notifying you of the exposure to the person who may have infected you:</strong></li>
+                <ul>
+                    <li>The App does not register all your contact with other people. This may be because other people are not using the App, you do not always have your device on you or you do not have the App activated at all times. There are also certain limitations in terms of contact/proximity measurement (see Section 8 below).</li>
+                    <li>The App only notifies you of potential exposures to confirmed cases. The App needs to have registered your contact with a confirmed case and the infected individual needs to have activated the App's warning feature. Activating the warning feature is voluntary and not all infected individuals may do so.</li>
+                </ul>
+            </ul>
+
+            <p>Please use the App in conjunction with the other relevant precautions and official requirements. Reliable information on the SARS-CoV-2 pandemic and the precautions you should take is available at:</p>
+
+            <p><a>www.infektionsschutz.de/coronavirus</a></p>
+
+            <p><a>www.zusammengegencorona.de</a></p>
+
+            <p><a>www.rki.de/covid-19</a></p>
+
+            <p>The above is purely for your information and does not form part of these Terms of Use.</p>
+
+            <p>Always follow these <strong>rules</strong>, including when you are using the App:</p>
+            
+            <p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Practice social distancing (at least 1.5m)</p>
+            
+            <p><strong>H</strong>&nbsp;&nbsp;&nbsp;- Wash your hands regularly for at least 20 seconds</p>
+            
+            <p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Always wear a face mask when you go shopping and on public transport</p>
+            
+            <p>This is the best way to protect yourself and others against the virus.</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Abrufen von Testergebnissen -->
+        <section>
+        
+            <h2>5.	ACCESSING TEST RESULTS</h2>
+
+            <p>You may only access your <u>own</u> test results via the App.</p>
+
+            <p>If you are waiting for test results and the CWA Services are not available or you cannot access your results via the App for any other reason, please use alternative means to obtain your result (e.g. contact the test provider such as your GP or the local public health department (<em>Gesundheitsamt</em>). Do not wait until the App is available again.</p>
+        
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Auslösen einer Warnung -->
+        <section>
+            <h2>6.	WARNING FEATURE</h2>
+
+            <p>You can use the App to warn other people you have had contact with that you have tested positive for SARS-CoV-2. <strong>You may only activate the warning feature if your positive test result came from an approved testing lab.</strong></p>
+
+            <p>If the approved test lab is not linked to the CWA Services, your infection status will be verified via a verification hotline set up by the RKI. You may not activate the warning feature on the basis of a reporting of positive test result only.</p>
+
+            <p><strong><em>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</em></strong></p>
+
+            <p>If you are not sure whether or not you have been infected, contact your GP or the local public health department (<em>Gesundheitsamt</em>) before activating the warning feature. They will be able to advise you what to do and you may be able to get yourself tested if necessary. In the meantime, make sure you follow the general recommendations for what to do in the event that you think you may be infected with SARS-CoV-2.</p>
+
+            <h4>Use of the warning feature without good reason</h4>
+
+            <p><strong>You may not activate the warning feature without good reason and doing so may have serious consequences.</strong> You may, for example, be liable for damages towards any other affected individuals. </p>
+
+            <p>In the event of any use of the App which is not in line with these Terms of Use, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
+        
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Voraussetzungen für die Nutzung der App -->
+        <section>
+            <h2>7.	TECHNICAL REQUIREMENTS</h2>
+
+            <p>The following technical requirements need to be met in order to use the App</p>
+
+            <h4>You will need a data connection</h4>
+
+            <p>Certain features of the App are based on central services and systems provided via the CWA Services. These features are therefore only available if your device has an internet data connection, e.g. via UMTS, LTE or WiFi, enabling access to the CWA Services. Some or all of the features of the App will not be available if you do not have a data connection. The same will apply when your device is turned off or in flight mode.</p>
+
+            <h4>The App must be running and activated</h4>
+
+            <p>The App muss must be running on your device (in the foreground or background) and must be activated. You will need to launch the App for this. If you fail to launch the App, or deactivate or quit the App, it will not register any encounters with other people and will not generate any random IDs which can be stored by other devices. You will need to relaunch the App if you restart your device (e.g. after turning it off, when the battery runs out or following an operating system update).</p>
+
+            <h4>Settings on your device</h4>
+
+			<p>You will also need to activate the Bluetooth (BLE) functions on your device and allow the App to access them.</p>
+
+			<p>The RKI also recommends activating the following functions on your device and allowing the App to access them, although you will still be able to use the basic features of the App without them:</p>
+
+            <ul>
+                <li>notifications</li>
+                <li>camera</li>
+            </ul>
+
+			<p>Please check the settings on your device to see whether these functions are activated and may be accessed by the App. </p>
+
+			<p>Detailed instructions on how to set up the App for iOS and Android are available at <a>https://www.coronawarn.app/en/</a>. These instructions are for information purposes only and do not form part of these Terms of Use.</p>
+
+            <h4>You will need to ensure that you are using the latest version of the App</h4>
+
+			<p>The RKI will publish occasional updates for the App. You will need to install these updates as soon as possible and ensure that you are always using the newest version of the App. Using older versions of the App may lead to technical issues or disruptions.</p>
+
+			<h4>You will need to have the latest versions of iOS or Android</h4>
+
+			<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6 and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
+
+        </section>
+			<p>&nbsp;</p>
+
+        <!-- Grenzen der App -->
+        <section>
+            <h2>8.	LIMITATIONS OF THE APP</h2>
+
+			<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations. </p>
+
+			<p>One of these is that, while the App is constantly sending out random IDs (rolling proximity identifiers), it only receives random IDs from other devices at specific intervals. The windows for receiving data in the App are currently up to five minutes apart and are only very short.. All these functionalities are based on the underlying Exposure Notification Framework from Apple and Google and can be changed by these companies at any time.</p>
+
+			<p>The Bluetooth signal attenuation is used for the proximity measurement. A lower signal attenuation essentially means that the other device is closer. A higher signal attenuation means that either the other device is further away (i.e. a distance of more than two metres) or there is something between the two devices blocking the signal. This might include something like a wall or a bag containing the device, but could just as easily be people or animals.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Nutzungsrechte -->
+        <section>
+            <p>9.	USER RIGHTS</p>
+
+			<h4>Simple user right</h4>
+			
+			<p>You are hereby granted a limited, non-exclusive, non-transferable and revocable licence, which may not be sub-licensed, to use the App for your own personal, non-commercial purposes. </p>
+			
+			<p>The licence for the iOS version der App covers use on any Apple device owned or controlled by you, subject to the applicable terms and conditions of the App Store. You may also access and use the App via other Apple accounts linked to your own Apple account via Family Sharing or the purchase of bulk licences.</p>
+			
+			<p>You are entitled to make copies of the App for your own backup purposes. You are not entitled to any other rights in respect of the App.</p>
+			
+			<h4>Ownership of the App</h4>
+			
+			<p>The App (including the source code) is the sole, exclusive property of SAP SE, Dietmar Hopp Allee 16, 69190 Walldorf, Germany ("SAP") or its licensors, subject to the rights granted to you under Section 9 and any other rights to the App which have been contractually granted to the Federal Republic of Germany by SAP.</p>
+			
+			<h4>Open source licensing notes</h4>
+			
+			<p>Information on the use of third-party components contained in the App and the applicable licensing provisions can be found in the open source licensing notes in the App.</p>
+
+			<p>The source code for the App is published under the "Apache 2.0 Licence" licence conditions and may be downloaded at "<a>https://github.com/corona-warn-app</a>". The licence conditions for the "Apache 2.0 Licence" are available at "<a>https://www.apache.org/licenses/LICENSE-2.0</a>".</p>
+
+			<p>The licensing provisions which apply to the source code for the App and the third-party components contained in the App are not affected by the rights granted under this Section 9.</p>
+
+			<h4>What you are not allowed to do</h4>
+
+			<p>You may not manipulate or change the App.</p>
+
+			<p>You may not use the App or the interfaces to the CWA Services for any purpose which is not in line with these Terms of Use. You may not use the CWA Services for any purpose other than the intended use of the App on your device. You may only access the CWA Services via the App.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Wichtige Hinweise zu Verfügbarkeit und Änderungen -->
+        <section>
+            <h2>10.	IMPORTANT INFORMATION ON AVAILABILITY AND CHANGES</h2>
+
+			<h4>No claim to a specific functionality</h4>
+
+			<p>The App is made available to you in the form in which it is published by the RKI. The RKI does not accept any responsibility for the operability of the App or the CWA Services and does not agree any specific properties or qualities with you. You are not entitled to any claim to a specific functionality or constitution of the App or the CWA Services. The RKI is entitled to make changes to the App at any time and to remove entire features or parts thereof or to add extra features to the App.</p>
+
+			<h4>No guarantee of availability</h4>
+
+			<p>The RKI may restrict or suspend the operation of the App and the CWA Services at any time. You do not have any claim to the continued availability of the App or any of the associated services and systems, including the CWA Services, either as regards individual features or the system as a whole.</p>
+
+			<p>The RKI does not guarantee the availability or performance of the CWA Services. The CWA Services may be temporarily unavailable due to maintenance or a fault. This may last for some time in certain cases. The functionality of the App will be restricted or completely unavailable during such periods.</p>
+
+			<h4>Changes to these Terms of Use</h4>
+
+			<p>The RKI reserves the right to make changes to these Terms of Use. You will be asked to agree to any such changes when you launch the App. If you do not agree to the changes, you will no longer be able to use the App and the CWA Services and you will need to uninstall the App from your device.</p>
+
+			<h4>Risk score</h4>
+
+			<p>The RKI also reserves the right to change the parameters used to determine the risk score at any time to take account of the latest research findings relating to the transmission and spread of the virus. The RKI may determine these parameters at its own discretion.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Keine Gewährleistung -->
+        <section>
+            <h2>11.	NO WARRANTY</h2>
+
+			<p>The RKI determines both the features and the design of the App and the CWA Services. In this respect, the RKI does not agree any specific properties or qualities with you and you have no right to the incorporation of specific features in the App or to these being designed in a specific way. The App is provided in the condition and with the features implemented by the RKI when it was published in the Apple App Store or Google Play.</p>
+			
+			<p>The RKI will exercise reasonable care in providing the App and the CWA Services. The RKI does not make any other promises or assurances regarding the App or the CWA Services and, in particular, does not warrant that:</p>
+
+            <ul>
+				<li>you will be able to use the App or the CWA Services without any interruption or that these will be free from errors,</li>
+				<li>the App and the CWA Services will not be subject to any losses, corruption, attacks, viruses, interference, hacking or other security-related issues.</li>
+            </ul>
+
+            <p>You have sole responsibility for data security on your device and any systems connected to it, including the data security of all other apps installed on your device.</p>
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Besondere Bedingungen für die iOS-Version der App -->
+        <section>
+            <h2>12.	SPECIAL TERMS FOR THE IOS VERSION OF THE APP</h2>
+
+			<p>The following terms apply if you obtain the App from the Apple App Store and use it with the iOS operating system.</p>
+			
+			<h4>Consent to data usage</h4>
+			
+			<p>You consent to the RKI collecting and using technical data and associated information (particularly technical information on your device, system and application software and your peripherals) at regular intervals in order to facilitate the provision of software updates, product support and any other services provided to you in connection with the App. The RKI may use this information to improve its products or offer you services or technology, provided this is done without disclosing your identity.</p>
+			
+			<h4>Maintenance and support</h4>
+			
+			<p>As publisher of the App, the RKI has sole responsibility for maintenance and support services for the App in line with these Terms of Use. Apple assumes no obligation whatsoever to provide any maintenance or support services in respect of the App. </p>
+			
+			<h4>Apple not liable for service interruptions</h4>
+			
+			<p>You may notify Apple in the event of service interruptions affecting the App. To the extent legally permissible, Apple has no further obligations in the event of such service interruptions. </p>
+			
+			<h4>Product liability</h4>
+			
+			<p>Apple is not liable for any claims by you or third parties in relation to the App or to the use or possession of the App. This includes </p>
+
+            <ul>
+                <li>product liability claims</li>
+                <li>claims based on the App not meeting statutory or regulatory requirements and</li>
+                <li>claims under consumer protection and data protection or any similar laws, </li>
+            </ul>
+
+			<p>including claims in connection with use of the HealthKit and HomeKit frameworks.</p>
+			
+			<h4>Infringement of third-party IP rights</h4>
+			
+			<p>In the event that third parties assert claims due to the infringement of intellectual property rights by the App or your possession or use of the App, Apple shall not be responsible for the investigation, defence, resolution or fulfilment of such claims due to the infringement of intellectual property rights.</p>
+			
+			<h4>US embargoes and sanctions</h4>
+			
+			<p>In acknowledging these Terms of Use, you confirm that</p>
+
+            <ul>
+				<li>you are not in a country subject to an embargo by the government of the United States of America or deemed by the government of the United States of America to be a terrorist supporting country and </li>
+				<li>you have not been place on a list of prohibited or restricted parties kept by the government of the United States of America.</li>
+            </ul>
+
+			<h4>Apple's rights as a third-party beneficiary</h4>
+			
+			<p>You acknowledge and accept that Apple is a third-party beneficiary under these Terms of Use and that Apple can therefore enforce these Terms of Use against you. The contracting parties retain the right to modify or terminate these Terms of Use, including Apple's rights. This does not require Apple's consent.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+        <!-- Schlussbestimmungen -->
+        <section>
+            <h2>13.	FINAL PROVISIONS</h2>
+
+			<h4>Proper use of the App / blocking users in the event of misuse</h4>
+			
+			<p>You may use the App and the CWA Services only in line with their intended used. In the event of misuse of the App or the CWA Services, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
+			
+			<h4>Third-party services</h4>
+			
+			<p>If you use third-party services in connection with accessing the App, including telecoms services to obtain a data connection, you are responsible for covering the associated costs and complying with the relevant terms and conditions.</p>
+			
+			<h4>Applicable law</h4>
+			
+			<p>These Terms of Use are governed by the laws of the Federal Republic of Germany. The United Nations Convention on Contracts for the International Sale of Goods is excluded. This does not affect the statutory provisions on restriction of the choice of law and on the applicability of mandatory provisions, including those in the country in which you as a consumer are resident.</p>
+			
+			<h4>Severability</h4>
+			
+			<p>Should any of these Terms of Use be or become legally invalid, this will not affect the remaining provisions. The invalid provisions shall be replaced by any applicable statutory provisions. If this would constitute unreasonable hardship for one of the parties, the entire Terms of Use shall be cease to be valid.</p>
+
+        </section>
+        <p>&nbsp;</p>
+
+
+    </body>
 </html>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -255,7 +255,7 @@
 			<h3>Technical specifications of the App</h3>
 			<p>Details of the technical features of the App and the related services and systems are available at:</p>
 			<p><a>https://github.com/Corona-Warn-App</a></p>
-			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement regarding the quality or specifications for the App. </p>
+			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement regarding the quality or specifications for the App.</p>
 
 			<h3>Further information</h3>
 			<p>Further information on the App is available at: <a>https://www.coronawarn.app/en/</a></p>
@@ -297,8 +297,8 @@
 
 			<p>The App serves to disrupt chains of infection.</p>
 			<ul>
-				<li><strong>The App will not protect you against infection with SARS-CoV-2. </strong></li>
-				<li><strong>The App does not reduce your own personal risk of infection. </strong></li>
+				<li><strong>The App will not protect you against infection with SARS-CoV-2.</strong></li>
+				<li><strong>The App does not reduce your own personal risk of infection.</strong></li>
 				<li><strong>You can still catch SARS-CoV-2 without the App notifying you of the exposure to the person who may have infected you:</strong></li>
 				<ul>
 					<li>The App does not register all your contact with other people. This may be because other people are not using the App, you do not always have your device on you or you do not have the App activated at all times. There are also certain limitations in terms of contact/proximity measurement (see Section 8 below).</li>
@@ -346,7 +346,7 @@
 
 			<h4>Use of the warning feature without good reason</h4>
 
-			<p><strong>You may not activate the warning feature without good reason and doing so may have serious consequences.</strong> You may, for example, be liable for damages towards any other affected individuals. </p>
+			<p><strong>You may not activate the warning feature without good reason and doing so may have serious consequences.</strong> You may, for example, be liable for damages towards any other affected individuals.</p>
 
 			<p>In the event of any use of the App which is not in line with these Terms of Use, the RKI reserves the right to ban users from accessing the App and the CWA Services.</p>
 		</section>
@@ -372,14 +372,14 @@
 				<li>notifications</li>
 				<li>camera</li>
 			</ul>
-			<p>Please check the settings on your device to see whether these functions are activated and may be accessed by the App. </p>
+			<p>Please check the settings on your device to see whether these functions are activated and may be accessed by the App.</p>
 			<p>Detailed instructions on how to set up the App for iOS and Android are available at <a>https://www.coronawarn.app/en/</a>. These instructions are for information purposes only and do not form part of these Terms of Use.</p>
 
 			<h4>You will need to ensure that you are using the latest version of the App</h4>
 			<p>The RKI will publish occasional updates for the App. You will need to install these updates as soon as possible and ensure that you are always using the newest version of the App. Using older versions of the App may lead to technical issues or disruptions.</p>
 
 			<h4>You will need to have the latest versions of iOS or Android</h4>
-			<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6 and upwards. Unfortunately the App does not work with earlier versions of those operating systems. </p>
+			<p>The App uses functions implemented specifically by Apple on iOS and Google on Android ("exposure notification"). These are only available on iOS version 13.5 and upwards and Android version 6 and upwards. Unfortunately the App does not work with earlier versions of those operating systems.</p>
 		</section>
 		<p>&nbsp;</p>
 
@@ -388,7 +388,7 @@
 		<section>
 			<h2>8. LIMITATIONS OF THE APP</h2>
 
-			<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations. </p>
+			<p>The App is designed to help you identify exposures you have had to people who subsequently received a positive test result. But you should always remember that the App has certain limitations.</p>
 
 			<p>One of these is that, while the App is constantly sending out random IDs (rolling proximity identifiers), it only receives random IDs from other devices at specific intervals. The windows for receiving data in the App are currently up to five minutes apart and are only very short.. All these functionalities are based on the underlying Exposure Notification Framework from Apple and Google and can be changed by these companies at any time.</p>
 
@@ -402,7 +402,7 @@
 			<h2>9. USER RIGHTS</h2>
 
 			<h4>Simple user right</h4>
-			<p>You are hereby granted a limited, non-exclusive, non-transferable and revocable licence, which may not be sub-licensed, to use the App for your own personal, non-commercial purposes. </p>
+			<p>You are hereby granted a limited, non-exclusive, non-transferable and revocable licence, which may not be sub-licensed, to use the App for your own personal, non-commercial purposes.</p>
 			<p>The licence for the iOS version der App covers use on any Apple device owned or controlled by you, subject to the applicable terms and conditions of the App Store. You may also access and use the App via other Apple accounts linked to your own Apple account via Family Sharing or the purchase of bulk licences.</p>
 			<p>You are entitled to make copies of the App for your own backup purposes. You are not entitled to any other rights in respect of the App.</p>
 
@@ -469,13 +469,13 @@
 			<p>You consent to the RKI collecting and using technical data and associated information (particularly technical information on your device, system and application software and your peripherals) at regular intervals in order to facilitate the provision of software updates, product support and any other services provided to you in connection with the App. The RKI may use this information to improve its products or offer you services or technology, provided this is done without disclosing your identity.</p>
 
 			<h4>Maintenance and support</h4>
-			<p>As publisher of the App, the RKI has sole responsibility for maintenance and support services for the App in line with these Terms of Use. Apple assumes no obligation whatsoever to provide any maintenance or support services in respect of the App. </p>
+			<p>As publisher of the App, the RKI has sole responsibility for maintenance and support services for the App in line with these Terms of Use. Apple assumes no obligation whatsoever to provide any maintenance or support services in respect of the App.</p>
 
 			<h4>Apple not liable for service interruptions</h4>
-			<p>You may notify Apple in the event of service interruptions affecting the App. To the extent legally permissible, Apple has no further obligations in the event of such service interruptions. </p>
+			<p>You may notify Apple in the event of service interruptions affecting the App. To the extent legally permissible, Apple has no further obligations in the event of such service interruptions.</p>
 
 			<h4>Product liability</h4>
-			<p>Apple is not liable for any claims by you or third parties in relation to the App or to the use or possession of the App. This includes </p>
+			<p>Apple is not liable for any claims by you or third parties in relation to the App or to the use or possession of the App. This includes</p>
 			<ul>
 				<li>product liability claims</li>
 				<li>claims based on the App not meeting statutory or regulatory requirements and</li>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -219,7 +219,7 @@
 
 			<p>represented by its President. Please call the RKI on +49 30 187 545 100 or email us at CoronaWarnApp@rki.de if you have any questions relating to these Terms of Use or if you wish to submit any complaints or legal claims.</p>
 
-			<p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("CWA") and any future versions thereof (patches, updates and upgrades) ("<strong>App</strong>") and the use of any other services ("<strong>CWA Services</strong>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf</a>) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
+			<p>Please make sure that you read these Terms of Use carefully. These Terms of Use form the basis for your use of the Corona-Warn-App ("<strong>CWA</strong>") and any future versions thereof (patches, updates and upgrades) ("<strong>App</strong>") and the use of any other services ("<strong>CWA Services</strong>") which are already available or may be made available by the RKI in connection with the App. The separate Data Protection Declaration (see <a>https://www.coronawarn.app/assets/documents/cwa-privacy-notice-en.pdf</a>) forms an integral part of these Terms of Use. Please also read the Data Protection Declaration carefully.</p>
 
 			<p>The App is available from the Apple App Store for all iOS devices and from Google Play for all Android devices. The general terms and conditions for apps available from Apple or Google do not apply with respect to the RKI. The RKI is solely responsible for the content and maintenance of the App and for any legal claims you may have in respect of the App.</p>
 
@@ -515,7 +515,6 @@
 			<h4>Severability</h4>
 			<p>Should any of these Terms of Use be or become legally invalid, this will not affect the remaining provisions. The invalid provisions shall be replaced by any applicable statutory provisions. If this would constitute unreasonable hardship for one of the parties, the entire Terms of Use shall be cease to be valid.</p>
 		</section>
-		<p>&nbsp;</p>
 
 
 	</body>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -239,25 +239,25 @@
 			<p>The aim of the Corona Warning App is to disrupt chains of infection of SARS-CoV-2 at an early stage. The intention is to notify people quickly and reliably about any contact they may have had with infected individuals and any potential exposure to the virus. This will allow people to self-isolate and limit the spread of the SARS-CoV-2 pandemic.</p>
 			<p>The key features of the App are set out below. The details provided are solely for your information. They do not constitute legally binding specifications or any agreement that certain features must be available. Please also consult the information and conditions contained in Section 10.</p>
 
-			<h3>Background app</h3>
+			<h4>Background app</h4>
 			<p>The App runs in the background on your device and automatically stores and encrypts random IDs (rolling proximity identifiers) produced by other nearby devices. The App regularly collects a list of random IDs (temporary exposure keys) via the CWA Services for those individuals who have voluntarily registered themselves as being infected. It then compares these against the random IDs already stored on the device and identifies any situation where an infection could have been passed on.</p>
 			<p>The App is only able to identify and register encounters with other persons if the App is equally installed on a device carried on by such person and if such person meets all the conditions for using the App (see Section 7 below). The App is not able to register whether the user has had contact with other people as such.</p>
 
-			<h3>Exposure notification</h3>
+			<h4>Exposure notification</h4>
 			<p>You will receive a notification if you have had exposure to someone who has a confirmed infection. This notification will include instructions on what you should do next. This may include contacting a medical professional or the local public health department (<em>Gesundheitsamt</em>) and/or self-isolating at home.</p>
 
-			<h3>Notification of test results</h3>
+			<h4>Notification of test results</h4>
 			<p>As soon as you have been tested for a SARS-CoV-2 infection, you can use the App to start the digital test notification process. You will then receive a notification of your test result in due course. The App is only able to provide the test result from the relevant lab. The RKI is not responsible for the performance of the test or the content of the test result.</p>
 
-			<h3>Positive result</h3>
+			<h4>Positive result</h4>
 			<p>If your SARS-CoV-2 test is positive, you may use the App to voluntarily publish your own random IDs registered by the App for the last 14 days as diagnosis keys. This will enable other App users to check on their own devices whether they may have had exposure to you during that period.</p>
 
-			<h3>Technical specifications of the App</h3>
+			<h4>Technical specifications of the App</h4>
 			<p>Details of the technical features of the App and the related services and systems are available at:</p>
 			<p><a>https://github.com/Corona-Warn-App</a></p>
 			<p>These technical specifications are for information purposes only and do not form part of these Terms of Use. They are not a legally binding agreement regarding the quality or specifications for the App.</p>
 
-			<h3>Further information</h3>
+			<h4>Further information</h4>
 			<p>Further information on the App is available at: <a>https://www.coronawarn.app/en/</a></p>
 			<p>Further information on the SARS-CoV-2 pandemic is available at: <a>https://www.zusammengegencorona.de/</a></p>
 			<p>The above information is for information purposes only and does not form part of these Terms of Use.</p>
@@ -342,7 +342,7 @@
 
 			<p>If the approved test lab is not linked to the CWA Services, your infection status will be verified via a verification hotline set up by the RKI. You may not activate the warning feature on the basis of a reporting of positive test result only.</p>
 
-			<p><strong><em>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</em></strong></p>
+			<h4>In cases of doubt, get in touch with your GP or the local public health department (Gesundheitsamt)</h4>
 
 			<p>If you are not sure whether or not you have been infected, contact your GP or the local public health department (<em>Gesundheitsamt</em>) before activating the warning feature. They will be able to advise you what to do and you may be able to get yourself tested if necessary. In the meantime, make sure you follow the general recommendations for what to do in the event that you think you may be infected with SARS-CoV-2.</p>
 

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/usage.html
@@ -313,9 +313,11 @@
 			<p>The above is purely for your information and does not form part of these Terms of Use.</p>
 
 			<p>Always follow these <strong>rules</strong>, including when you are using the App:</p>
-			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Practice social distancing (at least 1.5m)</p>
-			<p><strong>H</strong>&nbsp;&nbsp;&nbsp;- Wash your hands regularly for at least 20 seconds</p>
-			<p><strong>A</strong>&nbsp;&nbsp;&nbsp;- Always wear a face mask when you go shopping and on public transport</p>
+			<ul>
+				<li>Practice social distancing (at least 1.5m)</li>
+				<li>Wash your hands regularly for at least 20 seconds</li>
+				<li>Always wear a face mask when you go shopping and on public transport</li>
+			</ul>
 			<p>This is the best way to protect yourself and others against the virus.</p>
 		</section>
 		<p>&nbsp;</p>


### PR DESCRIPTION
Updated terms of use and data privacy statement to latest documents, both for German and English versions.

Please review these screens for both German and English:

|Terms of Use|Data Privacy Statement|
|:--|:--|
|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84578007-70252f80-adc1-11ea-8b3f-baa3db2faf59.png">|<img width="767" alt="image" src="https://user-images.githubusercontent.com/64848654/84577995-597ed880-adc1-11ea-9d53-f87811a61ccd.png">|

Attached documents represents the meta structure of the legal documents and have been signed off. The actual appearance in the app is aligned with the design typography and is not reflected.

[data-privacy-statement.de.pdf](https://github.com/corona-warn-app/cwa-app-ios/files/4775333/data-privacy-statement.de.pdf)
[data-privacy-statement.en.pdf](https://github.com/corona-warn-app/cwa-app-ios/files/4775334/data-privacy-statement.en.pdf)
[terms-of-use.de.pdf](https://github.com/corona-warn-app/cwa-app-ios/files/4775335/terms-of-use.de.pdf)
[terms-of-use.en.pdf](https://github.com/corona-warn-app/cwa-app-ios/files/4775336/terms-of-use.en.pdf)

