### PR TITLE
[Bug] Disable iTunes file sharing for the app (closes #700)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Info.plist
+++ b/src/xcode/ENA/ENA/Resources/Info.plist
@@ -61,7 +61,7 @@
 		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
-	<true/>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src/xcode/ENA/ENA/Resources/Info_Debug.plist
+++ b/src/xcode/ENA/ENA/Resources/Info_Debug.plist
@@ -74,7 +74,7 @@
 		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
-	<false/>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src/xcode/ENA/ENA/Resources/Info_Debug.plist
+++ b/src/xcode/ENA/ENA/Resources/Info_Debug.plist
@@ -74,7 +74,7 @@
 		<string>processing</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
-	<true/>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. See issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues/440)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
This is a small PR disabling the the iTunes file sharing property which caused the packages.sqlite3 file to be exposed. As far as I can tell we can disable this functionality completly. It closes #700  
