### PR TITLE
Fix/3246 Correct Flow Logic in Onboarding

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		50DC527924FEB2AE00F6D8EB /* AppInformationDynamicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DC527824FEB2AE00F6D8EB /* AppInformationDynamicCell.swift */; };
 		50DC527B24FEB5CA00F6D8EB /* AppInformationModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DC527A24FEB5CA00F6D8EB /* AppInformationModelTest.swift */; };
 		50E3BE5A250127DF0033E2C7 /* AppInformationDynamicAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E3BE59250127DF0033E2C7 /* AppInformationDynamicAction.swift */; };
+		50F9130D253F1D7800DFE683 /* OnboardingPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F9130C253F1D7800DFE683 /* OnboardingPageType.swift */; };
 		51486D9F2484FC0200FCE216 /* HomeRiskLevelCellConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51486D9E2484FC0200FCE216 /* HomeRiskLevelCellConfigurator.swift */; };
 		51486DA22485101500FCE216 /* RiskInactiveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51486DA02485101500FCE216 /* RiskInactiveCollectionViewCell.swift */; };
 		51486DA32485101500FCE216 /* RiskInactiveCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 51486DA12485101500FCE216 /* RiskInactiveCollectionViewCell.xib */; };
@@ -665,6 +666,7 @@
 		50DC527824FEB2AE00F6D8EB /* AppInformationDynamicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationDynamicCell.swift; sourceTree = "<group>"; };
 		50DC527A24FEB5CA00F6D8EB /* AppInformationModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationModelTest.swift; sourceTree = "<group>"; };
 		50E3BE59250127DF0033E2C7 /* AppInformationDynamicAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationDynamicAction.swift; sourceTree = "<group>"; };
+		50F9130C253F1D7800DFE683 /* OnboardingPageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageType.swift; sourceTree = "<group>"; };
 		5111E7622460BB1500ED6498 /* HomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInteractor.swift; sourceTree = "<group>"; };
 		51486D9E2484FC0200FCE216 /* HomeRiskLevelCellConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRiskLevelCellConfigurator.swift; sourceTree = "<group>"; };
 		51486DA02485101500FCE216 /* RiskInactiveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiskInactiveCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1526,6 +1528,7 @@
 				51C737BC245B349700286105 /* OnboardingInfoViewController.swift */,
 				A17366542484978A006BE209 /* OnboardingInfoViewControllerUtils.swift */,
 				137846482488027500A50AB8 /* OnboardingInfoViewController+Extension.swift */,
+				50F9130C253F1D7800DFE683 /* OnboardingPageType.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -3092,6 +3095,7 @@
 				2FA9E39524D2F2B00030561C /* ExposureSubmission+DeviceRegistrationKey.swift in Sources */,
 				A3FF84EC247BFAF00053E947 /* Hasher.swift in Sources */,
 				51895EDC245E16CD0085DA38 /* ENAColor.swift in Sources */,
+				50F9130D253F1D7800DFE683 /* OnboardingPageType.swift in Sources */,
 				A372DA3B24BDA075003248BB /* ExposureSubmissionCoordinator.swift in Sources */,
 				51FE277B2475340300BB8144 /* HomeRiskLoadingItemViewConfigurator.swift in Sources */,
 				0D5611B4247F852C00B5B094 /* SQLiteKeyValueStore.swift in Sources */,
@@ -4163,141 +4167,6 @@
 			};
 			name = AdHoc;
 		};
-		01DE5A74248E3CF800F6D7F2 /* UITesting */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG UITESTING";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = UITesting;
-		};
-		01DE5A75248E3CF800F6D7F2 /* UITesting */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = "${PROJECT}/Resources/ENACommunity.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = $IPHONE_APP_DEV_TEAM;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-					"SQLITE_HAS_CODEC=1",
-				);
-				INFOPLIST_FILE = ENA/Resources/Info.plist;
-				IPHONE_APP_CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONE_APP_DEV_TEAM = 523TP53AQF;
-				IPHONE_APP_DIST_PROF_SPECIFIER = "";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.6.0;
-				OTHER_CFLAGS = (
-					"-DSQLITE_HAS_CODEC",
-					"-DSQLITE_TEMP_STORE=3",
-					"-DSQLCIPHER_CRYPTO_CC",
-					"-DNDEBUG",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "de.rki.coronawarnapp-dev";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DISABLE_CERTIFICATE_PINNING";
-				SWIFT_OBJC_BRIDGING_HEADER = "ENA-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = UITesting;
-		};
-		01DE5A76248E3CF800F6D7F2 /* UITesting */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 523TP53AQF;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"SQLITE_HAS_CODEC=1",
-				);
-				INFOPLIST_FILE = ENATests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				OTHER_CFLAGS = (
-					"-DSQLITE_TEMP_STORE=3",
-					"-DSQLCIPHER_CRYPTO_CC",
-					"-DNDEBUG",
-					"-DSQLITE_HAS_CODEC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = de.rki.coronawarnapp.sqlite;
-				PRODUCT_NAME = CWASQLite;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = AdHoc;
-		};
 		85D7596624570491008175F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4689,48 +4558,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Community;
