### PR TITLE
Add country loading to flow without stating symptoms

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -49,6 +49,9 @@ protocol ExposureSubmissionCoordinating: class {
 	func showWarnOthersScreen()
 	func showThankYouScreen()
 
+	// Temporarily added for quickfix: https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
+	func loadSupportedCountries(isLoading: @escaping (Bool) -> Void, onSuccess: @escaping () -> Void, onError: @escaping (ExposureSubmissionError) -> Void)
+
 }
 
 /// This delegate allows a class to be notified for life-cycle events of the coordinator.
@@ -251,6 +254,11 @@ extension ExposureSubmissionCoordinator {
 	func showThankYouScreen() {
 		let vc = createSuccessViewController()
 		push(vc)
+	}
+
+	// Temporarily added for quickfix: https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
+	func loadSupportedCountries(isLoading: @escaping (Bool) -> Void, onSuccess: @escaping () -> Void, onError: @escaping (ExposureSubmissionError) -> Void) {
+		model.loadSupportedCountries(isLoading: isLoading, onSuccess: onSuccess, onError: onError)
 	}
 
 	// MARK: - UI-related helpers.

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
@@ -103,7 +103,8 @@ class ExposureSubmissionCoordinatorModel {
 
 	private var symptomsOnset: SymptomsOnset = .noInformation
 
-	private func loadSupportedCountries(
+	// Temporarily set to internal for quickfix: https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
+	func loadSupportedCountries(
 		isLoading: @escaping (Bool) -> Void,
 		onSuccess: @escaping () -> Void,
 		onError: @escaping (ExposureSubmissionError) -> Void

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
@@ -232,7 +232,25 @@ extension ExposureSubmissionTestResultViewController {
 		switch result {
 		case .positive:
 			checkExposureSubmissionPreconditions { [weak self] in
-				self?.coordinator?.showWarnOthersScreen()
+				// Temporarily loading countries here as quickfix: https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
+				self?.coordinator?.loadSupportedCountries(
+					isLoading: { isLoading in
+						self?.navigationFooterItem?.isPrimaryButtonEnabled = !isLoading
+						self?.navigationFooterItem?.isSecondaryButtonEnabled = !isLoading
+						self?.navigationFooterItem?.isSecondaryButtonLoading = isLoading
+					},
+					onSuccess: {
+						self?.coordinator?.showWarnOthersScreen()
+					},
+					onError: { _ in
+						guard let self = self else { return }
+
+						let alert = self.setupErrorAlert(
+							message: ExposureSubmissionError.noAppConfiguration.localizedDescription
+						)
+						self.present(alert, animated: true)
+					}
+				)
 			}
 		case .pending:
 			deleteTest()

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionCoordinator.swift
@@ -52,4 +52,8 @@ class MockExposureSubmissionCoordinator: ExposureSubmissionCoordinating {
 	func showWarnEuropeTravelConfirmationScreen() { }
 
 	func showWarnEuropeCountrySelectionScreen() { }
+
+	// Temporarily added for quickfix: https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
+	func loadSupportedCountries(isLoading: @escaping (Bool) -> Void, onSuccess: @escaping () -> Void, onError: @escaping (ExposureSubmissionError) -> Void) { }
+	
 }


### PR DESCRIPTION
## Description
This adds a quick fix to load countries if the user selects not to go through the symptoms screens.

## Link to Jira
https://jira.itc.sap.com/browse/EXPOSUREAPP-3231
