### PR TITLE
Fix: Make symptom options selectable on iOS 14

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewOptionGroupCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewOptionGroupCell.swift
@@ -48,13 +48,13 @@ class DynamicTableViewOptionGroupCell: UITableViewCell {
 		backgroundColor = .enaColor(for: .background)
 
 		optionGroupView.translatesAutoresizingMaskIntoConstraints = false
-		addSubview(optionGroupView)
+		contentView.addSubview(optionGroupView)
 
 		NSLayoutConstraint.activate([
-			optionGroupView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-			optionGroupView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
-			optionGroupView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
-			optionGroupView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16)
+			optionGroupView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+			optionGroupView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+			optionGroupView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+			optionGroupView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
 		])
 	}
 


### PR DESCRIPTION
## Description
Makes the symptom options selectable by adding the option group view to the content view. Otherwise the content view is put on top of them on iOS 14 and the tap gesture is not recognized by the underlying views.

Bug: https://jira.itc.sap.com/browse/EXPOSUREAPP-2698
