### PR TITLE
Admin/trigger ci rcbuild via tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,16 @@ jobs:
     shell: zsh
     steps:
       - checkout
+      - run:
+          name: Install dependencies
+          command: cd src/xcode && bundle install
+      - run: ./scripts/switch_to_dev_env.sh
+      - run:
+          name: fastlane testflight
+          command: cd src/xcode && bundle exec fastlane betaRelease --env TestFlight
+      - run:
+          name: fastlane appcenter
+          command: cd src/xcode && bundle exec fastlane adHocDistribution
   update-docs:
     macos:
       xcode: 11.6.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,6 @@ jobs:
     shell: zsh
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: cd src/xcode && bundle install
   update-docs:
     macos:
       xcode: 11.6.0
@@ -139,6 +136,9 @@ workflows:
               branches:
                 ignore: /.*/
         - testflight-release:
+            requires:
+              - test
+              - build
             filters:
               tags:
                 only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,15 +129,15 @@ workflows:
               tags:
                 only:
                   - /^v.*/
-            branches:
-              ignore: /.*/
+              branches:
+                ignore: /.*/
         - build:
             filters:
               tags:
                 only:
                   - /^v.*/
-            branches:
-              ignore: /.*/
+              branches:
+                ignore: /.*/
         - testflight-release:
             filters:
               tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,20 @@ workflows:
                   - master
     betaRelease:
       jobs:
+        - test:
+            filters:
+              tags:
+                only:
+                  - /^v.*/
+            branches:
+              ignore: /.*/
+        - build:
+            filters:
+              tags:
+                only:
+                  - /^v.*/
+            branches:
+              ignore: /.*/
         - testflight-release:
             filters:
               tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,6 @@ jobs:
       - run:
           name: Install dependencies
           command: cd src/xcode && bundle install
-      - run: ./scripts/switch_to_dev_env.sh
-      - run:
-          name: fastlane testflight
-          command: cd src/xcode && bundle exec fastlane betaRelease --env TestFlight
-      - run:
-          name: fastlane appcenter
-          command: cd src/xcode && bundle exec fastlane adHocDistribution
   update-docs:
     macos:
       xcode: 11.6.0
@@ -133,6 +126,8 @@ workflows:
       jobs:
         - testflight-release:
             filters:
-              branches:
+              tags:
                 only:
-                  - /rc\/.*/
+                  - /^v.*/
+              branches:
+                ignore: /.*/


### PR DESCRIPTION
This PR changes the trigger for a Beta Release or Release Candidate build. It will only run the betaRelease if a Tag ist created which starts with a "v".