### PR TITLE
Adjust wrong TAN error messages

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -386,9 +386,9 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionTanEntry_Submit" = "Weiter";
 
-"ExposureSubmissionTanEntry_InvalidCharacterError" = "Ungültige Eingabe, bitte überprüfen Sie das Zeichen.";
+"ExposureSubmissionTanEntry_InvalidCharacterError" = "Ihre Eingabe enthält ein ungültiges Zeichen. Bitte überprüfen Sie Ihre Eingabe";
 
-"ExposureSubmissionTanEntry_InvalidError" = "Ungültige TAN, bitte überprüfen Sie Ihre Eingabe.";
+"ExposureSubmissionTanEntry_InvalidError" = "Ungültige TAN. Bitte überprüfen Sie Ihre Eingabe.";
 
 "ExposureSubmission_NavTitle" = "Positivkennung senden";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTanInputViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTanInputViewController.swift
@@ -134,15 +134,14 @@ extension ExposureSubmissionTanInputViewController: ENATanInputDelegate {
 		navigationFooterItem?.isPrimaryButtonEnabled = (isValid && isChecksumValid)
 
 		UIView.animate(withDuration: CATransaction.animationDuration()) {
-			if isValid && !isChecksumValid {
-				self.errorLabel.text = AppStrings.ExposureSubmissionTanEntry.invalidError
-				self.errorView.alpha = 1
-			} else if isBlocked {
-				self.errorLabel.text = AppStrings.ExposureSubmissionTanEntry.invalidCharacterError
-				self.errorView.alpha = 1
-			} else {
-				self.errorView.alpha = 0
-			}
+
+			var errorTexts = [String]()
+
+			if isValid && !isChecksumValid { errorTexts.append(AppStrings.ExposureSubmissionTanEntry.invalidError) }
+			if isBlocked { errorTexts.append(AppStrings.ExposureSubmissionTanEntry.invalidCharacterError) }
+
+			self.errorView.alpha = errorTexts.isEmpty ? 0 : 1
+			self.errorLabel.text = errorTexts.joined(separator: "\n\n")
 
 			self.view.layoutIfNeeded()
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTanInputViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionTanInputViewControllerTests.swift
@@ -52,4 +52,25 @@ class ExposureSubmissionTanInputViewControllerTests: XCTestCase {
 		
 		waitForExpectations(timeout: .short)
 	}
+
+	// Checks that a wrong TAN was input.
+	func testWrongTan() {
+		let vc = createVC()
+		_ = vc.view
+
+		vc.tanInput.insertText("ZBYKEVDBNU")
+		XCTAssert(vc.errorView.alpha == 1)
+		XCTAssert(vc.errorLabel.text == AppStrings.ExposureSubmissionTanEntry.invalidError)
+	}
+
+	// Checks that a TAN with one wrong character was input.
+	func testWrongCharacterTan() {
+		let vc = createVC()
+		_ = vc.view
+
+		vc.tanInput.insertText("ZBYKEVDBNL")
+		XCTAssert(vc.errorView.alpha == 1)
+		XCTAssert(vc.errorLabel.text == "\(AppStrings.ExposureSubmissionTanEntry.invalidError)\n\n\(AppStrings.ExposureSubmissionTanEntry.invalidCharacterError)")
+	}
+
 }


### PR DESCRIPTION
This PR adjusts our error messages for wrong TAN inputs, as described in issue [2549](https://jira.itc.sap.com/browse/EXPOSUREAPP-2549), to match the ones from Android.

**Note**: Currently this PR is WIP because we need to double-check the English texts.

