### PR TITLE
EXPOSUREAPP-2491 Error Code 400 now has a better wording

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -610,6 +610,11 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionError_TeleTanAlreadyUsed" = "Die TAN ist ungültig oder wurde bereits verwendet. Bitte versuchen Sie es erneut oder kontaktieren Sie die technische Hotline über App-Informationen -> Technische Hotline.";
 
+"ExposureSubmissionError_QRNotExist_Title" = "QR-Code ist abgelaufen";
+
+"ExposureSubmissionError_QRNotExist" = "Bitte entfernen Sie den Test aus der App.
+Danach können Sie einen neuen Test in der App hinzufügen.";
+
 "ExposureSubmissionError_RegTokenNotExist" = "Es konnte keine Übermittlungs-TAN erstellt werden. Bitte kontaktieren Sie die technische Hotline über App-Informationen -> Technische Hotline.";
 
 "ExposureSubmissionError_other" = "Es ist ein Verbindungsfehler aufgetreten. Fehlercode für den technischen Support: ";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -612,8 +612,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionError_QRNotExist_Title" = "QR-Code ist abgelaufen";
 
-"ExposureSubmissionError_QRNotExist" = "Bitte entfernen Sie den Test aus der App.
-Danach können Sie einen neuen Test in der App hinzufügen.";
+"ExposureSubmissionError_QRNotExist" = "Bitte entfernen Sie den Test aus der App.\nDanach können Sie einen neuen Test in der App hinzufügen.";
 
 "ExposureSubmissionError_RegTokenNotExist" = "Es konnte keine Übermittlungs-TAN erstellt werden. Bitte kontaktieren Sie die technische Hotline über App-Informationen -> Technische Hotline.";
 

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -197,6 +197,7 @@ final class HTTPClient: Client {
 
 	func getTestResult(forDevice registrationToken: String, isFake: Bool = false, completion completeWith: @escaping TestResultHandler) {
 
+		
 		guard
 			let testResultRequest = try? URLRequest.getTestResultRequest(
 				configuration: configuration,
@@ -210,6 +211,12 @@ final class HTTPClient: Client {
 		session.response(for: testResultRequest, isFake: isFake) { result in
 			switch result {
 			case let .success(response):
+				
+				if response.statusCode == 400 {
+					completeWith(.failure(.qRNotExist))
+					return
+				}
+				
 				guard response.hasAcceptableStatusCode else {
 					completeWith(.failure(.serverError(response.statusCode)))
 					return

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/URLSession+Convenience.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/URLSession+Convenience.swift
@@ -106,6 +106,7 @@ extension URLSession.Response {
 		case noResponse
 		case teleTanAlreadyUsed
 		case qRAlreadyUsed
+		case qRNotExist
 		case regTokenNotExist
 		case invalidResponse
 		case serverError(Int)

--- a/src/xcode/ENA/ENA/Source/Extensions/ExposureSubmissionParsable.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/ExposureSubmissionParsable.swift
@@ -101,6 +101,8 @@ extension URLSession.Response.Failure: ExposureSubmissionErrorTransformable {
 			return .qRAlreadyUsed
 		case .regTokenNotExist:
 			return .regTokenNotExist
+		case .qRNotExist:
+			return .qRNotExist
 		case .noResponse:
 			return .noResponse
 		case let .serverError(code):

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionOverviewViewController.swift
@@ -158,6 +158,15 @@ extension ExposureSubmissionOverviewViewController: ExposureSubmissionQRScannerD
 			self.stopSpinner()
 			switch result {
 			case let .failure(error):
+				
+				if case .qRNotExist = error {
+					let alert = self.setupErrorAlert(
+						title: AppStrings.ExposureSubmissionError.qrNotExistTitle,
+						message: error.localizedDescription
+					)
+					self.present(alert, animated: true, completion: nil)
+					return
+				}
 
 				// Note: In the case the QR Code was already used, retrying will result
 				// in an endless loop.

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionError.swift
@@ -33,6 +33,7 @@ enum ExposureSubmissionError: Error, Equatable {
 	case teleTanAlreadyUsed
 	case qRAlreadyUsed
 	case regTokenNotExist
+	case qRNotExist
 	case serverError(Int)
 	case unknown
 	case httpError(String)
@@ -67,6 +68,8 @@ extension ExposureSubmissionError: LocalizedError {
 			return AppStrings.ExposureSubmissionError.noConfiguration
 		case .qRAlreadyUsed:
 			return AppStrings.ExposureSubmissionError.qrAlreadyUsed
+		case .qRNotExist:
+			return AppStrings.ExposureSubmissionError.qrNotExist
 		case .teleTanAlreadyUsed:
 			return AppStrings.ExposureSubmissionError.teleTanAlreadyUsed
 		case .regTokenNotExist:

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -206,6 +206,8 @@ enum AppStrings {
 		static let teleTanAlreadyUsed = NSLocalizedString("ExposureSubmissionError_TeleTanAlreadyUsed", comment: "")
 		static let qrAlreadyUsed = NSLocalizedString("ExposureSubmissionError_QRAlreadyUsed", comment: "")
 		static let qrAlreadyUsedTitle = NSLocalizedString("ExposureSubmissionError_QRAlreadyUsed_Title", comment: "")
+		static let qrNotExist = NSLocalizedString("ExposureSubmissionError_QRNotExist", comment: "")
+		static let qrNotExistTitle = NSLocalizedString("ExposureSubmissionError_QRNotExist_Title", comment: "")
 		static let regTokenNotExist = NSLocalizedString("ExposureSubmissionError_RegTokenNotExist", comment: "")
 		static let other = NSLocalizedString("ExposureSubmissionError_other", comment: "")
 		static let otherend = NSLocalizedString("ExposureSubmissionError_otherend", comment: "")


### PR DESCRIPTION
## Description
This changes the somehow cryptical error description (error 400) to a human-readable one. It's liked to {https://jira.itc.sap.com/browse/EXPOSUREAPP-2219}. 

![image](https://user-images.githubusercontent.com/70148649/92725115-e9560380-f36b-11ea-8199-81e5f34e7804.png)
