### PR TITLE
Show the delta onboarding even if the app configuration cannot be loaded

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -131,10 +131,16 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 
 	private func showDeltaOnboarding() {
 		appConfigurationProvider.appConfiguration { [weak self] result in
-			guard let self = self ,
-				  case let .success(applicationConfiguration) = result else { return }
+			guard let self = self else { return }
 
-			let supportedCountries = applicationConfiguration.supportedCountries.compactMap({ Country(countryCode: $0) })
+			let supportedCountries: [Country]
+
+			switch result {
+			case .success(let applicationConfiguration):
+				supportedCountries = applicationConfiguration.supportedCountries.compactMap({ Country(countryCode: $0) })
+			case .failure:
+				supportedCountries = []
+			}
 
 			let onboardings: [DeltaOnboarding] = [
 				DeltaOnboardingV15(store: self.store, supportedCountries: supportedCountries)


### PR DESCRIPTION
## Description
The delta onboarding should be shown without a list of countries if the app configuration could not be loaded.