### PR TITLE
Exclude files w/ legal texts

### DIFF
--- a/translation_v2.json
+++ b/translation_v2.json
@@ -8,6 +8,9 @@
           "sourceFilters": [
             "*.strings","*.stringsdict"
           ],
+          "excludedSourceFilters":[
+                  "*.legal.*"
+          ],
            "targetFolderPath":"../[langCode].lproj/"
         }
       ]


### PR DESCRIPTION
exclude files matching the pattern \*.legal.\* from the translation process

Legal texts are provided for each language (EN/DE/TR) and must not be part of the translation process. 