### PR TITLE
Fix warning resulting from reading self.store from non main thread

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -132,26 +132,26 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 	private func showDeltaOnboarding() {
 		appConfigurationProvider.appConfiguration { [weak self] result in
 			guard let self = self else { return }
-
+			
 			let supportedCountries: [Country]
-
+			
 			switch result {
 			case .success(let applicationConfiguration):
 				supportedCountries = applicationConfiguration.supportedCountries.compactMap({ Country(countryCode: $0) })
 			case .failure:
 				supportedCountries = []
 			}
-
-			let onboardings: [DeltaOnboarding] = [
-				DeltaOnboardingV15(store: self.store, supportedCountries: supportedCountries)
-			]
 			
-			self.deltaOnboardingCoordinator = DeltaOnboardingCoordinator(rootViewController: self, onboardings: onboardings)
-			self.deltaOnboardingCoordinator?.finished = { [weak self] in
-				self?.deltaOnboardingCoordinator = nil
-			}
-
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+				let onboardings: [DeltaOnboarding] = [
+					DeltaOnboardingV15(store: self.store, supportedCountries: supportedCountries)
+				]
+				
+				self.deltaOnboardingCoordinator = DeltaOnboardingCoordinator(rootViewController: self, onboardings: onboardings)
+				self.deltaOnboardingCoordinator?.finished = { [weak self] in
+					self?.deltaOnboardingCoordinator = nil
+				}
+				
 				self.deltaOnboardingCoordinator?.startOnboarding()
 			}
 		}


### PR DESCRIPTION
## Description
This PR fixes a warning resulting from accessing self.store of AppDelegate on a non main thread.

## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

