### PR TITLE
[Bug] Fix home navigation bar preferred alpha when scrolling

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeLayout.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeLayout.swift
@@ -22,6 +22,7 @@ protocol HomeLayoutDelegate: AnyObject {
 }
 
 extension UICollectionViewLayout {
+	static let topInset: CGFloat = 32.0
 	static let bottomBackgroundOverflowHeight: CGFloat = UIScreen.main.bounds.height
 
 	class func homeLayout(delegate: HomeLayoutDelegate) -> UICollectionViewLayout {
@@ -58,7 +59,7 @@ extension UICollectionViewLayout {
 		let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 
 		let section = NSCollectionLayoutSection(group: group)
-		section.contentInsets = .init(top: 32.0, leading: 16.0, bottom: 32.0, trailing: 16.0)
+		section.contentInsets = .init(top: 0.0, leading: 16.0, bottom: 32.0, trailing: 16.0)
 		section.interGroupSpacing = 32.0
 
 		return section

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -289,7 +289,7 @@ final class HomeViewController: UIViewController {
 		collectionView.collectionViewLayout = .homeLayout(delegate: self)
 		collectionView.delegate = self
 
-		collectionView.contentInset = UIEdgeInsets(top: 0.0, left: 0, bottom: -UICollectionViewLayout.bottomBackgroundOverflowHeight, right: 0)
+		collectionView.contentInset = UIEdgeInsets(top: UICollectionViewLayout.topInset, left: 0, bottom: -UICollectionViewLayout.bottomBackgroundOverflowHeight, right: 0)
 
 		collectionView.isAccessibilityElement = false
 		collectionView.shouldGroupAccessibilityChildren = true


### PR DESCRIPTION
This PR fixes the invalid alpha channel of the navigation bar on the home screen when scrolling. The nav bar should not be visible when scrolled to the top. When scrolling down it should slowly appear and each full opacity before the first element reaches the bottom edge of the navigation bar.