### PR TITLE
Risk Calculation Errors - Alert Refinement

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		2F80CFDB247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F80CFDA247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift */; };
 		2F96739B24AB70FA008E3147 /* ExposureSubmissionParsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F96739A24AB70FA008E3147 /* ExposureSubmissionParsable.swift */; };
 		2FC0356F24B342FA00E234AC /* UIViewcontroller+AlertTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC0356E24B342FA00E234AC /* UIViewcontroller+AlertTest.swift */; };
+		2FC0357124B5B70700E234AC /* Error+FAQUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC0357024B5B70700E234AC /* Error+FAQUrl.swift */; };
 		2FD881CC2490F65C00BEC8FC /* ExposureSubmissionHotlineViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD881CB2490F65C00BEC8FC /* ExposureSubmissionHotlineViewControllerTest.swift */; };
 		2FD881CE249115E700BEC8FC /* ExposureSubmissionNavigationControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD881CD249115E700BEC8FC /* ExposureSubmissionNavigationControllerTest.swift */; };
 		2FE15A3C249B8C0B0077BD8D /* AccessibilityIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE15A3B249B8C0B0077BD8D /* AccessibilityIdentifiers.swift */; };
@@ -435,6 +436,7 @@
 		2F80CFDA247EDDB3000F06AF /* ExposureSubmissionHotlineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionHotlineViewController.swift; sourceTree = "<group>"; };
 		2F96739A24AB70FA008E3147 /* ExposureSubmissionParsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionParsable.swift; sourceTree = "<group>"; };
 		2FC0356E24B342FA00E234AC /* UIViewcontroller+AlertTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewcontroller+AlertTest.swift"; sourceTree = "<group>"; };
+		2FC0357024B5B70700E234AC /* Error+FAQUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+FAQUrl.swift"; sourceTree = "<group>"; };
 		2FD881CB2490F65C00BEC8FC /* ExposureSubmissionHotlineViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionHotlineViewControllerTest.swift; sourceTree = "<group>"; };
 		2FD881CD249115E700BEC8FC /* ExposureSubmissionNavigationControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionNavigationControllerTest.swift; sourceTree = "<group>"; };
 		2FE15A3B249B8C0B0077BD8D /* AccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityIdentifiers.swift; sourceTree = "<group>"; };
@@ -1091,6 +1093,7 @@
 				2F26CE2D248B9C4F00BE30EE /* UIViewController+BackButton.swift */,
 				B1C7EE4324938E9E00F1F284 /* ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift */,
 				2F96739A24AB70FA008E3147 /* ExposureSubmissionParsable.swift */,
+				2FC0357024B5B70700E234AC /* Error+FAQUrl.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2257,6 +2260,7 @@
 				011E13AE24680A4000973467 /* HTTPClient.swift in Sources */,
 				853D987A24694A8700490DBA /* ENAButton.swift in Sources */,
 				CD8638532477EBD400A5A07C /* SettingsViewModel.swift in Sources */,
+				2FC0357124B5B70700E234AC /* Error+FAQUrl.swift in Sources */,
 				51CE1BB52460AC83002CF42A /* UICollectionView+Dequeue.swift in Sources */,
 				B17F2D48248CEB4C00CAA38F /* DetectionMode.swift in Sources */,
 				137846492488027600A50AB8 /* OnboardingInfoViewController+Extension.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -19,6 +19,14 @@
 
 "General_BackButtonTitle" = "Zurück";
 
+"Common_ENError5_Description" = "Fehler 5: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Wir arbeiten an einer Lösung für dieses Problem.";
+
+"Common_ENError11_Description" = "Fehler 11: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Bitte starten Sie Ihr Handy neu und versuchen Sie es morgen erneut.";
+
+"Common_ENError13_Description" = "Fehler 13: Ihre Risiko-Ermittlung für den heutigen Tag wurde bereits durchgeführt. Bitte versuchen Sie es in 24 Stunden erneut.";
+
+"Common_Alert_Action_moreInfo" = "Mehr Erfahren";
+
 /* General - Links */
 
 "General_moreInfo_URL" = "https://www.coronawarn.app/de/faq/";
@@ -113,14 +121,6 @@
 "ExposureDetectionError_Alert_Action_Details" = "Details";
 
 "ExposureDetectionError_Alert_Message" = "Während der Risiko-Ermittlung ist ein Fehler aufgetreten.";
