### PR TITLE
App Config Protobuf Changes (closes #862)

### DIFF
--- a/proto/resources/app_config.proto
+++ b/proto/resources/app_config.proto
@@ -70,7 +70,7 @@ message RiskScoreParameters {
         RiskLevel gt_27_le_33_dbm = 5;      // 27 < A <= 33 dBm
         RiskLevel gt_15_le_27_dbm = 6;      // 15 < A <= 27 dBm
         RiskLevel gt_10_le_15_dbm = 7;      // 10 < A <= 15 dBm
-        RiskLevel lt_10_dbm = 8;            // A <= 10 dBm, highest risk
+        RiskLevel le_10_dbm = 8;            // A <= 10 dBm, highest risk
     }
 }
 

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -483,6 +483,6 @@ private extension SAP_RiskScoreParameters.DurationRiskParameter {
 
 private extension SAP_RiskScoreParameters.AttenuationRiskParameter {
 	var asArray: [NSNumber] {
-		[gt73Dbm, gt63Le73Dbm, gt51Le63Dbm, gt33Le51Dbm, gt27Le33Dbm, gt15Le27Dbm, gt10Le15Dbm, lt10Dbm].map { $0.asNumber }
+		[gt73Dbm, gt63Le73Dbm, gt51Le63Dbm, gt33Le51Dbm, gt27Le33Dbm, gt15Le27Dbm, gt10Le15Dbm, le10Dbm].map { $0.asNumber }
 	}
 }

--- a/src/xcode/gen/output/app_config.pb.swift
+++ b/src/xcode/gen/output/app_config.pb.swift
@@ -314,7 +314,7 @@ struct SAP_RiskScoreParameters {
     var gt10Le15Dbm: SAP_RiskLevel = .invalid
 
     /// A <= 10 dBm, highest risk
-    var lt10Dbm: SAP_RiskLevel = .invalid
+    var le10Dbm: SAP_RiskLevel = .invalid
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -724,7 +724,7 @@ extension SAP_RiskScoreParameters.AttenuationRiskParameter: SwiftProtobuf.Messag
     5: .standard(proto: "gt_27_le_33_dbm"),
     6: .standard(proto: "gt_15_le_27_dbm"),
     7: .standard(proto: "gt_10_le_15_dbm"),
-    8: .standard(proto: "lt_10_dbm"),
+    8: .standard(proto: "le_10_dbm"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -737,7 +737,7 @@ extension SAP_RiskScoreParameters.AttenuationRiskParameter: SwiftProtobuf.Messag
       case 5: try decoder.decodeSingularEnumField(value: &self.gt27Le33Dbm)
       case 6: try decoder.decodeSingularEnumField(value: &self.gt15Le27Dbm)
       case 7: try decoder.decodeSingularEnumField(value: &self.gt10Le15Dbm)
-      case 8: try decoder.decodeSingularEnumField(value: &self.lt10Dbm)
+      case 8: try decoder.decodeSingularEnumField(value: &self.le10Dbm)
       default: break
       }
     }
@@ -765,8 +765,8 @@ extension SAP_RiskScoreParameters.AttenuationRiskParameter: SwiftProtobuf.Messag
     if self.gt10Le15Dbm != .invalid {
       try visitor.visitSingularEnumField(value: self.gt10Le15Dbm, fieldNumber: 7)
     }
-    if self.lt10Dbm != .invalid {
-      try visitor.visitSingularEnumField(value: self.lt10Dbm, fieldNumber: 8)
+    if self.le10Dbm != .invalid {
+      try visitor.visitSingularEnumField(value: self.le10Dbm, fieldNumber: 8)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -779,7 +779,7 @@ extension SAP_RiskScoreParameters.AttenuationRiskParameter: SwiftProtobuf.Messag
     if lhs.gt27Le33Dbm != rhs.gt27Le33Dbm {return false}
     if lhs.gt15Le27Dbm != rhs.gt15Le27Dbm {return false}
     if lhs.gt10Le15Dbm != rhs.gt10Le15Dbm {return false}
-    if lhs.lt10Dbm != rhs.lt10Dbm {return false}
+    if lhs.le10Dbm != rhs.le10Dbm {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)


## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
#862 describes a minor naming bug/issue with one of the range params in the `app_config.proto` file, specifically the last `AttenuationRiskParameters` range. The current wording implies a "less than 10 dBm", when in reality it is a "less than or equal to 10 dBm" range. 

Note that this does _not_ have any technical implications, it's simply a naming discrepancy. This PR fixes it.

The changed protocol file also required a re-generation of the Swift protobuf files and hence also a small code change.
