### PR TITLE
Fix: Grammar error in data privacy (EXPOSUREAPP-2251)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -255,7 +255,7 @@
 			<div>
 				<h3>b. Begegnungsdaten</h3>
 
-				<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes zu bezeichnet (im Folgenden: „<strong>Zufalls-IDs</strong>“), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
+				<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes zu bezeichnen (im Folgenden: „<strong>Zufalls-IDs</strong>“), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
 
 				<ul>
 					<li>Datum und Zeitpunkt des Kontakts</li>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -255,7 +255,7 @@
 			<div>
 				<h3>b. Begegnungsdaten</h3>
 
-				<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes zu bezeichnen (im Folgenden: „<strong>Zufalls-IDs</strong>“), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
+				<p>Wenn Sie auf Ihrem Smartphone die betriebssystemseitige Funktion zur Aufzeichnung von Kontakten zu anderen Nutzern aktivieren, versendet Ihr Smartphone per Bluetooth Low Energy kontinuierlich zufallsgenerierte Kennnummern, auch als Zufallscodes bezeichnet (im Folgenden: „<strong>Zufalls-IDs</strong>“), die von anderen Smartphones in Ihrer Nähe mit ebenfalls aktivierter Kontaktaufzeichnung empfangen werden können. Umgekehrt empfängt Ihr Smartphone auch die Zufalls-IDs der anderen Smartphones. Zu den von anderen Smartphones empfangenen Zufalls-IDs werden von der Kontaktaufzeichnungs-Funktion Ihres Smartphones zusätzlich folgende Begegnungsdaten aufgezeichnet und gespeichert:</p>
 
 				<ul>
 					<li>Datum und Zeitpunkt des Kontakts</li>


### PR DESCRIPTION
## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)

## Description
Fix: Grammar error in data privacy (EXPOSUREAPP-2251)