-
-"ExposureDetectionError_ENError5_Description" = "Fehler 5: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Wir arbeiten an einer Lösung für dieses Problem.";
-
-"ExposureDetectionError_ENError11_Description" = "Fehler 11: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Bitte starten Sie Ihr Handy neu und versuchen Sie es morgen erneut.";
-
-"ExposureDetectionError_ENError13_Description" = "Fehler 13: Ihre Risiko-Ermittlung für den heutigen Tag wurde bereits durchgeführt. Bitte versuchen Sie es in 24 Stunden erneut.";
-
-"ExposureDetectionError_Alert_Action_moreInfo" = "Mehr Erfahren";
 
 /* Settings */
 "Settings_StatusActive" = "An";
@@ -499,14 +499,6 @@
 "ExposureSubmissionError_unknown" = "Unbekannter Fehler";
 
 "ExposureSubmissionError_defaultError" = "Allgemeiner Exposure Submission Fehler";
-
-"ExposureSubmissionError_unsupported" = "Fehler 5: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Wir arbeiten an einer Lösung für dieses Problem.";
-
-"ExposureSubmissionError_internal" = "Fehler 11: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Mehr Informationen finden Sie in den FAQ.";
-
-"ExposureSubmissionError_rateLimited" = "Fehler 13: Ihre Risiko-Ermittlung für den heutigen Tag wurde bereits durchgeführt. Bitte versuchen Sie es morgen erneut.";
-
-"ExposureSubmissionError_moreInfo" = "Mehr Erfahren";
 
 /* Tracing Enable/Disable Settings */
 "ExposureNotificationSetting_TracingSettingTitle" = "Risiko-Ermittlung";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -19,6 +19,16 @@
 
 "General_BackButtonTitle" = "Zurück";
 
+/* General - Links */
+
+"General_moreInfo_URL" = "https://www.coronawarn.app/de/faq/";
+
+"General_moreInfo_URL_EN5" = "https://www.coronawarn.app/de/faq/#ENError5";
+
+"General_moreInfo_URL_EN11" = "https://www.coronawarn.app/de/faq/#ENError11";
+
+"General_moreInfo_URL_EN13" = "https://www.coronawarn.app/de/faq/#ENError13";
+
 /* Accessibility */
 "AccessibilityLabel_Close" = "Schließen";
 
@@ -98,11 +108,19 @@
 "ExposureDetection_Button_Refresh" = "Aktualisieren";
 
 /* Exposure Detection Errors */
-"ExposureDetectionError_Alert_Title" = "Etwas ist schiefgelaufen.";
+"ExposureDetectionError_Alert_Title" = "Fehler";
 
 "ExposureDetectionError_Alert_Action_Details" = "Details";
 
 "ExposureDetectionError_Alert_Message" = "Während der Risiko-Ermittlung ist ein Fehler aufgetreten.";
+
+"ExposureDetectionError_ENError5_Description" = "Fehler 5: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Wir arbeiten an einer Lösung für dieses Problem.";
+
+"ExposureDetectionError_ENError11_Description" = "Fehler 11: Es ist etwas schiefgelaufen. Ihr Risiko konnte leider nicht ermittelt werden. Bitte starten Sie Ihr Handy neu und versuchen Sie es morgen erneut.";
+
+"ExposureDetectionError_ENError13_Description" = "Fehler 13: Ihre Risiko-Ermittlung für den heutigen Tag wurde bereits durchgeführt. Bitte versuchen Sie es in 24 Stunden erneut.";
+
+"ExposureDetectionError_Alert_Action_moreInfo" = "Mehr Erfahren";
 
 /* Settings */
 "Settings_StatusActive" = "An";
@@ -489,14 +507,6 @@
 "ExposureSubmissionError_rateLimited" = "Fehler 13: Ihre Risiko-Ermittlung für den heutigen Tag wurde bereits durchgeführt. Bitte versuchen Sie es morgen erneut.";
 
 "ExposureSubmissionError_moreInfo" = "Mehr Erfahren";
-
-"ExposureSubmissionError_moreInfo_URL" = "https://www.coronawarn.app/de/faq/";
-
-"ExposureSubmissionError_moreInfo_URL_EN5" = "https://www.coronawarn.app/de/faq/#ENError5";
-
-"ExposureSubmissionError_moreInfo_URL_EN11" = "https://www.coronawarn.app/de/faq/#ENError11";
-
-"ExposureSubmissionError_moreInfo_URL_EN13" = "https://www.coronawarn.app/de/faq/#ENError13";
 
 /* Tracing Enable/Disable Settings */
 "ExposureNotificationSetting_TracingSettingTitle" = "Risiko-Ermittlung";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -19,6 +19,16 @@
 
 "General_BackButtonTitle" = "Back";
 
