### PR TITLE
Risk calculation download mode (Interop 2667 - 2765)

### DIFF
--- a/COMPILATION_CONDITIONS.md
+++ b/COMPILATION_CONDITIONS.md
@@ -9,4 +9,4 @@ Our code uses several (custom) [ compilation conditions](https://help.apple.com/
 | `COMMUNITY` | `true` is the *Community* build configuration/schema has been selected. The *Community* configuration enables other developers to run the app in Simulator. |
 | `USE_DEV_PK_FOR_SIG_VERIFICATION` | `true` if the app should use the dev-public keys for the signature verfification. This is only set for testing and during development. In case this is set mistakenly to `true` the app simply stops working. |
 | `DISABLE_CERTIFICATE_PINNING` | `true` if certificate pinning should be disabled. This is **NEVER EVER** set for builds that will end up in the App Store. We only use this for debugging purposes. |
-
+| `EUROPEMODE` | `true` if europe mode should be enabled. If the exposure detection runs in europe mode, only key packages for country "EUR" are downloaded. Countries from the supported countries list are ignored. |

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
@@ -61,6 +61,8 @@ extension Locale {
 			identifier = "gr"
 		case "no":
 			identifier = "nb_NO"
+		case "eur":
+			identifier = "eu"
 		default:
 			identifier = code
 		}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -59,9 +59,12 @@ final class ExposureDetection {
 	}
 
 	private func getCountriesToDetect(supportedCountries: [Country]) -> [Country.ID] {
-		var countryIDs = Set(supportedCountries.map { $0.id })
-		countryIDs.insert(Country.defaultCountry().id)
+		#if EUROPEMODE
+		return ["EUR"]
+		#else
+		let countryIDs = Set(supportedCountries.map { $0.id })
 		return Array(countryIDs)
+		#endif
 	}
 
 	private func downloadKeyPackages(for countries: [Country.ID], completion: @escaping () -> Void) {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -51,7 +51,14 @@ final class ExposureDetection {
 
 			switch result {
 			case .success(let supportedCountries):
-				completion(supportedCountries)
+				var _supportedCountries = supportedCountries
+
+				// If supported countries is empty for some reason, we add the default country (DE).
+				if _supportedCountries.isEmpty {
+					_supportedCountries.append(Country.defaultCountry())
+				}
+
+				completion(_supportedCountries)
 			case.failure:
 				self.endPrematurely(reason: .noSupportedCountries)
 			}


### PR DESCRIPTION
## Description
This PR introduces the possibility to switch to the europa approach with a compiler flag.
It also removes adding "DE" to the supported countries. "DE" will be provided by the backend. (https://github.com/corona-warn-app/cwa-app-tech-spec/commit/7a3b8584e3f6e52fcea2639b8a71bde6d353e1d0)

Story: [2765](https://jira.itc.sap.com/browse/EXPOSUREAPP-2765)

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)


