### PR TITLE
fix/3174 Empty checks in Exposure Check Log

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		AB1885D825238DD100D39BBE /* OnboardingInfoViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1885D025238DAA00D39BBE /* OnboardingInfoViewControllerTests.swift */; };
 		AB1FCBD42521FC47005930BA /* ServerEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1FCBCC2521FC44005930BA /* ServerEnvironmentTests.swift */; };
 		AB1FCBDC2521FCD5005930BA /* TestServerEnvironments.json in Resources */ = {isa = PBXBuildFile; fileRef = AB1FCBDB2521FCD5005930BA /* TestServerEnvironments.json */; };
+		AB453F602534B04400D8339E /* ExposureManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB453F5F2534B04400D8339E /* ExposureManagerTests.swift */; };
 		AB5F84AD24F8F7A1000400D4 /* SerialMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5F84AC24F8F7A1000400D4 /* SerialMigrator.swift */; };
 		AB5F84B024F8F7C3000400D4 /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5F84AF24F8F7C3000400D4 /* Migration.swift */; };
 		AB5F84B224F8F7E3000400D4 /* Migration0To1.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5F84B124F8F7E3000400D4 /* Migration0To1.swift */; };
@@ -873,6 +874,7 @@
 		AB1885D025238DAA00D39BBE /* OnboardingInfoViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInfoViewControllerTests.swift; sourceTree = "<group>"; };
 		AB1FCBCC2521FC44005930BA /* ServerEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerEnvironmentTests.swift; sourceTree = "<group>"; };
 		AB1FCBDB2521FCD5005930BA /* TestServerEnvironments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestServerEnvironments.json; sourceTree = "<group>"; };
+		AB453F5F2534B04400D8339E /* ExposureManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExposureManagerTests.swift; sourceTree = "<group>"; };
 		AB5F84AC24F8F7A1000400D4 /* SerialMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialMigrator.swift; sourceTree = "<group>"; };
 		AB5F84AF24F8F7C3000400D4 /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
 		AB5F84B124F8F7E3000400D4 /* Migration0To1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration0To1.swift; sourceTree = "<group>"; };
@@ -2321,6 +2323,7 @@
 			children = (
 				B15382DE248270B50010F007 /* Mocks */,
 				EE22DB8E247FB46C001B0A71 /* ENStateTests.swift */,
+				AB453F5F2534B04400D8339E /* ExposureManagerTests.swift */,
 				A17DA5E12486D8E7006F310F /* RiskLevelTests.swift */,
 				3598D99924FE280700483F1F /* CountryTests.swift */,
 				941F5ECB2518E82100785F06 /* ENSettingEuTracingViewModelTests.swift */,
@@ -3382,6 +3385,7 @@
 				51F1256024BEFB8F00126C86 /* HomeUnknown48hRiskCellConfiguratorTests.swift in Sources */,
 				EE22DB91247FB479001B0A71 /* MockStateHandlerObserverDelegate.swift in Sources */,
 				B1C7EE4624938EB700F1F284 /* ExposureDetection_DidEndPrematurelyReason+ErrorHandlingTests.swift in Sources */,
