### PR TITLE
[Technical] Added '@discardableResult' attribute to 'ENATanInput' (closes #696)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
@@ -117,11 +117,13 @@ extension ENATanInput {
 }
 
 extension ENATanInput {
+	@discardableResult
 	override func becomeFirstResponder() -> Bool {
 		delegate?.enaTanInputDidBeginEditing?(self)
 		return super.becomeFirstResponder()
 	}
 
+	@discardableResult
 	override func resignFirstResponder() -> Bool {
 		delegate?.enaTanInputDidEndEditing?(self)
 		return super.resignFirstResponder()


### PR DESCRIPTION
This PR addresses the issue described in #696  .

This removes the Swift compiler warning when calling the `becomeFirstResponder` and `resignFirstResponder` methods of the `ENATanInput` class.