+/* General - Links */
+
+"General_moreInfo_URL" = "https://www.coronawarn.app/de/faq/";
+
+"General_moreInfo_URL_EN5" = "https://www.coronawarn.app/de/faq/#ENError5";
+
+"General_moreInfo_URL_EN11" = "https://www.coronawarn.app/de/faq/#ENError11";
+
+"General_moreInfo_URL_EN13" = "https://www.coronawarn.app/de/faq/#ENError13";
+
 /* Accessibility */
 "AccessibilityLabel_Close" = "Close";
 
@@ -98,11 +108,19 @@
 "ExposureDetection_Button_Refresh" = "Update";
 
 /* Exposure Detection Errors */
-"ExposureDetectionError_Alert_Title" = "Something went wrong.";
+"ExposureDetectionError_Alert_Title" = "Error";
 
 "ExposureDetectionError_Alert_Action_Details" = "Details";
 
 "ExposureDetectionError_Alert_Message" = "An error occurred during exposure logging.";
+
+"ExposureDetectionError_ENError5_Description" = "Error 5: Something went wrong. Your level of risk cannot be determined. We are working on a solution of the problem.";
+
+"ExposureDetectionError_ENError11_Description" = "Error 11: Something went wrong. Your level of risk cannot be determined. Please restart your device and try again tomorrow.";
+
+"ExposureDetectionError_ENError13_Description" = "Error 13: Your risk calculation for today has already been carried out. Please try again in 24 hours.";
+
+"ExposureDetectionError_Alert_Action_moreInfo" = "Learn more";
 
 /* Settings */
 "Settings_StatusActive" = "On";
@@ -489,14 +507,6 @@
 "ExposureSubmissionError_rateLimited" = "Error 13: Your risk calculation for today has already been carried out. Please try again tomorrow.";
 
 "ExposureSubmissionError_moreInfo" = "Learn more";
-
-"ExposureSubmissionError_moreInfo_URL" = "https://www.coronawarn.app/en/faq/";
-
-"ExposureSubmissionError_moreInfo_URL_EN5" = "https://www.coronawarn.app/en/faq/#ENError5";
-
-"ExposureSubmissionError_moreInfo_URL_EN11" = "https://www.coronawarn.app/en/faq/#ENError11";
-
-"ExposureSubmissionError_moreInfo_URL_EN13" = "https://www.coronawarn.app/en/faq/#ENError13";
 
 /* Tracing Enable/Disable Settings */
 "ExposureNotificationSetting_TracingSettingTitle" = "Exposure Logging";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -19,6 +19,14 @@
 
 "General_BackButtonTitle" = "Back";
 
+"Common_ENError5_Description" = "Error 5: Something went wrong. Your level of risk cannot be determined. We are working on a solution of the problem.";
+
+"Common_ENError11_Description" = "Error 11: Something went wrong. Your level of risk cannot be determined. Please restart your device and try again tomorrow.";
+
+"Common_ENError13_Description" = "Error 13: Your risk calculation for today has already been carried out. Please try again in 24 hours.";
+
+"Common_Alert_Action_moreInfo" = "Learn more";
+
 /* General - Links */
 
 "General_moreInfo_URL" = "https://www.coronawarn.app/de/faq/";
@@ -113,14 +121,6 @@
 "ExposureDetectionError_Alert_Action_Details" = "Details";
 
 "ExposureDetectionError_Alert_Message" = "An error occurred during exposure logging.";
-
-"ExposureDetectionError_ENError5_Description" = "Error 5: Something went wrong. Your level of risk cannot be determined. We are working on a solution of the problem.";
-
-"ExposureDetectionError_ENError11_Description" = "Error 11: Something went wrong. Your level of risk cannot be determined. Please restart your device and try again tomorrow.";
-
-"ExposureDetectionError_ENError13_Description" = "Error 13: Your risk calculation for today has already been carried out. Please try again in 24 hours.";
-
-"ExposureDetectionError_Alert_Action_moreInfo" = "Learn more";
 
 /* Settings */
 "Settings_StatusActive" = "On";
@@ -499,14 +499,6 @@
 "ExposureSubmissionError_unknown" = "Unknown error";
 
 "ExposureSubmissionError_defaultError" = "General exposure submission error";
-
-"ExposureSubmissionError_unsupported" = "​Error 5: Something went wrong. Your level of risk cannot be determined. We are working on a solution of the problem.";
-
-"ExposureSubmissionError_internal" = "Error 11: Something went wrong. Your level of risk cannot be determined. You can find more information in the FAQ.";
-
-"ExposureSubmissionError_rateLimited" = "Error 13: Your risk calculation for today has already been carried out. Please try again tomorrow.";
-
-"ExposureSubmissionError_moreInfo" = "Learn more";
 
 /* Tracing Enable/Disable Settings */
 "ExposureNotificationSetting_TracingSettingTitle" = "Exposure Logging";