+				AB453F602534B04400D8339E /* ExposureManagerTests.swift in Sources */,
 				B10F9B8C249961CE00C418F4 /* UIFont+DynamicTypeTests.swift in Sources */,
 				01C2D4432501260D00FB23BF /* OptionGroupViewModelTests.swift in Sources */,
 				A173665324844F41006BE209 /* SQLiteKeyValueStoreTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -120,6 +120,7 @@ final class ENAExposureManager: NSObject, ExposureManager {
 	private weak var exposureManagerObserver: ENAExposureManagerObserver?
 	private var statusObservation: NSKeyValueObservation?
 	@objc private var manager: Manager
+	private var progress: Progress?
 
 	// MARK: Creating a Manager
 
@@ -207,9 +208,21 @@ final class ENAExposureManager: NSObject, ExposureManager {
 	/// Wrapper for `ENManager.detectExposures`
 	/// `ExposureManager` needs to be activated and enabled
 	func detectExposures(configuration: ENExposureConfiguration, diagnosisKeyURLs: [URL], completionHandler: @escaping ENDetectExposuresHandler) -> Progress {
-		manager.detectExposures(configuration: configuration, diagnosisKeyURLs: diagnosisKeyURLs) { summary, error in
+
+		// An exposure detection is currently running. Return current progress.
+		if let progress = progress, !progress.isCancelled && !progress.isFinished {
+			return progress
+		}
+
+		let _progress = manager.detectExposures(configuration: configuration, diagnosisKeyURLs: diagnosisKeyURLs) { [weak self] summary, error in
+			guard let self = self else { return }
+			self.progress = nil
 			completionHandler(summary, error)
 		}
+
+		progress = _progress
+
+		return _progress
 	}
 
 	// MARK: Diagnosis Keys

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ExposureManagerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/ExposureManagerTests.swift
@@ -1,0 +1,112 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import XCTest
+import ExposureNotification
+@testable import ENA
+
+class ExposureManagerTests: XCTestCase {
+
+	func test_GIVEN_RunningDetection_When_StartNewDetection_Then_SameProgressReturned() {
+		let managerSpy = ManagerSpy()
+		let exposureManager = ENAExposureManager(manager: managerSpy)
+
+		let progress1 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		let progress2 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		XCTAssertEqual(progress1, progress2)
+	}
+
+	func test_GIVEN_CanceledDetection_When_StartNewDetection_Then_NewProgressReturned() {
+		let managerSpy = ManagerSpy()
+		let exposureManager = ENAExposureManager(manager: managerSpy)
+
+		let progress1 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		progress1.cancel()
+
+		let progress2 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		XCTAssertNotEqual(progress1, progress2)
+	}
+
+	func test_GIVEN_FinishedDetection_When_StartNewDetection_Then_NewProgressReturned() {
+		let managerSpy = ManagerSpy()
+		let exposureManager = ENAExposureManager(manager: managerSpy)
+
+		let progress1 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		// Simulate isFinished state.
+		progress1.totalUnitCount = 1
+		progress1.completedUnitCount = 1
+
+		let progress2 = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		XCTAssertNotEqual(progress1, progress2)
+	}
+
+	func test_GIVEN_RunningDetection_When_StartNewDetection_Then_DetectExposuresNotCalled() {
+		let managerSpy = ManagerSpy()
+		let exposureManager = ENAExposureManager(manager: managerSpy)
+
+		_ = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		_ = exposureManager.detectExposures(configuration: ENExposureConfiguration(), diagnosisKeyURLs: []) { _, _ in
+		}
+
+		XCTAssertEqual(managerSpy.numberOfDetectionCalls, 1)
+	}
+}
+
+private final class ManagerSpy: NSObject, Manager {
+
+	static var authorizationStatus: ENAuthorizationStatus = .unknown
+
+	var numberOfDetectionCalls = 0
+
+	func detectExposures(configuration: ENExposureConfiguration, diagnosisKeyURLs: [URL], completionHandler: @escaping ENDetectExposuresHandler) -> Progress {
+		numberOfDetectionCalls += 1
+		return Progress()
+	}
+
+	func activate(completionHandler: @escaping ENErrorHandler) { }
+
+	func invalidate() { }
+
+	var invalidationHandler: (() -> Void)?
+
+	var exposureNotificationEnabled: Bool = false
+
+	func setExposureNotificationEnabled(_ enabled: Bool, completionHandler: @escaping ENErrorHandler) { }
+
+	var exposureNotificationStatus: ENStatus = .unknown
+
+	func getDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) { }
+
+	func getTestDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) { }
+
+}


### PR DESCRIPTION
## Description
This PR fixes the ExposureManager so it is not starting an exposure detection when there is already one running.
Starting exposure detection while another one is running leads to empty logs like described in the story.

## Link to Jira
[3174](https://jira.itc.sap.com/browse/EXPOSUREAPP-3174)
