### PR TITLE
Fix behaviour on key upload

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -379,8 +379,7 @@ extension ExposureSubmissionCoordinator {
 				switch error {
 				// If User doesn`t allow TEK`s to be shared with the app, we stay on the screen (https://jira.itc.sap.com/browse/EXPOSUREAPP-2293)
 				case .notAuthorized:
-					self.navigationFooterItem?.isPrimaryButtonLoading = false
-					self.navigationFooterItem?.isPrimaryButtonEnabled = true
+					onError()
 					return
 				
 				// We continue the regular flow even if there are no keys collected.

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -377,6 +377,12 @@ extension ExposureSubmissionCoordinator {
 			visitedCountries: visitedCountries,
 			completionHandler: { [weak self] error in
 				switch error {
+				// If User doesn`t allow TEK`s to be shared with the app, we stay on the screen (https://jira.itc.sap.com/browse/EXPOSUREAPP-2293)
+				case .notAuthorized:
+					self.navigationFooterItem?.isPrimaryButtonLoading = false
+					self.navigationFooterItem?.isPrimaryButtonEnabled = true
+					return
+				
 				// We continue the regular flow even if there are no keys collected.
 				case .none, .noKeys:
 					onSuccess()


### PR DESCRIPTION
## Description
Fixes: https://jira.itc.sap.com/browse/EXPOSUREAPP-2293

If the User declines sharing his TEKs with the App during Key Upload we want to stay on the same screen instead of showing an error message.

![DontShareTEKs](https://user-images.githubusercontent.com/10122052/91318569-a87ebc00-e7bb-11ea-85ca-2e7fb5d333fd.gif)