--- a/src/xcode/ENA/ENA/Source/Extensions/Error+FAQUrl.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/Error+FAQUrl.swift
@@ -1,0 +1,53 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import Foundation
+import ExposureNotification
+
+// These extensions enable some of the errors in our project to have their corresponding
+// FAQ links.
+
+extension ExposureSubmissionError {
+	/// Returns the correct shortlink based on the underlying EN notification error.
+	var faqURL: URL? {
+		switch self {
+		case .unsupported:
+			return URL(string: AppStrings.Links.appFaqENError5)
+		case .internal:
+			return URL(string: AppStrings.Links.appFaqENError11)
+		case .rateLimited:
+			return URL(string: AppStrings.Links.appFaqENError13)
+		default: return nil
+		}
+	}
+}
+
+extension ENError {
+	var faqURL: URL? {
+		switch code {
+		case .unsupported:
+			return URL(string: AppStrings.Links.appFaqENError5)
+		case .internal:
+			return URL(string: AppStrings.Links.appFaqENError11)
+		case .rateLimited:
+			return URL(string: AppStrings.Links.appFaqENError13)
+		default: return nil
+		}
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Extensions/ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift
@@ -18,22 +18,34 @@
 //
 
 import UIKit
+import ExposureNotification
 
 extension ExposureDetection.DidEndPrematurelyReason {
 	func errorAlertController(rootController: UIViewController) -> UIAlertController? {
 		guard case let ExposureDetection.DidEndPrematurelyReason.noSummary(error) = self else {
 			return nil
 		}
-		guard error != nil else {
+		guard let unwrappedError = error else {
 			return nil
 		}
-		let alert = UIAlertController(
-			title: AppStrings.ExposureDetectionError.errorAlertTitle,
-			message: error?.localizedDescription ?? "",
-			preferredStyle: .alert
-		)
-		let okAction = UIAlertAction(title: AppStrings.Common.alertActionOk, style: .default, handler: nil)
-		alert.addAction(okAction)
-		return alert
+
+		switch unwrappedError {
+		case let unwrappedError as ENError:
+			let openFAQ: (() -> Void)? = {
+				guard let url = unwrappedError.faqURL else { return nil }
+				return {
+					UIApplication.shared.open(url, options: [:])
+				}
+			}()
+			return rootController.setupErrorAlert(
+				message: localizedDescription,
+				secondaryActionTitle: AppStrings.ExposureDetectionError.errorAlertActionMoreInfo,
+				secondaryActionCompletion: openFAQ
+			)
+		default:
+			return rootController.setupErrorAlert(
+				message: localizedDescription
+			)
+		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift
@@ -39,7 +39,7 @@ extension ExposureDetection.DidEndPrematurelyReason {
 			}()
 			return rootController.setupErrorAlert(
 				message: localizedDescription,
-				secondaryActionTitle: AppStrings.ExposureDetectionError.errorAlertActionMoreInfo,
+				secondaryActionTitle: AppStrings.Common.errorAlertActionMoreInfo,
 				secondaryActionCompletion: openFAQ
 			)
 		default:

--- a/src/xcode/ENA/ENA/Source/Extensions/__tests__/ExposureDetection_DidEndPrematurelyReason+ErrorHandlingTests.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/__tests__/ExposureDetection_DidEndPrematurelyReason+ErrorHandlingTests.swift
@@ -42,10 +42,59 @@ final class ExposureDetection_DidEndPrematurelyReason_ErrorHandlingTests: XCTest
 			Reason.noSummary(ENError(.apiMisuse)).errorAlertController(rootController: root)
 		)
 	}
+
+	// MARK: - Special ENError handling tests
 	
 	func testErrorDescription() {
 		XCTAssertTrue(
 			Reason.noSummary(ENError(.apiMisuse)).errorDescription?.contains("EN Code: 10") == true
 		)
+	}
+
+	func testError_ENError_Unsupported() {
+		let root = UIViewController()
+		let alert = Reason.noSummary(ENError(.unsupported)).errorAlertController(rootController: root)
+
+		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
+		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError5Description)
+		XCTAssertEqual(alert?.actions.count, 2)
+		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+	}
+
+	func testError_ENError_Internal() {
+		let root = UIViewController()
+		let alert = Reason.noSummary(ENError(.internal)).errorAlertController(rootController: root)
+
+		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
+		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError11Description)
+		XCTAssertEqual(alert?.actions.count, 2)
+		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+	}
+
+	func testError_ENError_RateLimit() {
+		let root = UIViewController()
+		let alert = Reason.noSummary(ENError(.rateLimited)).errorAlertController(rootController: root)
+
+		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
+		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError13Description)
+		XCTAssertEqual(alert?.actions.count, 2)
+		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+	}
+
+	// MARK: - ENError FAQ URL mapping tests
+
+	func testENError_Unsupported_FAQURL() {
+		XCTAssertEqual(ENError(.unsupported).faqURL, URL(string: AppStrings.Links.appFaqENError5))
+	}
+
+	func testENError_Internal_FAQURL() {
+		XCTAssertEqual(ENError(.internal).faqURL, URL(string: AppStrings.Links.appFaqENError11))
+	}
+
+	func testENError_RateLimited_FAQURL() {
+		XCTAssertEqual(ENError(.rateLimited).faqURL, URL(string: AppStrings.Links.appFaqENError13))
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/__tests__/ExposureDetection_DidEndPrematurelyReason+ErrorHandlingTests.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/__tests__/ExposureDetection_DidEndPrematurelyReason+ErrorHandlingTests.swift
@@ -56,10 +56,10 @@ final class ExposureDetection_DidEndPrematurelyReason_ErrorHandlingTests: XCTest
 		let alert = Reason.noSummary(ENError(.unsupported)).errorAlertController(rootController: root)
 
 		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
-		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError5Description)
+		XCTAssertEqual(alert?.message, AppStrings.Common.enError5Description)
 		XCTAssertEqual(alert?.actions.count, 2)
 		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
-		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.Common.errorAlertActionMoreInfo)
 	}
 
 	func testError_ENError_Internal() {
@@ -67,10 +67,10 @@ final class ExposureDetection_DidEndPrematurelyReason_ErrorHandlingTests: XCTest
 		let alert = Reason.noSummary(ENError(.internal)).errorAlertController(rootController: root)
 
 		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
-		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError11Description)
+		XCTAssertEqual(alert?.message, AppStrings.Common.enError11Description)
 		XCTAssertEqual(alert?.actions.count, 2)
 		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
