### PR TITLE
exclude legal files from translation

### DIFF
--- a/translation_v2.json
+++ b/translation_v2.json
@@ -8,6 +8,9 @@
           "sourceFilters": [
             "*.strings","*.stringsdict"
           ],
+          "excludedSourceFilters":[
+            "*.legal.*"
+          ],
            "targetFolderPath":"../[langCode].lproj/"
         }
       ]


### PR DESCRIPTION
adapt translation_v2 json file in order to exclude legal texts from translation process
