### PR TITLE
Force tan input field to be ordered left-to-right even for RTL languages

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATanInput.swift
@@ -153,6 +153,9 @@ extension ENATanInput {
 		stackView.isUserInteractionEnabled = false
 		stackView.alignment = .fill
 
+		// Enfore left-to-right semantics for RTL languages such as Arabic.
+		stackView.semanticContentAttribute = .forceLeftToRight
+
 		// Generate character groups
 		for (index, numberOfDigitsInGroup) in digitGroups.enumerated() {
 			let groupView = createGroup(count: numberOfDigitsInGroup, hasDash: index < digitGroups.count - 1)
@@ -191,6 +194,9 @@ extension ENATanInput {
 		stackView.axis = .horizontal
 		stackView.alignment = .fill
 		stackView.distribution = .fill
+
+		// Enfore left-to-right semantics for RTL languages such as Arabic.
+		stackView.semanticContentAttribute = .forceLeftToRight
 
 		for _ in 0..<count { stackView.addArrangedSubview(createLabel()) }
 		if hasDash { stackView.addArrangedSubview(createDash()) }


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

This small PR makes sure that the tan input field is always displayed from left-to-right even for languages that are RTL (such as Arabic, see discussion JIRA 1734).

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)


## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
