### PR TITLE
Add basic tests for getTestResult()

### DIFF
--- a/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
@@ -64,7 +64,8 @@ extension ClientMock: Client {
 
 	func getTestResult(forDevice device: String, completion completeWith: @escaping TestResultHandler) {
 		guard let onGetTestResult = self.onGetTestResult else {
-			completeWith(.success(2))
+			let positiveTestResult = 2
+			completeWith(.success(positiveTestResult))
 			return
 		}
 

--- a/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
@@ -19,12 +19,15 @@
 import ExposureNotification
 
 final class ClientMock {
+
 	// MARK: - Creating a Mock Client.
+
 	init(submissionError: SubmissionError? = nil) {
 		self.submissionError = submissionError
 	}
 
 	// MARK: - Properties.
+	
 	let submissionError: SubmissionError?
 
 	// MARK: - Configurable Mock Callbacks.

--- a/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
@@ -19,14 +19,18 @@
 import ExposureNotification
 
 final class ClientMock {
-	// MARK: Creating a Mock Client
-	init(submissionError: SubmissionError?) {
+	// MARK: - Creating a Mock Client.
+	init(submissionError: SubmissionError? = nil) {
 		self.submissionError = submissionError
 	}
 
-	// MARK: Properties
+	// MARK: - Properties.
 	let submissionError: SubmissionError?
+
+	// MARK: - Configurable Mock Callbacks.
+
 	var onAppConfiguration: (AppConfigurationCompletion) -> Void = { $0(nil) }
+	var onGetTestResult: ((String, TestResultHandler) -> Void)?
 }
 
 extension ClientMock: Client {
@@ -59,7 +63,12 @@ extension ClientMock: Client {
 	}
 
 	func getTestResult(forDevice device: String, completion completeWith: @escaping TestResultHandler) {
-		completeWith(.success(2))
+		guard let onGetTestResult = self.onGetTestResult else {
+			completeWith(.success(2))
+			return
+		}
+
+		onGetTestResult(device, completeWith)
 	}
 
 	func getTANForExposureSubmit(forDevice device: String, completion completeWith: @escaping TANHandler) {

--- a/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/ClientMock.swift
@@ -64,8 +64,7 @@ extension ClientMock: Client {
 
 	func getTestResult(forDevice device: String, completion completeWith: @escaping TestResultHandler) {
 		guard let onGetTestResult = self.onGetTestResult else {
-			let positiveTestResult = 2
-			completeWith(.success(positiveTestResult))
+			completeWith(.success(TestResult.positive.rawValue))
 			return
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -26,7 +26,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 	func testSubmitExpousure_Success() {
 		// Arrange
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
-		let client = ClientMock(submissionError: nil)
+		let client = ClientMock()
 		let store = MockTestStore()
 		store.registrationToken = "dummyRegistrationToken"
 
@@ -49,7 +49,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 	func testSubmitExpousure_NoKeys() {
 		// Arrange
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (nil, nil))
-		let client = ClientMock(submissionError: nil)
+		let client = ClientMock()
 		let store = MockTestStore()
 
 		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
@@ -74,7 +74,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 	func testSubmitExpousure_EmptyKeys() {
 		// Arrange
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (nil, nil))
-		let client = ClientMock(submissionError: nil)
+		let client = ClientMock()
 		let store = MockTestStore()
 
 		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
@@ -126,7 +126,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		// Arrange
 
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
-		let client = ClientMock(submissionError: nil)
+		let client = ClientMock()
 		let store = MockTestStore()
 
 		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
@@ -176,7 +176,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		let expectation = self.expectation(description: "Expect to receive a result.")
 		let service = ENAExposureSubmissionService(
 			diagnosiskeyRetrieval: MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil)),
-			client: ClientMock(submissionError: nil),
+			client: ClientMock(),
 			store: MockTestStore()
 		)
 
@@ -200,7 +200,6 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		// Initialize.
 
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
-
 		let store = MockTestStore()
 		store.registrationToken = "dummyRegistrationToken"
 


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR adds 3 basic tests for the getTestResult method of the exposure submission service. Particularly relevant is the testGetTestResult_unknownTestResultValue case as discussed in JIRA 1743.

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
