### PR TITLE
[Tests] Add ExposureSubmissionService Mock for UI Tests

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -201,7 +201,6 @@
 		A328424E248B91E0006B1F09 /* HomeTestResultLoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328424C248B91E0006B1F09 /* HomeTestResultLoadingCell.swift */; };
 		A3284250248B9269006B1F09 /* HomeTestResultLoadingCellConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328424F248B9269006B1F09 /* HomeTestResultLoadingCellConfigurator.swift */; };
 		A3284255248E493B006B1F09 /* ExposureSubmissionOverviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284254248E493B006B1F09 /* ExposureSubmissionOverviewViewControllerTests.swift */; };
-		A3284257248E7431006B1F09 /* MockExposureSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284256248E7431006B1F09 /* MockExposureSubmissionService.swift */; };
 		A3284259248E7672006B1F09 /* MockExposureSubmissionQRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284258248E7672006B1F09 /* MockExposureSubmissionQRScannerViewController.swift */; };
 		A328425D248E82BC006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328425B248E82B5006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift */; };
 		A328425F248E943D006B1F09 /* ExposureSubmissionTanInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A328425E248E943D006B1F09 /* ExposureSubmissionTanInputViewControllerTests.swift */; };
@@ -213,10 +212,10 @@
 		A3C4F96024812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */; };
 		A3E5E71A247D4FFB00237116 /* ExposureSubmissionViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */; };
 		A3E5E71E247E6F7A00237116 /* SpinnerInjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */; };
-		A3EE6E58249B9D6C00C64B61 /* MockExposureSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284256248E7431006B1F09 /* MockExposureSubmissionService.swift */; };
 		A3EE6E5A249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E59249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift */; };
 		A3EE6E5C249BB97500C64B61 /* UITestingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */; };
 		A3EE6E5D249BB9B900C64B61 /* UITestingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */; };
+		A3EE6E61249BC57F00C64B61 /* MockExposureSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284256248E7431006B1F09 /* MockExposureSubmissionService.swift */; };
 		A3FF84EC247BFAF00053E947 /* Hasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF84EB247BFAF00053E947 /* Hasher.swift */; };
 		B10F9B8B249961BC00C418F4 /* DynamicTypeLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F9B89249961B500C418F4 /* DynamicTypeLabelTests.swift */; };
 		B10F9B8C249961CE00C418F4 /* UIFont+DynamicTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B163D11424993F64001A322C /* UIFont+DynamicTypeTests.swift */; };
@@ -2334,12 +2333,12 @@
 				71B8044D248525CD00D53506 /* RiskLegendViewController+DynamicTableViewModel.swift in Sources */,
 				859DD512248549790073D59F /* MockDiagnosisKeysRetrieval.swift in Sources */,
 				EE22DB89247FB43A001B0A71 /* TracingHistoryTableViewCell.swift in Sources */,
+				A3EE6E61249BC57F00C64B61 /* MockExposureSubmissionService.swift in Sources */,
 				71B804472484CC0800D53506 /* ENALabel.swift in Sources */,
 				71FE1C7F247AC2B500851FEB /* ExposureSubmissionTestResultViewController.swift in Sources */,
 				B1D6B002247DA0320079DDD3 /* ExposureDetectionViewControllerDelegate.swift in Sources */,
 				713EA25B247818B000AB7EE8 /* DynamicTypeButton.swift in Sources */,
 				51C77910248684F5004582F8 /* HomeRiskListItemViewConfigurator.swift in Sources */,
-				A3EE6E58249B9D6C00C64B61 /* MockExposureSubmissionService.swift in Sources */,
 				B1D6B004247DA4920079DDD3 /* UIApplication+CoronaWarn.swift in Sources */,
 				51CE1BC32460B28D002CF42A /* HomeInfoCellConfigurator.swift in Sources */,
 				138910C5247A909000D739F6 /* ENATaskScheduler.swift in Sources */,
