### PR TITLE
[Bug] Fix unknown outdated risk detail screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
@@ -321,7 +321,6 @@ extension ExposureDetectionViewController {
 					.riskRefreshed(text: AppStrings.ExposureDetection.refreshed, image: UIImage(named: "Icons_Aktualisiert"))
 				]
 			),
-			riskRefreshSection,
 			riskLoadingSection,
 			standardGuideSection,
 			explanationSection(

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController+DynamicTableViewModel.swift
@@ -84,7 +84,11 @@ private extension DynamicCell {
 		.exposureDetectionCell(ReusableCellIdentifer.risk) { viewController, cell, indexPath in
 			let state = viewController.state
 			cell.backgroundColor = state.riskTintColor
-			cell.tintColor = state.isTracingEnabled ? .enaColor(for: .textContrast) : .enaColor(for: .riskNeutral)
+
+			var tintColor: UIColor = state.isTracingEnabled ? .enaColor(for: .textContrast) : .enaColor(for: .riskNeutral)
+			if state.riskLevel == .unknownOutdated { tintColor = .enaColor(for: .riskNeutral) }
+			cell.tintColor = tintColor
+
 			cell.textLabel?.textColor = state.riskContrastColor
 			if let cell = cell as? ExposureDetectionRiskCell {
 				cell.separatorView.isHidden = (indexPath.row == 0) || !hasSeparator


### PR DESCRIPTION
This PR fixes the tint color for unknown outdated risk level as well as the time pill.

|Before|After|
|:--|:--|
|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84678640-8bfb1380-af30-11ea-8500-faa4ea9bd963.png">|<img width="768" alt="image" src="https://user-images.githubusercontent.com/64848654/84679061-18a5d180-af31-11ea-9a1d-11d635b4af37.png">|