-		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.Common.errorAlertActionMoreInfo)
 	}
 
 	func testError_ENError_RateLimit() {
@@ -78,10 +78,10 @@ final class ExposureDetection_DidEndPrematurelyReason_ErrorHandlingTests: XCTest
 		let alert = Reason.noSummary(ENError(.rateLimited)).errorAlertController(rootController: root)
 
 		XCTAssertEqual(alert?.title, AppStrings.ExposureDetectionError.errorAlertTitle)
-		XCTAssertEqual(alert?.message, AppStrings.ExposureDetectionError.enError13Description)
+		XCTAssertEqual(alert?.message, AppStrings.Common.enError13Description)
 		XCTAssertEqual(alert?.actions.count, 2)
 		XCTAssertEqual(alert?.actions[0].title, AppStrings.Common.alertActionOk)
-		XCTAssertEqual(alert?.actions[1].title, AppStrings.ExposureDetectionError.errorAlertActionMoreInfo)
+		XCTAssertEqual(alert?.actions[1].title, AppStrings.Common.errorAlertActionMoreInfo)
 	}
 
 	// MARK: - ENError FAQ URL mapping tests

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionWarnOthersViewController.swift
@@ -103,9 +103,9 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, EN
 	func createENAlert(_ error: ExposureSubmissionError) -> UIAlertController {
 		return self.setupErrorAlert(
 			message: error.localizedDescription,
-			secondaryActionTitle: AppStrings.ExposureSubmissionError.moreInfo,
+			secondaryActionTitle: AppStrings.Common.errorAlertActionMoreInfo,
 			secondaryActionCompletion: {
-				guard let url = self.getURL(for: error) else {
+				guard let url = error.faqURL else {
 					logError(message: "Unable to open FAQ page.", level: .error)
 					return
 				}
@@ -116,23 +116,6 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, EN
 				)
 		 })
 	}