@@ -2443,7 +2442,6 @@
 				B15382FE248424F00010F007 /* ExposureDetectionTests.swift in Sources */,
 				CDF27BD3246ADBA70044D32B /* ExposureSubmissionServiceTests.swift in Sources */,
 				A328426324910552006B1F09 /* ExposureSubmissionSuccessViewControllerTests.swift in Sources */,
-				A3284257248E7431006B1F09 /* MockExposureSubmissionService.swift in Sources */,
 				B163D1102499068D001A322C /* SettingsViewModelTests.swift in Sources */,
 				A1E419462495479D0016E52A /* HTTPClient+MockNetworkStack.swift in Sources */,
 				B1CD333E24865E0000B06E9B /* TracingStatusHistoryTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		A3C4F96024812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */; };
 		A3E5E71A247D4FFB00237116 /* ExposureSubmissionViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */; };
 		A3E5E71E247E6F7A00237116 /* SpinnerInjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */; };
+		A3EE6E58249B9D6C00C64B61 /* MockExposureSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284256248E7431006B1F09 /* MockExposureSubmissionService.swift */; };
 		A3FF84EC247BFAF00053E947 /* Hasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF84EB247BFAF00053E947 /* Hasher.swift */; };
 		B10F9B8B249961BC00C418F4 /* DynamicTypeLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F9B89249961B500C418F4 /* DynamicTypeLabelTests.swift */; };
 		B10F9B8C249961CE00C418F4 /* UIFont+DynamicTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B163D11424993F64001A322C /* UIFont+DynamicTypeTests.swift */; };
@@ -2319,6 +2320,7 @@
 				B1D6B002247DA0320079DDD3 /* ExposureDetectionViewControllerDelegate.swift in Sources */,
 				713EA25B247818B000AB7EE8 /* DynamicTypeButton.swift in Sources */,
 				51C77910248684F5004582F8 /* HomeRiskListItemViewConfigurator.swift in Sources */,
+				A3EE6E58249B9D6C00C64B61 /* MockExposureSubmissionService.swift in Sources */,
 				B1D6B004247DA4920079DDD3 /* UIApplication+CoronaWarn.swift in Sources */,
 				51CE1BC32460B28D002CF42A /* HomeInfoCellConfigurator.swift in Sources */,
 				138910C5247A909000D739F6 /* ENATaskScheduler.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -214,6 +214,9 @@
 		A3E5E71A247D4FFB00237116 /* ExposureSubmissionViewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */; };
 		A3E5E71E247E6F7A00237116 /* SpinnerInjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */; };
 		A3EE6E58249B9D6C00C64B61 /* MockExposureSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3284256248E7431006B1F09 /* MockExposureSubmissionService.swift */; };
+		A3EE6E5A249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E59249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift */; };
+		A3EE6E5C249BB97500C64B61 /* UITestingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */; };
+		A3EE6E5D249BB9B900C64B61 /* UITestingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */; };
 		A3FF84EC247BFAF00053E947 /* Hasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF84EB247BFAF00053E947 /* Hasher.swift */; };
 		B10F9B8B249961BC00C418F4 /* DynamicTypeLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F9B89249961B500C418F4 /* DynamicTypeLabelTests.swift */; };
 		B10F9B8C249961CE00C418F4 /* UIFont+DynamicTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B163D11424993F64001A322C /* UIFont+DynamicTypeTests.swift */; };
@@ -608,6 +611,8 @@
 		A3C4F95F24812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionWarnOthersViewController.swift; sourceTree = "<group>"; };
 		A3E5E719247D4FFB00237116 /* ExposureSubmissionViewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionViewUtils.swift; sourceTree = "<group>"; };
 		A3E5E71D247E6F7A00237116 /* SpinnerInjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerInjectable.swift; sourceTree = "<group>"; };
+		A3EE6E59249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionServiceFactory.swift; sourceTree = "<group>"; };
+		A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestingParameters.swift; sourceTree = "<group>"; };
 		A3FF84EB247BFAF00053E947 /* Hasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hasher.swift; sourceTree = "<group>"; };
 		B102BDC22460410600CD55A2 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B10F9B89249961B500C418F4 /* DynamicTypeLabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicTypeLabelTests.swift; sourceTree = "<group>"; };
@@ -1290,6 +1295,7 @@
 				13E5046A248E3CE60086641C /* AppInformation */,
 				85D7596324570491008175F0 /* ENAUITests.swift */,
 				134F0F2B2475793400D88934 /* SnapshotHelper.swift */,
