### PR TITLE
[HOTFIX] Call requestRisk on sceneWillEnterForeground

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -217,6 +217,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension AppDelegate: ENATaskExecutionDelegate {
 	func executeExposureDetectionRequest(task: BGTask, completion: @escaping ((Bool) -> Void)) {
 
+		let backgroundRefreshStatus = UIApplication.shared.backgroundRefreshStatus
+		let detectionMode = DetectionMode.from(backgroundStatus: backgroundRefreshStatus)
+		riskProvider.configuration.detectionMode = detectionMode
+
 		riskProvider.requestRisk(userInitiated: false) { risk in
 			// present a notification if the risk score has increased
 			if let risk = risk,

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -104,7 +104,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 	}
 
 	func sceneWillEnterForeground(_ scene: UIScene) {
-		riskProvider.requestRisk(userInitiated: true)
+		let backgroundRefreshStatus = UIApplication.shared.backgroundRefreshStatus
+		let detectionMode = DetectionMode.from(backgroundStatus: backgroundRefreshStatus)
+		riskProvider.configuration.detectionMode = detectionMode
+
+		riskProvider.requestRisk(userInitiated: false)
+
 		let state = exposureManager.preconditions()
 		updateExposureState(state)
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -104,10 +104,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 	}
 
 	func sceneWillEnterForeground(_ scene: UIScene) {
+		riskProvider.requestRisk(userInitiated: false)
 		let state = exposureManager.preconditions()
 		updateExposureState(state)
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
-		riskProvider.requestRisk(userInitiated: false)
 	}
 
 	func sceneDidEnterBackground(_ scene: UIScene) {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -107,6 +107,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 		let state = exposureManager.preconditions()
 		updateExposureState(state)
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
+		riskProvider.requestRisk(userInitiated: false)
 	}
 
 	func sceneDidEnterBackground(_ scene: UIScene) {

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -104,7 +104,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 	}
 
 	func sceneWillEnterForeground(_ scene: UIScene) {
-		riskProvider.requestRisk(userInitiated: false)
+		riskProvider.requestRisk(userInitiated: true)
 		let state = exposureManager.preconditions()
 		updateExposureState(state)
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)


### PR DESCRIPTION
In sceneWillEnterForeground(_ scene: UIScene), call riskProvider.requestRisk(userInitiated: false)

This will ensure that every time the user goes back into the app, the app will attempt to request the latest risk.

Internally, the RiskProvider ensures that the logic behind throttling the actual API requests is applied.