-
-	/// Returns the correct shortlink based on the EN notification error.
-	func getURL(for error: ExposureSubmissionError) -> URL? {
-		switch error {
-		case .internal:
-			return URL(string: AppStrings.ExposureSubmissionError.moreInfoURLEN11)
-		case .unsupported:
-			return URL(string: AppStrings.ExposureSubmissionError.moreInfoURLEN5)
-		case .rateLimited:
-			return URL(string: AppStrings.ExposureSubmissionError.moreInfoURLEN13)
-		default:
-			// This case should not be hit, as we made sure we're only getting
-			// EN-related errors in the method calling this one.
-			return nil
-		}
-	}
-
 }
 
 // MARK: ENANavigationControllerWithFooterChild methods.

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionWarnOthersViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionWarnOthersViewControllerTests.swift
@@ -59,8 +59,8 @@ class ExposureSubmissionWarnOthersViewControllerTests: XCTestCase {
 
 		let alert = vc.createENAlert(.internal)
 		XCTAssert(alert.actions.count == 2)
-		XCTAssert(alert.actions[1].title == AppStrings.ExposureSubmissionError.moreInfo)
-		XCTAssert(alert.message == AppStrings.ExposureSubmissionError.internal)
+		XCTAssert(alert.actions[1].title == AppStrings.Common.errorAlertActionMoreInfo)
+		XCTAssert(alert.message == AppStrings.Common.enError11Description)
 	}
 
 	func testShowENErrorAlertUnsupported() {
@@ -69,8 +69,8 @@ class ExposureSubmissionWarnOthersViewControllerTests: XCTestCase {
 
 		let alert = vc.createENAlert(.unsupported)
 		XCTAssert(alert.actions.count == 2)
-		XCTAssert(alert.actions[1].title == AppStrings.ExposureSubmissionError.moreInfo)
-		XCTAssert(alert.message == AppStrings.ExposureSubmissionError.unsupported)
+		XCTAssert(alert.actions[1].title == AppStrings.Common.errorAlertActionMoreInfo)
+		XCTAssert(alert.message == AppStrings.Common.enError5Description)
 	}
 
 	func testShowENErrorAlertRateLimited() {
@@ -79,29 +79,23 @@ class ExposureSubmissionWarnOthersViewControllerTests: XCTestCase {
 
 		let alert = vc.createENAlert(.rateLimited)
 		XCTAssert(alert.actions.count == 2)
-		XCTAssert(alert.actions[1].title == AppStrings.ExposureSubmissionError.moreInfo)
-		XCTAssert(alert.message == AppStrings.ExposureSubmissionError.rateLimited)
+		XCTAssert(alert.actions[1].title == AppStrings.Common.errorAlertActionMoreInfo)
+		XCTAssert(alert.message == AppStrings.Common.enError13Description)
 	}
 
 	func testGetURLInternal() {
-		let vc = createVC()
-
-		let url = vc.getURL(for: .internal)
-		XCTAssert(url?.absoluteString == AppStrings.ExposureSubmissionError.moreInfoURLEN11)
+		let url = ExposureSubmissionError.internal.faqURL
+		XCTAssert(url?.absoluteString == AppStrings.Links.appFaqENError11)
 	}
 
 	func testGetURLUnsupported() {
-		let vc = createVC()
-
-		let url = vc.getURL(for: .unsupported)
-		XCTAssert(url?.absoluteString == AppStrings.ExposureSubmissionError.moreInfoURLEN5)
+		let url = ExposureSubmissionError.unsupported.faqURL
+		XCTAssert(url?.absoluteString == AppStrings.Links.appFaqENError5)
 	}
 
 	func testGetURLRateLimited() {
-		let vc = createVC()
-
-		let url = vc.getURL(for: .rateLimited)
-		XCTAssert(url?.absoluteString == AppStrings.ExposureSubmissionError.moreInfoURLEN13)
+		let url = ExposureSubmissionError.rateLimited.faqURL
+		XCTAssert(url?.absoluteString == AppStrings.Links.appFaqENError13)
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
@@ -47,11 +47,11 @@ extension ExposureDetection.DidEndPrematurelyReason: LocalizedError {
 			}
 			switch enError.code {
 			case .unsupported:
-				return AppStrings.ExposureDetectionError.enError5Description
+				return AppStrings.Common.enError5Description
 			case .internal:
-				return AppStrings.ExposureDetectionError.enError11Description
+				return AppStrings.Common.enError11Description
 			case .rateLimited:
-				return AppStrings.ExposureDetectionError.enError13Description
+				return AppStrings.Common.enError13Description
 			default:
 				return AppStrings.ExposureDetectionError.errorAlertMessage + " EN Code: \(enError.code.rawValue)"
 			}
@@ -59,20 +59,6 @@ extension ExposureDetection.DidEndPrematurelyReason: LocalizedError {
 			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoDaysAndHours"
 		case .noExposureConfiguration:
 			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoExposureConfiguration"
-		}
-	}
-}
-
-extension ENError {
-	var faqURL: URL? {
-		switch code {
-		case .unsupported:
-			return URL(string: AppStrings.Links.appFaqENError5)
-		case .internal:
-			return URL(string: AppStrings.Links.appFaqENError11)
-		case .rateLimited:
-			return URL(string: AppStrings.Links.appFaqENError13)
-		default: return nil
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionTransaction+DidEndPrematurelyReason.swift
@@ -45,11 +45,34 @@ extension ExposureDetection.DidEndPrematurelyReason: LocalizedError {
 			guard let enError = error as? ENError else {
 				return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoSummary"
 			}
-			return AppStrings.ExposureDetectionError.errorAlertMessage + " EN Code: \(enError.code.rawValue)"
+			switch enError.code {
+			case .unsupported:
+				return AppStrings.ExposureDetectionError.enError5Description
+			case .internal:
+				return AppStrings.ExposureDetectionError.enError11Description
+			case .rateLimited:
+				return AppStrings.ExposureDetectionError.enError13Description
+			default:
+				return AppStrings.ExposureDetectionError.errorAlertMessage + " EN Code: \(enError.code.rawValue)"
+			}
 		case .noDaysAndHours:
 			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoDaysAndHours"
 		case .noExposureConfiguration:
 			return AppStrings.ExposureDetectionError.errorAlertMessage + " Code: NoExposureConfiguration"
+		}
+	}
+}
+
+extension ENError {
+	var faqURL: URL? {
+		switch code {
+		case .unsupported:
+			return URL(string: AppStrings.Links.appFaqENError5)
+		case .internal:
+			return URL(string: AppStrings.Links.appFaqENError11)
+		case .rateLimited:
+			return URL(string: AppStrings.Links.appFaqENError13)
+		default: return nil
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ExposureSubmissionService.swift
@@ -346,11 +346,11 @@ extension ExposureSubmissionError: LocalizedError {
 		case .noKeys:
 			return AppStrings.ExposureSubmissionError.noKeys
 		case .internal:
-			return AppStrings.ExposureSubmissionError.internal
+			return AppStrings.Common.enError11Description
 		case .unsupported:
-			return AppStrings.ExposureSubmissionError.unsupported
+			return AppStrings.Common.enError5Description
 		case .rateLimited:
-			return AppStrings.ExposureSubmissionError.rateLimited
+			return AppStrings.Common.enError13Description
 		case let .other(desc):
 			return  "\(AppStrings.ExposureSubmissionError.other)\(desc)\(AppStrings.ExposureSubmissionError.otherend)"
 		case .unknown:

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -33,6 +33,13 @@ enum AppStrings {
 		static let general_BackButtonTitle = NSLocalizedString("General_BackButtonTitle", comment: "")
 	}
 
+	enum Links {
+		static let appFaq = NSLocalizedString("General_moreInfo_URL", comment: "")
+		static let appFaqENError5 = NSLocalizedString("General_moreInfo_URL_EN5", comment: "")
+		static let appFaqENError11 = NSLocalizedString("General_moreInfo_URL_EN11", comment: "")
+		static let appFaqENError13 = NSLocalizedString("General_moreInfo_URL_EN13", comment: "")
+	}
+
 	enum AccessibilityLabel {
 		static let close = NSLocalizedString("AccessibilityLabel_Close", comment: "")
 		static let phoneNumber = NSLocalizedString("AccessibilityLabel_PhoneNumber", comment: "")
@@ -195,10 +202,10 @@ enum AppStrings {
 		static let `internal` = NSLocalizedString("ExposureSubmissionError_internal", comment: "")
 		static let rateLimited = NSLocalizedString("ExposureSubmissionError_rateLimited", comment: "")
 		static let moreInfo = NSLocalizedString("ExposureSubmissionError_moreInfo", comment: "")
-		static let moreInfoURL = NSLocalizedString("ExposureSubmissionError_moreInfo_URL", comment: "")
-		static let moreInfoURLEN5 = NSLocalizedString("ExposureSubmissionError_moreInfo_URL_EN5", comment: "")
-		static let moreInfoURLEN11 = NSLocalizedString("ExposureSubmissionError_moreInfo_URL_EN11", comment: "")
-		static let moreInfoURLEN13 = NSLocalizedString("ExposureSubmissionError_moreInfo_URL_EN13", comment: "")
+		static let moreInfoURL = AppStrings.Links.appFaq
+		static let moreInfoURLEN5 = AppStrings.Links.appFaqENError5
+		static let moreInfoURLEN11 = AppStrings.Links.appFaqENError11
+		static let moreInfoURLEN13 = AppStrings.Links.appFaqENError13
 	}
 
 	enum ExposureDetection {
@@ -252,6 +259,10 @@ enum AppStrings {
 		static let errorAlertTitle = NSLocalizedString("ExposureDetectionError_Alert_Title", comment: "")
 				static let errorAlertMessage = NSLocalizedString("ExposureDetectionError_Alert_Message", comment: "")
 		static let errorAlertActionDetails = NSLocalizedString("ExposureDetectionError_Alert_Action_Details", comment: "")
+		static let errorAlertActionMoreInfo = NSLocalizedString("ExposureDetectionError_Alert_Action_moreInfo", comment: "")
+		static let enError5Description = NSLocalizedString("ExposureDetectionError_ENError5_Description", comment: "")
+		static let enError11Description = NSLocalizedString("ExposureDetectionError_ENError11_Description", comment: "")
+		static let enError13Description = NSLocalizedString("ExposureDetectionError_ENError13_Description", comment: "")
 	}
 
 	enum Settings {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -31,6 +31,11 @@ enum AppStrings {
 		static let alertActionLater = NSLocalizedString("Alert_CancelAction_Later", comment: "")
 		static let alertActionOpenSettings = NSLocalizedString("Alert_DefaultAction_OpenSettings", comment: "")
 		static let general_BackButtonTitle = NSLocalizedString("General_BackButtonTitle", comment: "")
+
+		static let errorAlertActionMoreInfo = NSLocalizedString("Common_Alert_Action_moreInfo", comment: "")
+		static let enError5Description = NSLocalizedString("Common_ENError5_Description", comment: "")
+		static let enError11Description = NSLocalizedString("Common_ENError11_Description", comment: "")
+		static let enError13Description = NSLocalizedString("Common_ENError13_Description", comment: "")
 	}
 
 	enum Links {
@@ -198,14 +203,6 @@ enum AppStrings {
 		static let unknown = NSLocalizedString("ExposureSubmissionError_unknown", comment: "")
 		static let defaultError = NSLocalizedString("ExposureSubmissionError_defaultError", comment: "")
 		static let noConfiguration = NSLocalizedString("No Exposure Configuration available", comment: "")
-		static let unsupported = NSLocalizedString("ExposureSubmissionError_unsupported", comment: "")
-		static let `internal` = NSLocalizedString("ExposureSubmissionError_internal", comment: "")
-		static let rateLimited = NSLocalizedString("ExposureSubmissionError_rateLimited", comment: "")
-		static let moreInfo = NSLocalizedString("ExposureSubmissionError_moreInfo", comment: "")
-		static let moreInfoURL = AppStrings.Links.appFaq
-		static let moreInfoURLEN5 = AppStrings.Links.appFaqENError5
-		static let moreInfoURLEN11 = AppStrings.Links.appFaqENError11
-		static let moreInfoURLEN13 = AppStrings.Links.appFaqENError13
 	}
 
 	enum ExposureDetection {
@@ -257,12 +254,8 @@ enum AppStrings {
 
 	enum ExposureDetectionError {
 		static let errorAlertTitle = NSLocalizedString("ExposureDetectionError_Alert_Title", comment: "")
-				static let errorAlertMessage = NSLocalizedString("ExposureDetectionError_Alert_Message", comment: "")
+		static let errorAlertMessage = NSLocalizedString("ExposureDetectionError_Alert_Message", comment: "")
 		static let errorAlertActionDetails = NSLocalizedString("ExposureDetectionError_Alert_Action_Details", comment: "")
-		static let errorAlertActionMoreInfo = NSLocalizedString("ExposureDetectionError_Alert_Action_moreInfo", comment: "")
-		static let enError5Description = NSLocalizedString("ExposureDetectionError_ENError5_Description", comment: "")
-		static let enError11Description = NSLocalizedString("ExposureDetectionError_ENError11_Description", comment: "")
-		static let enError13Description = NSLocalizedString("ExposureDetectionError_ENError13_Description", comment: "")
 	}
 
 	enum Settings {


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)


## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
Previously, `UIAlertController`s  triggered by the app because of a failed exposure detection (when an `ExposureDetection.DidEndPrematurelyReason` is thrown) would have a simple OK button and nothing else. This PR adds some more details, as well as links several `ENError`s to their corresponding [FAQ](https://www.coronawarn.app/de/faq/) entries:
- `ENError(.unsupported)` -> [FAQ](https://www.coronawarn.app/de/faq/#ENError5)
- `ENError(.internal)` -> [FAQ](https://www.coronawarn.app/de/faq/#ENError11)
- `ENError(.rateLimited)` -> [FAQ](https://www.coronawarn.app/de/faq/#ENError13)

Alert before:
![IMG_55CC76CD50C1-1](https://user-images.githubusercontent.com/66173406/86860940-bac16100-c07a-11ea-8720-fdd00e1bcfcc.jpeg)

Alert after:
![IMG_F7288C2C29BF-1](https://user-images.githubusercontent.com/66173406/86860945-c14fd880-c07a-11ea-8826-ca224d212e30.jpeg)


