### PR TITLE
[Bug] Fix onboarding check for UITests

### DIFF
--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -63,6 +63,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 		let window = UIWindow(windowScene: windowScene)
 		self.window = window
 
+		#if UITESTING
+		if let isOnboarded = UserDefaults.standard.value(forKey: "isOnboarded") as? String {
+			store.isOnboarded = (isOnboarded != "NO")
+		}
+		#endif
+
 		exposureManager.resume(observer: self)
 
 		riskConsumer.didCalculateRisk = { [weak self] risk in
@@ -109,20 +115,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 	private func setupUI() {
 		setupNavigationBarAppearance()
 
-		#if UITESTING
-		// Present initial screen
-		if UserDefaults.standard.value(forKey: "isOnboarded") as? String == "NO" {
-			showOnboarding()
-		} else {
-			showHome()
-		}
-		#else
 		if !store.isOnboarded {
 			showOnboarding()
 		} else {
 			showHome()
 		}
-		#endif
 		UIImageView.appearance().accessibilityIgnoresInvertColors = true
 		window?.rootViewController = navigationController
 		window?.makeKeyAndVisible()


### PR DESCRIPTION
Moved test for isOnboarded to func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions), setting the store.isOnboarded value to the UserDefaults value passed through from the UITest