### PR TITLE
Fixed number of active days

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
@@ -91,7 +91,7 @@ extension Array where Element == TracingStatusEntry {
 	///
 	/// - parameter since: Date to use as the baseline. Defaults to `Date()`
 	func countEnabledDays(since date: Date = Date()) -> Int {
-		Int(getContinuousEnabledInterval(since: date) / (60 * 60 * 24))
+		Int(Double(getContinuousEnabledInterval(since: date) / (60 * 60 * 24)).rounded(.up))
 	}
 
 	/// Mark returns the count of hours that tracing has been enabled

--- a/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/TracingStatusHistory.swift
@@ -91,7 +91,10 @@ extension Array where Element == TracingStatusEntry {
 	///
 	/// - parameter since: Date to use as the baseline. Defaults to `Date()`
 	func countEnabledDays(since date: Date = Date()) -> Int {
-		Int(Double(getContinuousEnabledInterval(since: date) / (60 * 60 * 24)).rounded(.up))
+		// 5.5 days => 6 days
+		// 0.5 days => 1 day
+		// 13.99999 days => 14 days
+		Int(Double(getContinuousEnabledInterval(since: date) / (60 * 60 * 24)).rounded(.toNearestOrAwayFromZero))
 	}
 
 	/// Mark returns the count of hours that tracing has been enabled

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/TracingStatusHistoryTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/TracingStatusHistoryTests.swift
@@ -280,6 +280,26 @@ final class TracingStatusHistoryTests: XCTestCase {
 		XCTAssertEqual(history.countEnabledHours(since: now), 24 * 2)
 		XCTAssertEqual(history.countEnabledDays(since: now), 2)
 	}
+
+	func testNumberOfDays_Rounding() {
+		let now = Date()
+
+		var history: TracingStatusHistory = [
+			.init(on: true, date: now.addingTimeInterval(.init(hours: -((24 * 5) + 4))))
+		]
+
+		XCTAssertEqual(history.countEnabledDays(since: now), 5)
+
+		history = [
+			.init(on: true, date: now.addingTimeInterval(.init(hours: -((24 * 5) + 13))))
+		]
+		XCTAssertEqual(history.countEnabledDays(since: now), 6)
+
+		history = [
+			.init(on: true, date: now.addingTimeInterval(.init(hours: -((24 * 5) + 0))))
+		]
+		XCTAssertEqual(history.countEnabledDays(since: now), 5)
+	}
 }
 
 private extension TimeInterval {

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/TracingStatusHistoryTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/TracingStatusHistoryTests.swift
@@ -225,7 +225,7 @@ final class TracingStatusHistoryTests: XCTestCase {
 		history = history.consumingState(badState, now.addingTimeInterval(.init(hours: -1)))	// active for 23 hours
 
 		XCTAssertEqual(history.countEnabledHours(since: now), 24 * 4 + 23)
-		XCTAssertEqual(history.countEnabledDays(since: now), 4)
+		XCTAssertEqual(history.countEnabledDays(since: now), 5)
 	}
 
 	func testGetEnabledInterval_Accumulator_Good() {


### PR DESCRIPTION

## Testing

You can test this by:

- installing the app
- go through the onboarding (yes/yes)
- go 15 days into the future
- the app should display 14/14
- disable tracing for a few second within the app
- the app should still display 14/4

1 | 2 | 3
:-------------------------:|:-------------------------:|--------------------:
| ![IMG_0100](https://user-images.githubusercontent.com/153225/86472181-0ef8d800-bd3f-11ea-966b-f18fa8686713.jpeg) | ![IMG_0101](https://user-images.githubusercontent.com/153225/86472184-0f916e80-bd3f-11ea-90e0-24f1844d4df3.jpeg)  | ![IMG_0102](https://user-images.githubusercontent.com/153225/86472185-102a0500-bd3f-11ea-925c-3fca4994f6a3.jpeg) |
