### PR TITLE
Increase timeout to 10 minutes for risk calculation transaction (INTEROP 1660-2617)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -254,7 +254,7 @@ extension RiskProvider: RiskProviding {
 			group.leave()
 		}
 
-		guard group.wait(timeout: .now() + .seconds(60)) == .success else {
+		guard group.wait(timeout: .now() + .seconds(60 * 10)) == .success else {
 			provideLoadingStatus(isLoading: false)
 			cancellationToken?.cancel()
 			cancellationToken = nil


### PR DESCRIPTION
## Description
This PR increases the timeout of downloading, processing key packages and calculating risk to 10 minutes.

Story: [2617](https://jira.itc.sap.com/browse/EXPOSUREAPP-2617)

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)



