### PR TITLE
Apply minimum risk score values from configuration

### DIFF
--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -85,7 +85,7 @@ final class HTTPClient: Client {
 				completion(nil)
 				return
 			}
-			completion(try? ENExposureConfiguration(from: config.exposureConfig))
+			completion(try? ENExposureConfiguration(from: config.exposureConfig, minRiskScore: config.minRiskScore))
 		}
 	}
 
@@ -614,9 +614,10 @@ private extension URLRequest {
 }
 
 private extension ENExposureConfiguration {
-	convenience init(from riskscoreParameters: SAP_RiskScoreParameters) throws {
+	convenience init(from riskscoreParameters: SAP_RiskScoreParameters, minRiskScore: Int32) throws {
 		self.init()
-		// We are intentionally not setting minimumRiskScore.
+		minimumRiskScore = UInt8(minRiskScore)
+		minimumRiskScoreFullRange = Double(minRiskScore)
 		attenuationLevelValues = riskscoreParameters.attenuation.asArray
 		daysSinceLastExposureLevelValues = riskscoreParameters.daysSinceLastExposure.asArray
 		durationLevelValues = riskscoreParameters.duration.asArray

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -616,7 +616,7 @@ private extension URLRequest {
 private extension ENExposureConfiguration {
 	convenience init(from riskscoreParameters: SAP_RiskScoreParameters, minRiskScore: Int32) throws {
 		self.init()
-		minimumRiskScore = UInt8(minRiskScore)
+		minimumRiskScore = UInt8(clamping: minRiskScore)
 		minimumRiskScoreFullRange = Double(minRiskScore)
 		attenuationLevelValues = riskscoreParameters.attenuation.asArray
 		daysSinceLastExposureLevelValues = riskscoreParameters.daysSinceLastExposure.asArray


### PR DESCRIPTION
## Description
This PR applies the minRiskScore from the configuration to minimumRiskScore and minimumRiskScoreFullRange of the ENExposureConfiguration.

Related Story: [2437](https://jira.itc.sap.com/browse/EXPOSUREAPP-2437)

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

