### PR TITLE
Fix/exposure detection executor completion callbacks

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -198,17 +198,21 @@ extension DownloadedPackagesStore {
 				switch error {
 				case .sqlite_full:
 					completion(ExposureDetection.DidEndPrematurelyReason.noDiskSpace)
+					return
 				case .unknown:
 					completion(ExposureDetection.DidEndPrematurelyReason.unableToWriteDiagnosisKeys)
+					return
 				case .none:
-					completion(nil)
+					break
 				}
 			}
-			
+
 			let hours = daysAndHours.hours
 			hours.bucketsByHour.forEach { hour, bucket in
 				self.set(country: country, hour: hour, day: hours.day, package: bucket)
 			}
 		}
+
+		completion(nil)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -145,6 +145,70 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 		waitForExpectations(timeout: 2.0)
 	}
 
+	func testStoreDelta_CompletionCalledOnlyOnce() throws {
+		// Test the case where the exector is asked to store the latest DaysAndHours delta,
+		// and the server has new data. We expect that completion is only called once.
+
+		let downloadedPackageStore = DownloadedPackagesSQLLiteStore.openInMemory
+		let testDaysAndHours = DaysAndHours(days: ["2020-01-01", "2020-01-02"], hours: [])
+		let testPackage = try SAPDownloadedPackage.makePackage()
+		let completionExpectation = expectation(description: "Expect that the completion handler is called.")
+		completionExpectation.expectedFulfillmentCount = 1
+
+		let sut = ExposureDetectionExecutor.makeWith(
+			client: ClientMock(
+				availableDaysAndHours: testDaysAndHours,
+				downloadedPackage: testPackage),
+			packageStore: downloadedPackageStore
+		)
+
+		sut.exposureDetection(
+			country: "IT",
+			downloadAndStore: testDaysAndHours) { error in
+				defer { completionExpectation.fulfill() }
+				XCTAssertNil(error)
+
+				guard let storedPackage = downloadedPackageStore.package(for: "2020-01-01", country: "IT") else {
+					// We can't XCUnwrap here as completion handler closure cannot throw
+					XCTFail("Package store did not contain downloaded delta package!")
+					return
+				}
+
+				XCTAssertEqual(storedPackage.bin, testPackage.bin)
+				XCTAssertEqual(storedPackage.signature, testPackage.signature)
+		}
+		waitForExpectations(timeout: 2.0)
+	}
+
+	func testStoreDelta_WhenErrorHappens_ThenCompletionCalledOnlyOnce() throws {
+		// Test the case where the exector is asked to store the latest DaysAndHours delta.
+		// The packages store returns an error. We expect that completion is only called once.
+
+		let mockKeyValueStore = MockTestStore()
+		mockKeyValueStore.fakeSQLiteError = 13
+		let downloadedPackageStore = DownloadedPackagesSQLLiteStore.openInMemory
+		downloadedPackageStore.keyValueStore = mockKeyValueStore
+		let testDaysAndHours = DaysAndHours(days: ["2020-01-01", "2020-01-02"], hours: [])
+		let testPackage = try SAPDownloadedPackage.makePackage()
+		let completionExpectation = expectation(description: "Expect that the completion handler is called.")
+		completionExpectation.assertForOverFulfill = true
+
+		let sut = ExposureDetectionExecutor.makeWith(
+			client: ClientMock(
+				availableDaysAndHours: testDaysAndHours,
+				downloadedPackage: testPackage),
+			packageStore: downloadedPackageStore
+		)
+
+		sut.exposureDetection(
+			country: "IT",
+			downloadAndStore: testDaysAndHours) { error in
+				XCTAssertNotNil(error)
+				completionExpectation.fulfill()
+		}
+		waitForExpectations(timeout: 2.0)
+	}
+
 	// MARK: - Write Downloaded Package Tests
 
 	func testWriteDownloadedPackage_NoHourlyFetching() throws {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -176,6 +176,7 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 
 				XCTAssertEqual(storedPackage.bin, testPackage.bin)
 				XCTAssertEqual(storedPackage.signature, testPackage.signature)
+				XCTAssertEqual(downloadedPackageStore.allDays(country: "IT").count, 2)
 		}
 		waitForExpectations(timeout: 2.0)
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -191,7 +191,7 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 		let testDaysAndHours = DaysAndHours(days: ["2020-01-01", "2020-01-02"], hours: [])
 		let testPackage = try SAPDownloadedPackage.makePackage()
 		let completionExpectation = expectation(description: "Expect that the completion handler is called.")
-		completionExpectation.assertForOverFulfill = true
+		completionExpectation.expectedFulfillmentCount = 1
 
 		let sut = ExposureDetectionExecutor.makeWith(
 			client: ClientMock(


### PR DESCRIPTION
## Description
This PR streamlines the persistence of the keys and calls completion once when all keys are persisted.
This way the risk detection starts only when all keys are persisted.

## Link to Jira
[3242](https://jira.itc.sap.com/browse/EXPOSUREAPP-3242)
