### PR TITLE
Fix: Privacy protection window never shown

### DIFF
--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -89,7 +89,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
 	}
 
-	func sceneDidEnterBackground(_ scene: UIScene) {
+	func sceneWillResignActive(_ scene: UIScene) {
 		showPrivacyProtectionWindow()
 		taskScheduler.scheduleTasks()
 	}


### PR DESCRIPTION
### Description
Now when you open the app switcher from the app directly the protection view does not get triggered due to focus. It would be more nice if we call it when the scene will resign active instead of only when entering the background state. For this case we need to change the method to `sceneWillResignActive` and the privacy protection window gets called immediately when entering the app switcher mode.


