### PR TITLE
Show Alert when AppConfig could not be loaded during RiskCalculation

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -150,6 +150,8 @@
 
 "ExposureDetectionError_Alert_Message" = "Während der Risiko-Ermittlung ist ein Fehler aufgetreten.";
 
+"ExposureDetectionError_Alert_AppConfig_Missing_Message" = "Ihre Internetverbindung wurde unterbrochen. Bitte prüfen Sie die Verbindung und öffnen Sie die App dann erneut.";
+
 /* How Risk Detection Works Alert.\n First introduced due to EXPOSUREAPP-1738.\n The alert only displays a single OK-button. We re-use the localized string\n `Alert_ActionOk` for that. */
 "How_Risk_Detection_Works_Alert_Title" = "Information zur Funktionsweise der Risiko-Ermittlung";
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -265,6 +265,7 @@ extension RiskProvider: RiskProviding {
 		guard let _appConfiguration = appConfiguration else {
 			provideLoadingStatus(isLoading: false)
 			completeOnTargetQueue(risk: nil, completion: completion)
+			showAppConfigError()
 			return
 		}
 
@@ -322,6 +323,16 @@ extension RiskProvider: RiskProviding {
 			store.previousRiskLevel = .increased
 		default:
 			break
+		}
+	}
+	
+	private func showAppConfigError() {
+		// This should only be in the App temporarly until we refactor either how we update/get AppConfiguration or refactor how Errors are handled during the RiskCalculation.
+		DispatchQueue.main.async {
+			UIApplication.shared.windows.first?.rootViewController?.alertError(
+				message: AppStrings.ExposureDetectionError.errorAlertAppConfigMissingMessage,
+				title: AppStrings.ExposureDetectionError.errorAlertTitle
+			)
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -270,6 +270,8 @@ enum AppStrings {
 		static let errorAlertTitle = NSLocalizedString("ExposureDetectionError_Alert_Title", comment: "")
 		static let errorAlertMessage = NSLocalizedString("ExposureDetectionError_Alert_Message", comment: "")
 		static let errorAlertActionDetails = NSLocalizedString("ExposureDetectionError_Alert_Action_Details", comment: "")
+		static let errorAlertAppConfigMissingMessage = NSLocalizedString("ExposureDetectionError_Alert_AppConfig_Missing_Message", comment: "")
+
 	}
 
 	enum Settings {


### PR DESCRIPTION
## Description
Solves: https://jira.itc.sap.com/browse/EXPOSUREAPP-2472
An Error is shown when AppConfiguration is nil during RiskCalculation. 

![Screen Shot 2020-09-07 at 12 26 47](https://user-images.githubusercontent.com/10122052/92384893-2d999780-f111-11ea-91da-314449afd79b.png)