-		};
-		B1FF6B712497D0B50041CF02 /* UITesting */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CODE_SIGNING_REQUIRED = NO;
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DISABLE_CERTIFICATE_PINNING=1",
-					"SQLITE_HAS_CODEC=1",
-				);
-				INFOPLIST_FILE = CWASQLite/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				OTHER_CFLAGS = (
-					"-DSQLITE_TEMP_STORE=3",
-					"-DSQLCIPHER_CRYPTO_CC",
-					"-DNDEBUG",
-					"-DSQLITE_HAS_CODEC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = de.rki.coronawarnapp.sqlite;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
-				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = UITesting;
 		};
 		B1FF6B722497D0B50041CF02 /* Release */ = {
 			isa = XCBuildConfiguration;

--- a/src/xcode/ENA/ENA/Source/Models/Onboarding/OnboardingInfo.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Onboarding/OnboardingInfo.swift
@@ -32,6 +32,7 @@ struct OnboardingInfo {
 	var link: String
 	var linkDisplayText: String
 	var actionText: String
+	var alternativeActionText: String
 	var ignoreText: String
 	var titleAccessibilityIdentifier: String?
 	var imageAccessibilityIdentifier: String?
@@ -51,6 +52,7 @@ extension OnboardingInfo {
 			link: AppStrings.Onboarding.onboardingInfo_togetherAgainstCoronaPage_link,
 			linkDisplayText: AppStrings.Onboarding.onboardingInfo_togetherAgainstCoronaPage_linkText,
 			actionText: AppStrings.Onboarding.onboardingLetsGo,
+			alternativeActionText: "",
 			ignoreText: "",
 			titleAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_togetherAgainstCoronaPage_title,
 			imageAccessibilityIdentifier:
@@ -69,6 +71,7 @@ extension OnboardingInfo {
 			link: "",
 			linkDisplayText: "",
 			actionText: AppStrings.Onboarding.onboardingContinue,
+			alternativeActionText: "",
 			ignoreText: "",
 			titleAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_privacyPage_title,
 			imageAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_privacyPage_imageDescription,
@@ -91,6 +94,7 @@ extension OnboardingInfo {
 			link: "",
 			linkDisplayText: "",
 			actionText: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_button,
+			alternativeActionText: AppStrings.Onboarding.onboardingContinue,
 			ignoreText: AppStrings.Onboarding.onboardingDoNotActivate,
 			titleAccessibilityIdentifier:
 			AccessibilityIdentifiers.Onboarding.onboardingInfo_privacyPage_title,
@@ -109,6 +113,7 @@ extension OnboardingInfo {
 			link: "",
 			linkDisplayText: "",
 			actionText: AppStrings.Onboarding.onboardingContinue,
+			alternativeActionText: "",
 			ignoreText: "",
 			titleAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_howDoesDataExchangeWorkPage_title,
 			imageAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_howDoesDataExchangeWorkPage_imageDescription,
@@ -126,6 +131,7 @@ extension OnboardingInfo {
 			link: "",
 			linkDisplayText: "",
 			actionText: AppStrings.Onboarding.onboardingContinue,
+			alternativeActionText: "",
 			ignoreText: AppStrings.Onboarding.onboardingDoNotAllow,
 			titleAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_alwaysStayInformedPage_title,
 			imageAccessibilityIdentifier: AccessibilityIdentifiers.Onboarding.onboardingInfo_alwaysStayInformedPage_imageDescription,

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
@@ -19,24 +19,6 @@
 
 import UIKit
 
-
-enum OnboardingPageType: Int, CaseIterable {
-	case togetherAgainstCoronaPage = 0
-	case privacyPage = 1
-	case enableLoggingOfContactsPage = 2
-	case howDoesDataExchangeWorkPage = 3
-	case alwaysStayInformedPage = 4
-
-	func next() -> OnboardingPageType? {
-		OnboardingPageType(rawValue: rawValue + 1)
-	}
-
-	func isLast() -> Bool {
-		(self == OnboardingPageType.allCases.last)
-	}
-}
-
-
 extension OnboardingInfoViewController {
 
 	func addPanel(

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
@@ -19,6 +19,24 @@
 
 import UIKit
 
+
+enum OnboardingPageType: Int, CaseIterable {
+	case togetherAgainstCoronaPage = 0
+	case privacyPage = 1
+	case enableLoggingOfContactsPage = 2
+	case howDoesDataExchangeWorkPage = 3
+	case alwaysStayInformedPage = 4
+
+	func next() -> OnboardingPageType? {
+		OnboardingPageType(rawValue: rawValue + 1)
+	}
+
+	func isLast() -> Bool {
+		(self == OnboardingPageType.allCases.last)
+	}
+}
+
+
 extension OnboardingInfoViewController {
 
 	func addPanel(
@@ -32,7 +50,6 @@ extension OnboardingInfoViewController {
 		itemSpacing: CGFloat = 10
 	) {
 
-		// MARK: - Title label.
 		let titleLabel = ENALabel()
 		titleLabel.style = titleStyle
 		titleLabel.text = title
@@ -41,7 +58,6 @@ extension OnboardingInfoViewController {
 		titleLabel.lineBreakMode = .byWordWrapping
 		titleLabel.numberOfLines = 0
 
-		// MARK: - Text label.
 		let textLabel = ENALabel()
 		textLabel.style = bodyStyle
 		textLabel.text = body
@@ -50,7 +66,6 @@ extension OnboardingInfoViewController {
 		textLabel.lineBreakMode = .byWordWrapping
 		textLabel.numberOfLines = 0
 
-		// MARK: - Stackview for labels.
 		let labelStackView = UIStackView(arrangedSubviews: [titleLabel, textLabel])
 		labelStackView.translatesAutoresizingMaskIntoConstraints = false
 		labelStackView.axis = .vertical
@@ -58,7 +73,6 @@ extension OnboardingInfoViewController {
 		labelStackView.distribution = .equalSpacing
 		labelStackView.spacing = itemSpacing
 
-		// MARK: - Container for entire view.
 		let containerView = UIView()
 		containerView.addSubview(labelStackView)
 		containerView.layer.cornerRadius = 14.0
@@ -102,7 +116,6 @@ extension OnboardingInfoViewController {
 
 		let containerView = UIView()
 
-		// MARK: - Create country table.
 		let countryListView = UIStackView()
 		countryListView.translatesAutoresizingMaskIntoConstraints = false
 		countryListView.axis = .vertical
@@ -111,7 +124,6 @@ extension OnboardingInfoViewController {
 		countryListView.spacing = 7.5
 		containerView.addSubview(countryListView)
 
-		// MARK: - Create title label.
 		let titleLabel = ENALabel()
 		titleLabel.style = .headline
 		titleLabel.text = title
@@ -122,18 +134,15 @@ extension OnboardingInfoViewController {
 		containerView.addSubview(titleLabel)
 
 		for (index, country) in countries.enumerated() {
-			// MARK: - Create stack view to hold label and flag for country.
 			let stackView = UIStackView()
 			stackView.axis = .horizontal
 			stackView.alignment = .center
 			stackView.spacing = 13
 
-			// MARK: - Country name.
 			let label = ENALabel()
 			label.style = .body
 			label.text = country.localizedName
 
-			// MARK: - Country flag.
 			let image = UIImageView(image: country.flag)
 			image.widthAnchor.constraint(equalToConstant: 28).isActive = true
 			image.contentMode = .scaleAspectFit
@@ -142,7 +151,6 @@ extension OnboardingInfoViewController {
 			stackView.addArrangedSubview(label)
 			countryListView.addArrangedSubview(stackView)
 
-			// MARK: - Add separator inbetween each.
 			if index == countries.count - 1 { break }
 			let separator = UIView()
 			separator.backgroundColor = .enaColor(for: .hairline)
@@ -185,5 +193,26 @@ extension OnboardingInfoViewController {
 		let containerView = createCountrySection(title: title, countries: countries)
 		stackView.addArrangedSubview(containerView)
 	}
+
+}
+
+
+extension OnboardingInfoViewController: UITextViewDelegate {
+	func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+		LinkHelper.openLink(withUrl: url, from: self)
+		return false
+	}
+}
+
+
+extension OnboardingInfoViewController: NavigationBarOpacityDelegate {
+	var preferredNavigationBarOpacity: CGFloat {
+		let alpha = (scrollView.adjustedContentInset.top + scrollView.contentOffset.y) / scrollView.adjustedContentInset.top
+		return max(0, min(alpha, 1))
+	}
+}
+
+
+extension OnboardingInfoViewController: RequiresAppDependencies {
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
@@ -178,6 +178,7 @@ extension OnboardingInfoViewController {
 
 }
 
+// MARK: - Protocol UITextViewDelegate
 
 extension OnboardingInfoViewController: UITextViewDelegate {
 	func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
@@ -186,6 +187,7 @@ extension OnboardingInfoViewController: UITextViewDelegate {
 	}
 }
 
+// MARK: - Protocol NavigationBarOpacityDelegate
 
 extension OnboardingInfoViewController: NavigationBarOpacityDelegate {
 	var preferredNavigationBarOpacity: CGFloat {
@@ -194,6 +196,7 @@ extension OnboardingInfoViewController: NavigationBarOpacityDelegate {
 	}
 }
 
+// MARK: - Protocol RequiresAppDependencies
 
 extension OnboardingInfoViewController: RequiresAppDependencies {
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -22,22 +22,8 @@ import ExposureNotification
 
 final class OnboardingInfoViewController: UIViewController {
 
-	@IBOutlet var imageView: UIImageView!
-	@IBOutlet var stateHeaderLabel: ENALabel!
-	@IBOutlet var stateTitleLabel: ENALabel!
-	@IBOutlet var stateStateLabel: ENALabel!
-	@IBOutlet var titleLabel: UILabel!
-	@IBOutlet var boldLabel: UILabel!
-	@IBOutlet var textLabel: UILabel!
-	@IBOutlet var linkTextView: UITextView!
-	@IBOutlet var nextButton: ENAButton!
-	@IBOutlet var ignoreButton: ENAButton!
-
 	@IBOutlet var scrollView: UIScrollView!
 	@IBOutlet var stackView: UIStackView!
-	@IBOutlet var stateView: UIView!
-	@IBOutlet var innerStackView: UIStackView!
-	@IBOutlet var footerView: UIView!
 	
 	// MARK: - Init
 	
@@ -93,6 +79,20 @@ final class OnboardingInfoViewController: UIViewController {
 
 	// MARK: - Private
 	
+	@IBOutlet private var imageView: UIImageView!
+	@IBOutlet private var stateHeaderLabel: ENALabel!
+	@IBOutlet private var stateTitleLabel: ENALabel!
+	@IBOutlet private var stateStateLabel: ENALabel!
+	@IBOutlet private var titleLabel: UILabel!
+	@IBOutlet private var boldLabel: UILabel!
+	@IBOutlet private var textLabel: UILabel!
+	@IBOutlet private var linkTextView: UITextView!
+	@IBOutlet private var nextButton: ENAButton!
+	@IBOutlet private var ignoreButton: ENAButton!
+	@IBOutlet private var stateView: UIView!
+	@IBOutlet private var innerStackView: UIStackView!
+	@IBOutlet private var footerView: UIView!
+
 	private var pageType: OnboardingPageType
 	private var exposureManager: ExposureManager
 	private var store: Store

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -75,26 +75,6 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 
 
-	@IBAction func didTapNextButton(_: Any) {
-		nextButton.isUserInteractionEnabled = false
-		runActionForPageType(
-			completion: { [weak self] in
-				self?.gotoNextScreen()
-				self?.nextButton.isUserInteractionEnabled = true
-			}
-		)
-	}
-
-
-	@IBAction func didTapIgnoreButton(_: Any) {
-		runIgnoreActionForPageType(
-			completion: {
-				self.gotoNextScreen()
-			}
-		)
-	}
-
-	
 	// MARK: - Overrides
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -197,6 +177,26 @@ final class OnboardingInfoViewController: UIViewController {
 	
 	
 	// MARK: - Private
+	@IBAction private func didTapNextButton(_: Any) {
+		nextButton.isUserInteractionEnabled = false
+		runActionForPageType(
+			completion: { [weak self] in
+				self?.gotoNextScreen()
+				self?.nextButton.isUserInteractionEnabled = true
+			}
+		)
+	}
+
+
+	@IBAction private func didTapIgnoreButton(_: Any) {
+		runIgnoreActionForPageType(
+			completion: {
+				self.gotoNextScreen()
+			}
+		)
+	}
+
+
 	private func openSettings() {
 		guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
 		UIApplication.shared.open(url, options: [:], completionHandler: nil)

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -40,6 +40,7 @@ final class OnboardingInfoViewController: UIViewController {
 	@IBOutlet var footerView: UIView!
 	
 	// MARK: - Init
+	
 	init?(
 		coder: NSCoder,
 		pageType: OnboardingPageType,
@@ -62,6 +63,7 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 
 	// MARK: - Overrides
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		onboardingInfo = onboardingInfos[pageType.rawValue]
@@ -89,6 +91,7 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 	
 	// MARK: - Public
+	
 	func runActionForPageType(completion: @escaping () -> Void) {
 		switch pageType {
 		case .privacyPage:
@@ -155,6 +158,7 @@ final class OnboardingInfoViewController: UIViewController {
 	}
 	
 	// MARK: - Private
+	
 	private var pageType: OnboardingPageType
 	private var exposureManager: ExposureManager
 	private var store: Store

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -38,18 +38,6 @@ final class OnboardingInfoViewController: UIViewController {
 	@IBOutlet var stateView: UIView!
 	@IBOutlet var innerStackView: UIStackView!
 	@IBOutlet var footerView: UIView!
-
-	private var pageType: OnboardingPageType
-	private var exposureManager: ExposureManager
-	private var store: Store
-	private var htmlTextView: HtmlTextView?
-	private var onboardingInfo: OnboardingInfo?
-	private var supportedCountries: [Country]?
-	private var client: Client
-
-	private var pageSetupDone = false
-	private var onboardingInfos = OnboardingInfo.testData()
-	private var exposureManagerActivated = false
 	
 	
 	// MARK: - Init
@@ -177,6 +165,18 @@ final class OnboardingInfoViewController: UIViewController {
 	
 	
 	// MARK: - Private
+	private var pageType: OnboardingPageType
+	private var exposureManager: ExposureManager
+	private var store: Store
+	private var htmlTextView: HtmlTextView?
+	private var onboardingInfo: OnboardingInfo?
+	private var supportedCountries: [Country]?
+	private var client: Client
+	private var pageSetupDone = false
+	private var onboardingInfos = OnboardingInfo.testData()
+	private var exposureManagerActivated = false
+
+
 	@IBAction private func didTapNextButton(_: Any) {
 		nextButton.isUserInteractionEnabled = false
 		runActionForPageType(

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -185,6 +185,7 @@ final class OnboardingInfoViewController: UIViewController {
 		let exposureNotificationsNotSet = exposureManagerState.status == .unknown || exposureManagerState.status == .bluetoothOff
 		let exposureNotificationsEnabled = exposureManagerState.enabled
 		let exposureNotificationsDisabled = !exposureNotificationsEnabled && !exposureNotificationsNotSet
+		// show state of "Expoure Logging" when it has been enabled by the user
 		let showStateView = onboardingInfo.showState && !exposureNotificationsNotSet
 
 		// swiftlint:disable force_unwrapping
@@ -227,7 +228,9 @@ final class OnboardingInfoViewController: UIViewController {
 		stateStateLabel.text = exposureNotificationsEnabled ? onboardingInfo.stateActivated : onboardingInfo.stateDeactivated
 
 		guard !pageSetupDone else {
-			if pageType == .enableLoggingOfContactsPage && exposureManagerState.status == .active {
+			// Back button tapped
+			// If "logging of contacts" has been enabled then display alternative text on buttom
+			if pageType == .enableLoggingOfContactsPage && showStateView {
 				nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
 			}
 			return
@@ -235,7 +238,7 @@ final class OnboardingInfoViewController: UIViewController {
 
 		switch pageType {
 		case .enableLoggingOfContactsPage:
-			if exposureManagerState.status == .active {
+			if showStateView {
 				nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
 			}
 			addParagraph(

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -211,7 +211,11 @@ final class OnboardingInfoViewController: UIViewController {
 			linkTextView.isHidden = true
 		}
 
-		nextButton.setTitle(onboardingInfo.actionText, for: .normal)
+		if pageType == .enableLoggingOfContactsPage && showStateView {
+			nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
+		} else {
+			nextButton.setTitle(onboardingInfo.actionText, for: .normal)
+		}
 		nextButton.isHidden = onboardingInfo.actionText.isEmpty
 
 		ignoreButton.setTitle(onboardingInfo.ignoreText, for: .normal)
@@ -222,10 +226,6 @@ final class OnboardingInfoViewController: UIViewController {
 		stateHeaderLabel.text = onboardingInfo.stateHeader?.uppercased()
 		stateTitleLabel.text = onboardingInfo.stateTitle
 		stateStateLabel.text = exposureNotificationsEnabled ? onboardingInfo.stateActivated : onboardingInfo.stateDeactivated
-
-		if pageType == .enableLoggingOfContactsPage && showStateView {
-			nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
-		}
 		
 		if pageSetupDone {
 			return

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -39,7 +39,6 @@ final class OnboardingInfoViewController: UIViewController {
 	@IBOutlet var innerStackView: UIStackView!
 	@IBOutlet var footerView: UIView!
 	
-	
 	// MARK: - Init
 	init?(
 		coder: NSCoder,
@@ -62,7 +61,6 @@ final class OnboardingInfoViewController: UIViewController {
 		fatalError("init(coder:) has intentionally not been implemented")
 	}
 
-
 	// MARK: - Overrides
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -76,14 +74,12 @@ final class OnboardingInfoViewController: UIViewController {
 		if pageType == .togetherAgainstCoronaPage { loadCountryList() }
 	}
 
-	
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
 
 		let preconditions = exposureManager.preconditions()
 		updateUI(exposureManagerState: preconditions)
 	}
-
 	
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
@@ -91,7 +87,6 @@ final class OnboardingInfoViewController: UIViewController {
 		scrollView.contentInset.bottom = footerView.frame.height - scrollView.safeAreaInsets.bottom
 		scrollView.verticalScrollIndicatorInsets.bottom = scrollView.contentInset.bottom
 	}
-
 	
 	// MARK: - Public
 	func runActionForPageType(completion: @escaping () -> Void) {
@@ -117,7 +112,6 @@ final class OnboardingInfoViewController: UIViewController {
 			completion()
 		}
 	}
-
 	
 	func runIgnoreActionForPageType(completion: @escaping () -> Void) {
 		guard pageType == .enableLoggingOfContactsPage, !exposureManager.preconditions().authorized else {
@@ -130,7 +124,6 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 		present(alert, animated: true, completion: nil)
 	}
-
 	
 	func setupAccessibility() {
 		imageView.isAccessibilityElement = true
@@ -148,7 +141,6 @@ final class OnboardingInfoViewController: UIViewController {
 		ignoreButton.isAccessibilityElement = true
 	}
 
-	
 	func addSkipAccessibilityActionToHeader() {
 		titleLabel.accessibilityHint = AppStrings.Onboarding.onboardingContinueDescription
 		let actionName = AppStrings.Onboarding.onboardingContinue
@@ -157,12 +149,10 @@ final class OnboardingInfoViewController: UIViewController {
 		htmlTextView?.accessibilityCustomActions = [skipAction]
 	}
 
-	
 	@objc
 	func skip(_ sender: Any) {
 		didTapNextButton(sender)
 	}
-	
 	
 	// MARK: - Private
 	private var pageType: OnboardingPageType
@@ -176,7 +166,6 @@ final class OnboardingInfoViewController: UIViewController {
 	private var onboardingInfos = OnboardingInfo.testData()
 	private var exposureManagerActivated = false
 
-
 	@IBAction private func didTapNextButton(_: Any) {
 		nextButton.isUserInteractionEnabled = false
 		runActionForPageType(
@@ -187,7 +176,6 @@ final class OnboardingInfoViewController: UIViewController {
 		)
 	}
 
-
 	@IBAction private func didTapIgnoreButton(_: Any) {
 		runIgnoreActionForPageType(
 			completion: {
@@ -196,19 +184,17 @@ final class OnboardingInfoViewController: UIViewController {
 		)
 	}
 
-
 	private func openSettings() {
 		guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
 		UIApplication.shared.open(url, options: [:], completionHandler: nil)
 	}
 
-	
+
 	private func showError(_ error: ExposureNotificationError, from viewController: UIViewController, completion: (() -> Void)?) {
 		let alert = UIAlertController(title: AppStrings.ExposureSubmission.generalErrorTitle, message: String(describing: error), preferredStyle: .alert)
 		alert.addAction(UIAlertAction(title: AppStrings.Common.alertActionOk, style: .cancel))
 		viewController.present(alert, animated: true, completion: completion)
 	}
-
 
 	private func gotoNextScreen() {
 		guard let nextPageType = pageType.next() else {
@@ -230,7 +216,6 @@ final class OnboardingInfoViewController: UIViewController {
 		navigationController?.pushViewController(next!, animated: true)
 	}
 
-
 	private func loadCountryList() {
 		appConfigurationProvider.appConfiguration { [weak self] result in
 			var supportedCountryIDs: [String]
@@ -249,7 +234,6 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 	}
 
-	
 	private func updateUI(exposureManagerState: ExposureManagerState) {
 		guard isViewLoaded else { return }
 		guard let onboardingInfo = onboardingInfo else { return }
@@ -312,7 +296,6 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 	}
 
-    
 	private func setupPage() {
 		switch pageType {
 		case .enableLoggingOfContactsPage:
@@ -348,7 +331,6 @@ final class OnboardingInfoViewController: UIViewController {
 		pageSetupDone = true
 	}
 	
-	
 	private func persistTimestamp(completion: (() -> Void)?) {
 		if let acceptedDate = store.dateOfAcceptedPrivacyNotice {
 			Log.warning("User has already accepted the privacy terms on \(acceptedDate)", log: .localData)
@@ -359,7 +341,6 @@ final class OnboardingInfoViewController: UIViewController {
 		Log.info("Persist that user accepted the privacy terms on \(Date())", log: .localData)
 		completion?()
 	}
-
 
 	private func askExposureNotificationsPermissions(completion: (() -> Void)?) {
 		#if DEBUG
@@ -423,14 +404,12 @@ final class OnboardingInfoViewController: UIViewController {
 		}
 	}
 
-	
 	private func askLocalNotificationsPermissions(completion: (() -> Void)?) {
 		exposureManager.requestUserNotificationsPermissions {
 			completion?()
 			return
 		}
 	}
-
 
 	private func finishOnBoarding() {
 		store.isOnboarded = true

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -227,11 +227,17 @@ final class OnboardingInfoViewController: UIViewController {
 		stateStateLabel.text = exposureNotificationsEnabled ? onboardingInfo.stateActivated : onboardingInfo.stateDeactivated
 
 		guard !pageSetupDone else {
+			if pageType == .enableLoggingOfContactsPage && exposureManagerState.status == .active {
+				nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
+			}
 			return
 		}
 
 		switch pageType {
 		case .enableLoggingOfContactsPage:
+			if exposureManagerState.status == .active {
+				nextButton.setTitle(onboardingInfo.alternativeActionText, for: .normal)
+			}
 			addParagraph(
 				title: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_euTitle,
 				body: AppStrings.Onboarding.onboardingInfo_enableLoggingOfContactsPage_euDescription

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -90,73 +90,7 @@ final class OnboardingInfoViewController: UIViewController {
 		scrollView.verticalScrollIndicatorInsets.bottom = scrollView.contentInset.bottom
 	}
 	
-	// MARK: - Public
-	
-	func runActionForPageType(completion: @escaping () -> Void) {
-		switch pageType {
-		case .privacyPage:
-			persistTimestamp(completion: completion)
-		case .enableLoggingOfContactsPage:
-			func handleBluetooth(completion: @escaping () -> Void) {
-				if let alertController = self.exposureManager.alertForBluetoothOff(completion: { completion() }) {
-					self.present(alertController, animated: true)
-				}
-				completion()
-			}
-			askExposureNotificationsPermissions(completion: {
-				handleBluetooth {
-					completion()
-				}
-			})
 
-		case .alwaysStayInformedPage:
-			askLocalNotificationsPermissions(completion: completion)
-		default:
-			completion()
-		}
-	}
-	
-	func runIgnoreActionForPageType(completion: @escaping () -> Void) {
-		guard pageType == .enableLoggingOfContactsPage, !exposureManager.preconditions().authorized else {
-			completion()
-			return
-		}
-
-		let alert = OnboardingInfoViewControllerUtils.setupExposureConfirmationAlert {
-			completion()
-		}
-		present(alert, animated: true, completion: nil)
-	}
-	
-	func setupAccessibility() {
-		imageView.isAccessibilityElement = true
-		imageView.accessibilityLabel = onboardingInfo?.imageDescription
-		imageView.accessibilityIdentifier = onboardingInfo?.imageAccessibilityIdentifier
-		titleLabel.isAccessibilityElement = true
-		titleLabel.accessibilityIdentifier = onboardingInfo?.titleAccessibilityIdentifier
-		titleLabel.accessibilityTraits = .header
-		boldLabel.isAccessibilityElement = true
-		textLabel.isAccessibilityElement = true
-		linkTextView.isAccessibilityElement = true
-		nextButton.isAccessibilityElement = true
-		nextButton.accessibilityIdentifier = onboardingInfo?.actionTextAccessibilityIdentifier
-		ignoreButton.accessibilityIdentifier = onboardingInfo?.ignoreTextAccessibilityIdentifier
-		ignoreButton.isAccessibilityElement = true
-	}
-
-	func addSkipAccessibilityActionToHeader() {
-		titleLabel.accessibilityHint = AppStrings.Onboarding.onboardingContinueDescription
-		let actionName = AppStrings.Onboarding.onboardingContinue
-		let skipAction = UIAccessibilityCustomAction(name: actionName, target: self, selector: #selector(skip(_:)))
-		titleLabel.accessibilityCustomActions = [skipAction]
-		htmlTextView?.accessibilityCustomActions = [skipAction]
-	}
-
-	@objc
-	func skip(_ sender: Any) {
-		didTapNextButton(sender)
-	}
-	
 	// MARK: - Private
 	
 	private var pageType: OnboardingPageType
@@ -421,5 +355,70 @@ final class OnboardingInfoViewController: UIViewController {
 
 		NotificationCenter.default.post(name: .isOnboardedDidChange, object: nil)
 	}
+	
+	private func runActionForPageType(completion: @escaping () -> Void) {
+		switch pageType {
+		case .privacyPage:
+			persistTimestamp(completion: completion)
+		case .enableLoggingOfContactsPage:
+			func handleBluetooth(completion: @escaping () -> Void) {
+				if let alertController = self.exposureManager.alertForBluetoothOff(completion: { completion() }) {
+					self.present(alertController, animated: true)
+				}
+				completion()
+			}
+			askExposureNotificationsPermissions(completion: {
+				handleBluetooth {
+					completion()
+				}
+			})
 
+		case .alwaysStayInformedPage:
+			askLocalNotificationsPermissions(completion: completion)
+		default:
+			completion()
+		}
+	}
+	
+	private func runIgnoreActionForPageType(completion: @escaping () -> Void) {
+		guard pageType == .enableLoggingOfContactsPage, !exposureManager.preconditions().authorized else {
+			completion()
+			return
+		}
+
+		let alert = OnboardingInfoViewControllerUtils.setupExposureConfirmationAlert {
+			completion()
+		}
+		present(alert, animated: true, completion: nil)
+	}
+	
+	private func setupAccessibility() {
+		imageView.isAccessibilityElement = true
+		imageView.accessibilityLabel = onboardingInfo?.imageDescription
+		imageView.accessibilityIdentifier = onboardingInfo?.imageAccessibilityIdentifier
+		titleLabel.isAccessibilityElement = true
+		titleLabel.accessibilityIdentifier = onboardingInfo?.titleAccessibilityIdentifier
+		titleLabel.accessibilityTraits = .header
+		boldLabel.isAccessibilityElement = true
+		textLabel.isAccessibilityElement = true
+		linkTextView.isAccessibilityElement = true
+		nextButton.isAccessibilityElement = true
+		nextButton.accessibilityIdentifier = onboardingInfo?.actionTextAccessibilityIdentifier
+		ignoreButton.accessibilityIdentifier = onboardingInfo?.ignoreTextAccessibilityIdentifier
+		ignoreButton.isAccessibilityElement = true
+	}
+
+	private func addSkipAccessibilityActionToHeader() {
+		titleLabel.accessibilityHint = AppStrings.Onboarding.onboardingContinueDescription
+		let actionName = AppStrings.Onboarding.onboardingContinue
+		let skipAction = UIAccessibilityCustomAction(name: actionName, target: self, selector: #selector(skip(_:)))
+		titleLabel.accessibilityCustomActions = [skipAction]
+		htmlTextView?.accessibilityCustomActions = [skipAction]
+	}
+
+	@objc
+	private func skip(_ sender: Any) {
+		didTapNextButton(sender)
+	}
+	
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingPageType.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingPageType.swift
@@ -1,0 +1,35 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors /
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+
+enum OnboardingPageType: Int, CaseIterable {
+	case togetherAgainstCoronaPage = 0
+	case privacyPage = 1
+	case enableLoggingOfContactsPage = 2
+	case howDoesDataExchangeWorkPage = 3
+	case alwaysStayInformedPage = 4
+
+	func next() -> OnboardingPageType? {
+		OnboardingPageType(rawValue: rawValue + 1)
+	}
+
+	func isLast() -> Bool {
+		(self == OnboardingPageType.allCases.last)
+	}
+}


### PR DESCRIPTION
## Description
Fixes a bug in the onboarding flow logic. Once the user has enabled logging of contacts then the button "Activate Exposure Logging" is not displayed any more when navigating back and forth in the onboarding process.

### How to Test
1 Onboarding Screen 3 - How to make exposure logging possible: Select "Do Not Activate".
2 on the next screen tap "Back".
3 Onboarding Screen 3: both buttons are displayed. Scroll down to the bottom of the view and check the content of screen 3.
4 Tap on "Activate Exposure Logging" (Screenshot 1).
5 On the next screen tap "Back" (Screenshot 2).
6 Onboarding Screen 3: only one button is displayed (Screenshot 3).
7 Scroll down to the bottom of the view and verify the content of screen 3 is still OK.

## Link to Jira
Story: https://jira.itc.sap.com/browse/EXPOSUREAPP-1692 
Task: https://jira.itc.sap.com/browse/EXPOSUREAPP-3246

## Screenshots
### Screenshot 1
![IMG_0037](https://user-images.githubusercontent.com/7896005/96157096-26d12200-0f12-11eb-8521-2694f3710dfc.PNG)
### Screenshot 2
![IMG_0038](https://user-images.githubusercontent.com/7896005/96157115-2d5f9980-0f12-11eb-9dbf-5d6aec843149.PNG)
### Screenshot 3
![IMG_0039](https://user-images.githubusercontent.com/7896005/96157145-35b7d480-0f12-11eb-8c2d-5c72fb21f640.PNG)

