### PR TITLE
[Technical] Marked the "not implemented" initializers as "unavailable" (closes #681)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMConfigurationViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMConfigurationViewController.swift
@@ -31,6 +31,7 @@ final class DMConfigurationViewController: UITableViewController, RequiresAppDep
 		title = "⚙️ Configuration"
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}
@@ -131,6 +132,7 @@ private class DMConfigurationCell: UITableViewCell {
 		super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeScanViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeScanViewController.swift
@@ -36,6 +36,7 @@ final class DMQRCodeScanViewController: UIViewController {
 		super.init(nibName: nil, bundle: nil)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}
@@ -109,6 +110,7 @@ private final class DMQRCodeScanView: UIView {
 		videoPreviewLayer.session = captureSession
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMQRCodeViewController.swift
@@ -28,6 +28,7 @@ final class DMQRCodeViewController: UIViewController {
 		super.init(nibName: nil, bundle: nil)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMSubmissionStateViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMSubmissionStateViewController.swift
@@ -38,6 +38,7 @@ final class DMSubmissionStateViewController: UITableViewController {
 		super.init(style: .plain)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
@@ -36,6 +36,7 @@ final class DMViewController: UITableViewController {
 		title = "👩🏾‍💻🧑‍💻"
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}
@@ -261,6 +262,7 @@ private class KeyCell: UITableViewCell {
 		super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationLegalCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationLegalCell.swift
@@ -25,6 +25,7 @@ class AppInformationLegalCell: UITableViewCell {
 	var licensorLabel = ENALabel()
 	var licenseLabel = ENALabel()
 
+	@available(*, unavailable)
 	required init?(coder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewHeaderImageView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewHeaderImageView.swift
@@ -32,6 +32,7 @@ class DynamicTableViewHeaderImageView: UITableViewHeaderFooterView {
 		get { heightConstraint.constant }
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewHeaderSeparatorView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewHeaderSeparatorView.swift
@@ -32,6 +32,7 @@ class DynamicTableViewHeaderSeparatorView: UITableViewHeaderFooterView {
 		get { heightConstraint.constant }
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -49,6 +49,7 @@ final class ExposureNotificationSettingViewController: UITableViewController {
 		super.init(coder: coder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -50,6 +50,7 @@ final class ExposureDetectionViewController: DynamicTableViewController, Require
 		super.init(coder: coder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has intentionally not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionNavigationController.swift
@@ -101,6 +101,7 @@ final class ExposureSubmissionNavigationController: UINavigationController, UINa
 		self.testResult = testResult
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionOverviewViewController.swift
@@ -35,6 +35,7 @@ class ExposureSubmissionOverviewViewController: DynamicTableViewController, Spin
 		super.init(coder: aDecoder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -48,6 +48,7 @@ final class HomeViewController: UIViewController {
 		addToUpdatingSetIfNeeded(homeInteractor)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has intentionally not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -54,6 +54,7 @@ final class OnboardingInfoViewController: UIViewController {
 		super.init(coder: coder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has intentionally not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettingsViewController.swift
@@ -40,6 +40,7 @@ class NotificationSettingsViewController: UIViewController {
 		super.init(coder: coder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -54,6 +54,7 @@ final class SettingsViewController: UITableViewController {
 		super.init(coder: coder)
 	}
 
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}

--- a/src/xcode/ENA/ENA/Source/Views/Home Screen/Decorations/SectionSystemBackgroundDecorationView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/Home Screen/Decorations/SectionSystemBackgroundDecorationView.swift
@@ -18,6 +18,7 @@
 import UIKit
 
 class SectionSystemBackgroundDecorationView: UICollectionReusableView {
+	@available(*, unavailable)
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}


### PR DESCRIPTION
This PR addresses the issue described in #681 .

## Description

When providing a custom initializer for subclasses of (mostly) UIKit
classes conforming to 'NSCoding' the required initializer must be
provided by those subclasses.

Most of them will never be used and stay with the auto suggestion
of Xcode causing a `fatalError`:

```swift
required init?(coder: NSCoder) {
    fatalError("init(coder:) has not been implemented")
}
```

As this should never be called, I marked those initializers
with `available(*, unavailable)`. Calling those initializers
will now fail at compile time instead of causing a
runtime crash.

Additionally, it will stop Xcode suggesting those initializers
as code completions.

<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->
