### PR TITLE
Change "Mundschutz" to "Mund-Nasen-Bedeckung"

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -61,7 +61,7 @@
 
 "ExposureDetection_Guide_Hands" = "Waschen Sie Ihre Hände regelmäßig.";
 
-"ExposureDetection_Guide_Mask" = "Tragen Sie einen Mundschutz bei Begegnungen mit anderen Personen.";
+"ExposureDetection_Guide_Mask" = "Tragen Sie eine Mund-Nasen-Bedeckung bei Begegnungen mit anderen Personen.";
 
 "ExposureDetection_Guide_Distance" = "Halten Sie mindestens 1,5 Meter Abstand zu anderen Personen.";
 


### PR DESCRIPTION
This pull-request changes the translation for "Mundschutz" to "Mund-Nasen-Bedeckung" this is because "Mundschutz" is confusing many people and they wear it only on their mouth instead of the mount and nose. It is also the term used from RKI:
https://www.rki.de/SharedDocs/FAQ/NCOV2019/FAQ_Mund_Nasen_Schutz.html

<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->