+				A3EE6E5B249BB97500C64B61 /* UITestingParameters.swift */,
 				85D7596524570491008175F0 /* Info.plist */,
 			);
 			path = ENAUITests;
@@ -1366,6 +1372,7 @@
 				B14D0CD8246E939600D5BEBC /* Exposure Transaction */,
 				B1D431C9246C848E00E728AD /* DownloadedPackagesStore */,
 				CD99A3A8245C272400BF12AF /* ExposureSubmissionService.swift */,
+				A3EE6E59249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2250,6 +2257,7 @@
 				A3C4F96024812CD20047F23E /* ExposureSubmissionWarnOthersViewController.swift in Sources */,
 				B1741B582462EBDB006275D9 /* HomeViewController.swift in Sources */,
 				3DD767462483D4DE002DD2B3 /* ReachabilityService.swift in Sources */,
+				A3EE6E5A249BB7AF00C64B61 /* ExposureSubmissionServiceFactory.swift in Sources */,
 				4026C2E424854C8D00926FB4 /* AppInformationLegalCell.swift in Sources */,
 				51C737BF245B3B5D00286105 /* OnboardingInfo.swift in Sources */,
 				B1FE13EB24891CFA00D012E5 /* RiskProvider.swift in Sources */,
@@ -2278,6 +2286,7 @@
 				514C0A0F247AFEC500F235F6 /* HomeRiskTextItemViewConfigurator.swift in Sources */,
 				A3284250248B9269006B1F09 /* HomeTestResultLoadingCellConfigurator.swift in Sources */,
 				713EA25D24798A7000AB7EE8 /* ExposureDetectionRoundedView.swift in Sources */,
+				A3EE6E5D249BB9B900C64B61 /* UITestingParameters.swift in Sources */,
 				710224F42490E7A3000C5DEF /* ExposureSubmissionStepCell.swift in Sources */,
 				B19FD7132491A08500A9D56A /* SAP_SemanticVersion+Compare.swift in Sources */,
 				3DD7674B2483D6C1002DD2B3 /* ConnectivityReachabilityService.swift in Sources */,
@@ -2465,6 +2474,7 @@
 				13E50469248E3CD20086641C /* ENAUITestsAppInformation.swift in Sources */,
 				130CB19C246D92F800ADE602 /* ENAUITestsOnboarding.swift in Sources */,
 				13E5046B248E3DF30086641C /* AppStrings.swift in Sources */,
+				A3EE6E5C249BB97500C64B61 /* UITestingParameters.swift in Sources */,
 				134F0F2C2475793400D88934 /* SnapshotHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
@@ -114,11 +114,61 @@ class ExposureSubmissionUITests: XCTestCase {
 		app.alerts.buttons.firstMatch.tap()
 
 	}
+
+	func test_SubmitTAN() {
+
+		// Setup service mocks.
+		app.launchArguments += ["UI:ExposureSubmission:getRegistrationTokenSuccess"]
+		app.launchArguments += ["UI:ExposureSubmission:submitExposureSuccess"]
+		launch()
+
+		// Open Intro screen.
+		XCTAssert(app.collectionViews.buttons["AppStrings.Home.submitCardButton"].waitForExistence(timeout: .long))
+		app.collectionViews.buttons["AppStrings.Home.submitCardButton"].tap()
+
+		// Click next button.
+		XCTAssertNotNil(app.buttons["AppStrings.ExposureSubmission.continueText"].waitForExistence(timeout: .medium))
+		app.buttons["AppStrings.ExposureSubmission.continueText"].tap()
+
+		// Click TAN button.
+		XCTAssert(app
+			.buttons["AppStrings.ExposureSubmissionDispatch.tanButtonDescription"]
+			.waitForExistence(timeout: .medium)
+		)
+		app.buttons["AppStrings.ExposureSubmissionDispatch.tanButtonDescription"].tap()
+
+		// Fill in dummy TAN.
+		XCTAssert(app.buttons["AppStrings.ExposureSubmission.continueText"].waitForExistence(timeout: .medium))
+		type(app, text: "qwdzxcsrhe")
+
+		// Click continue button.
+		XCTAssert(app.buttons["AppStrings.ExposureSubmission.continueText"].isEnabled)
+		app.buttons["AppStrings.ExposureSubmission.continueText"].tap()
+
+		// TAN tests are ALWAYS positive!
+
+		// Click next.
+		XCTAssert(app.buttons["AppStrings.ExposureSubmission.continueText"].waitForExistence(timeout: .medium))
+		app.buttons["AppStrings.ExposureSubmission.continueText"].tap()
+
+		// Click next to warn others.
+		XCTAssert(app.buttons["AppStrings.ExposureSubmission.continueText"].waitForExistence(timeout: .medium))
+		app.buttons["AppStrings.ExposureSubmission.continueText"].tap()
+
+		XCTAssert(app.navigationBars["ENA.ExposureSubmissionSuccessView"].waitForExistence(timeout: .medium))
+
+	}
 }
 
 // MARK: - Helpers.
 
 extension ExposureSubmissionUITests {
+
+	private func type(_ app: XCUIApplication, text: String) {
+		text.forEach {
+			app.keys[String($0)].tap()
+		}
+	}
 
 	/// Launch and wait until the app is ready.
 	private func launch() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
@@ -118,8 +118,9 @@ class ExposureSubmissionUITests: XCTestCase {
 	func test_SubmitTAN() {
 
 		// Setup service mocks.
-		app.launchArguments += ["UI:ExposureSubmission:getRegistrationTokenSuccess"]
-		app.launchArguments += ["UI:ExposureSubmission:submitExposureSuccess"]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.useMock.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.getRegistrationTokenSuccess.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.submitExposureSuccess.rawValue]
 		launch()
 
 		// Open Intro screen.

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
@@ -18,7 +18,6 @@
 //
 
 import Foundation
-@testable import ENA
 
 class MockExposureSubmissionService: ExposureSubmissionService {
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -50,7 +50,7 @@ final class HomeInteractor: RequiresAppDependencies {
 
 	private unowned var homeViewController: HomeViewController
 	lazy var exposureSubmissionService: ExposureSubmissionService = {
-		ENAExposureSubmissionService(
+		ExposureSubmissionServiceFactory.create(
 			diagnosiskeyRetrieval: self.exposureManager,
 			client: self.client,
 			store: self.store

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
@@ -30,51 +30,6 @@ enum TestResult: Int {
 	case invalid = 3
 }
 
-// TODO: Move to file.
-// TODO: Introduce UITestingParameters enum?
-class ExposureSubmissionServiceFactory { }
-
-#if UITESTING
-
-extension ExposureSubmissionServiceFactory {
-	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
-		let service = MockExposureSubmissionService()
-
-		if ProcessInfo.processInfo.arguments.contains("UI:ExposureSubmission:getRegistrationTokenSuccess") {
-			service.getRegistrationTokenCallback = { _, completeWith in
-				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-					completeWith(.success("dummyRegToken"))
-				}
-			}
-		}
-
-		if ProcessInfo.processInfo.arguments.contains("UI:ExposureSubmission:submitExposureSuccess") {
-			service.submitExposureCallback = { completeWith in
-				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-					completeWith(nil)
-				}
-			}
-		}
-
-		return service
-	}
-}
-
-#else
-
-extension ExposureSubmissionServiceFactory {
-	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
-
-		return ENAExposureSubmissionService(
-			diagnosiskeyRetrieval: diagnosiskeyRetrieval,
-			client: client,
-			store: store
-		)
-	}
-}
-
-#endif
-
 protocol ExposureSubmissionService {
 	typealias ExposureSubmissionHandler = (_ error: ExposureSubmissionError?) -> Void
 	typealias RegistrationHandler = (Result<String, ExposureSubmissionError>) -> Void

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
@@ -30,6 +30,51 @@ enum TestResult: Int {
 	case invalid = 3
 }
 
+// TODO: Move to file.
+// TODO: Introduce UITestingParameters enum?
+class ExposureSubmissionServiceFactory { }
+
+#if UITESTING
+
+extension ExposureSubmissionServiceFactory {
+	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
+		let service = MockExposureSubmissionService()
+
+		if ProcessInfo.processInfo.arguments.contains("UI:ExposureSubmission:getRegistrationTokenSuccess") {
+			service.getRegistrationTokenCallback = { _, completeWith in
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+					completeWith(.success("dummyRegToken"))
+				}
+			}
+		}
+
+		if ProcessInfo.processInfo.arguments.contains("UI:ExposureSubmission:submitExposureSuccess") {
+			service.submitExposureCallback = { completeWith in
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+					completeWith(nil)
+				}
+			}
+		}
+
+		return service
+	}
+}
+
+#else
+
+extension ExposureSubmissionServiceFactory {
+	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
+
+		return ENAExposureSubmissionService(
+			diagnosiskeyRetrieval: diagnosiskeyRetrieval,
+			client: client,
+			store: store
+		)
+	}
+}
+
+#endif
+
 protocol ExposureSubmissionService {
 	typealias ExposureSubmissionHandler = (_ error: ExposureSubmissionError?) -> Void
 	typealias RegistrationHandler = (Result<String, ExposureSubmissionError>) -> Void

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionServiceFactory.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionServiceFactory.swift
@@ -1,0 +1,83 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+
+/// Service factory that can be used to create an instance of the ExposureSubmissionService.
+class ExposureSubmissionServiceFactory { }
+
+// MARK: Default implementation.
+#if !UITESTING
+
+extension ExposureSubmissionServiceFactory {
+	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
+		return ENAExposureSubmissionService(
+			diagnosiskeyRetrieval: diagnosiskeyRetrieval,
+			client: client,
+			store: store
+		)
+	}
+}
+
+#endif
+
+// MARK: UI Testing implementation.
+#if UITESTING
+
+/// This extension will return a mock service if and only if the .useMock parameter is passed to the application.
+/// If the parameter is _not_ provided, the factory will instantiate a regular ENAExposureSubmissionService.
+/// - NOTE: This is condtionally compiled so no test code spills into the release build.
+extension ExposureSubmissionServiceFactory {
+	static func create(diagnosiskeyRetrieval: DiagnosisKeysRetrieval, client: Client, store: Store) -> ExposureSubmissionService {
+
+		guard isEnabled(.useMock) else {
+			return ENAExposureSubmissionService(
+				diagnosiskeyRetrieval: diagnosiskeyRetrieval,
+				client: client,
+				store: store
+			)
+		}
+
+		let service = MockExposureSubmissionService()
+
+		if isEnabled(.getRegistrationTokenSuccess) {
+			service.getRegistrationTokenCallback = { _, completeWith in
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+					completeWith(.success("dummyRegToken"))
+				}
+			}
+		}
+
+		if isEnabled(.submitExposureSuccess) {
+			service.submitExposureCallback = { completeWith in
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+					completeWith(nil)
+				}
+			}
+		}
+
+		return service
+	}
+
+	private static func isEnabled(_ parameter: UITestingParameters.ExposureSubmission) -> Bool {
+		return ProcessInfo.processInfo.arguments.contains(parameter.rawValue)
+	}
+}
+
+#endif

--- a/src/xcode/ENA/ENAUITests/UITestingParameters.swift
+++ b/src/xcode/ENA/ENAUITests/UITestingParameters.swift
@@ -1,0 +1,28 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+
+enum UITestingParameters {
+	enum ExposureSubmission: String {
+		case useMock = "UI:ExposureSubmission:useMock"
+		case getRegistrationTokenSuccess = "UI:ExposureSubmission:getRegistrationTokenSuccess"
+		case submitExposureSuccess = "UI:ExposureSubmission:submitExposureSuccess"
+	}
+}


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

This PR introduces the integration of an exposure submission mock object for UI testing and a sample UI test that uses the newly integrated mock.

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. See issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues/440)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
