### PR TITLE
Fix/dead man switch backport from 1.6

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		EB2394A024E5492900E71225 /* BackgroundAppRefreshViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB23949F24E5492900E71225 /* BackgroundAppRefreshViewModel.swift */; };
 		EB3BCA882507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3BCA872507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift */; };
 		EB3BCA8C2507C3B0003F27C7 /* DynamicTableViewBulletPointCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3BCA85250799E7003F27C7 /* DynamicTableViewBulletPointCell.swift */; };
+		EB6B5D8325398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6B5D8225398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift */; };
 		EB7057D724E6BACA002235B4 /* InfoBoxView.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB7057D624E6BACA002235B4 /* InfoBoxView.xib */; };
 		EB7D205424E6A3320089264C /* InfoBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7D205324E6A3320089264C /* InfoBoxView.swift */; };
 		EB7D205624E6A5930089264C /* InfoBoxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7D205524E6A5930089264C /* InfoBoxViewModel.swift */; };
@@ -993,6 +994,7 @@
 		EB3BCA85250799E7003F27C7 /* DynamicTableViewBulletPointCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTableViewBulletPointCell.swift; sourceTree = "<group>"; };
 		EB3BCA872507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionSymptomsOnsetViewController.swift; sourceTree = "<group>"; };
 		EB3BCA8A2507B8F3003F27C7 /* ExposureSubmissionSymptomsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionSymptomsViewControllerTests.swift; sourceTree = "<group>"; };
+		EB6B5D8225398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+DeadManSwitch.swift"; sourceTree = "<group>"; };
 		EB7057D624E6BACA002235B4 /* InfoBoxView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoBoxView.xib; sourceTree = "<group>"; };
 		EB7D205324E6A3320089264C /* InfoBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBoxView.swift; sourceTree = "<group>"; };
 		EB7D205524E6A5930089264C /* InfoBoxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBoxViewModel.swift; sourceTree = "<group>"; };
@@ -1483,6 +1485,7 @@
 		51D420B524583B5100AD70CA /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				EB6B5D8225398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift */,
 				71176E2C24891BCF004B0C9F /* __tests__ */,
 				514EE996246D4BDD00DE4884 /* UICollectionView */,
 				514EE997246D4BEB00DE4884 /* UITableView */,
@@ -3155,6 +3158,7 @@
 				B19FD7132491A08500A9D56A /* SAP_SemanticVersion+Compare.swift in Sources */,
 				B1D7D68E24766D2100E4DA5D /* submission_payload.pb.swift in Sources */,
 				B1B381432472EF8B0056BEEE /* HTTPClient+Configuration.swift in Sources */,
+				EB6B5D8325398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift in Sources */,
 				354E305924EFF26E00526C9F /* Country.swift in Sources */,
 				A328424E248B91E0006B1F09 /* HomeTestResultLoadingCell.swift in Sources */,
 				A3816086250633D7002286E9 /* RequiresDismissConfirmation.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -456,6 +456,8 @@
 		EB3BCA882507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3BCA872507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift */; };
 		EB3BCA8C2507C3B0003F27C7 /* DynamicTableViewBulletPointCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3BCA85250799E7003F27C7 /* DynamicTableViewBulletPointCell.swift */; };
 		EB6B5D8325398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6B5D8225398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift */; };
+		EB6B5D882539AE9400B0ED57 /* DMNotificationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6B5D872539AE9400B0ED57 /* DMNotificationsViewController.swift */; };
+		EB6B5D8D2539B36100B0ED57 /* DMNotificationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6B5D8C2539B36100B0ED57 /* DMNotificationCell.swift */; };
 		EB7057D724E6BACA002235B4 /* InfoBoxView.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB7057D624E6BACA002235B4 /* InfoBoxView.xib */; };
 		EB7D205424E6A3320089264C /* InfoBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7D205324E6A3320089264C /* InfoBoxView.swift */; };
 		EB7D205624E6A5930089264C /* InfoBoxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7D205524E6A5930089264C /* InfoBoxViewModel.swift */; };
@@ -995,6 +997,8 @@
 		EB3BCA872507B6C1003F27C7 /* ExposureSubmissionSymptomsOnsetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionSymptomsOnsetViewController.swift; sourceTree = "<group>"; };
 		EB3BCA8A2507B8F3003F27C7 /* ExposureSubmissionSymptomsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionSymptomsViewControllerTests.swift; sourceTree = "<group>"; };
 		EB6B5D8225398D9E00B0ED57 /* UNUserNotificationCenter+DeadManSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+DeadManSwitch.swift"; sourceTree = "<group>"; };
+		EB6B5D872539AE9400B0ED57 /* DMNotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMNotificationsViewController.swift; sourceTree = "<group>"; };
+		EB6B5D8C2539B36100B0ED57 /* DMNotificationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMNotificationCell.swift; sourceTree = "<group>"; };
 		EB7057D624E6BACA002235B4 /* InfoBoxView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoBoxView.xib; sourceTree = "<group>"; };
 		EB7D205324E6A3320089264C /* InfoBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBoxView.swift; sourceTree = "<group>"; };
 		EB7D205524E6A5930089264C /* InfoBoxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBoxViewModel.swift; sourceTree = "<group>"; };
@@ -2369,6 +2373,7 @@
 				AB6289D8251C833100CF61D2 /* DMDeltaOnboardingViewController.swift */,
 				ABDA2791251CE308006BAE84 /* DMServerEnvironmentViewController.swift */,
 				9417BA94252B6B5100AD4053 /* DMSQLiteErrorViewController.swift */,
+				EB6B5D872539AE9400B0ED57 /* DMNotificationsViewController.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -2480,6 +2485,7 @@
 				B1FC2D1F24D9C8DF00083C81 /* SAP_TemporaryExposureKey+DeveloperMenu.swift */,
 				B1A31F6824DAE6C000E263DF /* DMKeyCell.swift */,
 				B103193124E18A0A00DD02EF /* DMMenuItem.swift */,
+				EB6B5D8C2539B36100B0ED57 /* DMNotificationCell.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -3092,6 +3098,7 @@
 				2F26CE2E248B9C4F00BE30EE /* UIViewController+BackButton.swift in Sources */,
 				A16714BB248D18D20031B111 /* SummaryMetadata.swift in Sources */,
 				51C779162486E5BA004582F8 /* RiskFindingPositiveCollectionViewCell.swift in Sources */,
+				EB6B5D882539AE9400B0ED57 /* DMNotificationsViewController.swift in Sources */,
 				B10FD5F4246EAC1700E9D7F2 /* AppleFilesWriter.swift in Sources */,
 				711EFCC72492EE31005FEF21 /* ENAFooterView.swift in Sources */,
 				B1FE13F024891D1500D012E5 /* RiskCalculation.swift in Sources */,
@@ -3205,6 +3212,7 @@
 				71B8044D248525CD00D53506 /* RiskLegendViewController+DynamicTableViewModel.swift in Sources */,
 				EB7D205624E6A5930089264C /* InfoBoxViewModel.swift in Sources */,
 				859DD512248549790073D59F /* MockDiagnosisKeysRetrieval.swift in Sources */,
+				EB6B5D8D2539B36100B0ED57 /* DMNotificationCell.swift in Sources */,
 				2FA9E39324D2F2920030561C /* ExposureSubmission+TestResult.swift in Sources */,
 				EE22DB89247FB43A001B0A71 /* TracingHistoryTableViewCell.swift in Sources */,
 				71B804472484CC0800D53506 /* ENALabel.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate+ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate+ENATaskExecutionDelegate.swift
@@ -101,9 +101,6 @@ extension AppDelegate: ENATaskExecutionDelegate {
 				body: AppStrings.LocalNotifications.detectExposureBody,
 				identifier: ENATaskIdentifier.exposureNotification.backgroundTaskSchedulerIdentifier + ".risk-detection"
 			)
-			
-			// We were successful to calculate a risk in the Background, time to reset Deadman Notification
-			ENATaskScheduler.resetDeadmanNotification()
 
 			completion(true)
 		}

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -187,6 +187,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		taskScheduler.delegate = self
 
 		riskProvider.observeRisk(consumer)
+		
+		// Setup DeadmanNotification after AppLaunch
+		UNUserNotificationCenter.current().scheduleDeadmanNotificationIfNeeded()
 
 		return true
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
@@ -137,6 +137,8 @@ final class DMViewController: UITableViewController, RequiresAppDependencies {
 			vc = makeServerEnvironmentViewController()
 		case .simulateNoDiskSpace:
 			vc = DMSQLiteErrorViewController(store: store)
+		case .listPendingNotifications:
+			vc = DMNotificationsViewController()
 		}
 		
 		if let vc = vc {

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -1,0 +1,87 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+#if !RELEASE
+
+import UIKit
+
+final class DMNotificationsViewController: UITableViewController {
+	
+	// MARK: - Init
+	
+	init() {
+		super.init(style: .plain)
+		self.title = "Pending Notifications"
+	}
+
+	@available(*, unavailable)
+	required init?(coder _: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	// MARK: - Overrides
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		tableView.register(DMNotificationCell.self, forCellReuseIdentifier: DMNotificationCell.reuseIdentifier)
+		
+		UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
+			self.localNotificationRequests = requests
+		}
+	}
+	
+	// MARK: - Protocol UITableView
+	
+	override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
+		localNotificationRequests.count
+	}
+
+	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		let cell = tableView.dequeueReusableCell(withIdentifier: DMNotificationCell.reuseIdentifier, for: indexPath)
+		let notificationRequest = localNotificationRequests[indexPath.row]
+		
+		cell.textLabel?.text = notificationRequest.identifier
+		
+		guard let trigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger else {
+			return cell
+		}
+		guard let triggerDate = trigger.nextTriggerDate() else {
+			return cell
+		}
+		let df = DateFormatter()
+		df.dateFormat = "yyyy-MM-dd hh:mm:ss"
+
+		cell.detailTextLabel?.text = df.string(from: triggerDate)
+		return cell
+	}
+
+	override func tableView(_: UITableView, didSelectRowAt _: IndexPath) {}
+	
+	// MARK: - Private
+
+	private var localNotificationRequests = [UNNotificationRequest]() {
+		didSet {
+			DispatchQueue.main.async {
+				self.tableView.reloadData()
+			}
+		}
+	}
+}
+#endif

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -41,6 +41,7 @@ final class DMNotificationsViewController: UITableViewController {
 		super.viewDidLoad()
 		
 		tableView.register(DMNotificationCell.self, forCellReuseIdentifier: DMNotificationCell.reuseIdentifier)
+		tableView.allowsSelection = false
 		
 		UNUserNotificationCenter.current().getPendingNotificationRequests { requests in
 			self.localNotificationRequests = requests
@@ -71,8 +72,6 @@ final class DMNotificationsViewController: UITableViewController {
 		cell.detailTextLabel?.text = df.string(from: triggerDate)
 		return cell
 	}
-
-	override func tableView(_: UITableView, didSelectRowAt _: IndexPath) {}
 	
 	// MARK: - Private
 

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -60,12 +60,10 @@ final class DMNotificationsViewController: UITableViewController {
 		
 		cell.textLabel?.text = notificationRequest.identifier
 		
-		guard let trigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger else {
+		guard let trigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger, let triggerDate = trigger.nextTriggerDate() else {
 			return cell
 		}
-		guard let triggerDate = trigger.nextTriggerDate() else {
-			return cell
-		}
+		
 		let df = DateFormatter()
 		df.dateFormat = "yyyy-MM-dd hh:mm:ss"
 

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMMenuItem.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMMenuItem.swift
@@ -36,6 +36,7 @@ enum DMMenuItem: Int, CaseIterable {
 	case onboardingVersion
 	case serverEnvironment
 	case simulateNoDiskSpace
+	case listPendingNotifications
 }
 
 extension DMMenuItem {
@@ -67,6 +68,7 @@ extension DMMenuItem {
 		case .onboardingVersion: return "Onboarding Version"
 		case .serverEnvironment: return "Server Environment"
 		case .simulateNoDiskSpace: return "Simulate SQLite Error"
+		case .listPendingNotifications: return "Pending Notifications"
 		}
 	}
 	var subtitle: String {
@@ -86,6 +88,7 @@ extension DMMenuItem {
 		case .onboardingVersion: return "Set the onboarding version"
 		case .serverEnvironment: return "Select server environment"
 		case .simulateNoDiskSpace: return "Simulates SQLite returns defined error"
+		case .listPendingNotifications: return "List all pending Notifications"
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMNotificationCell.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMNotificationCell.swift
@@ -1,0 +1,34 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import UIKit
+
+final class DMNotificationCell: UITableViewCell {
+	static var reuseIdentifier = "DMNotificationCell"
+	
+	override init(style _: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+		textLabel?.lineBreakMode = .byTruncatingMiddle
+	}
+
+	@available(*, unavailable)
+	required init?(coder _: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMNotificationCell.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMNotificationCell.swift
@@ -20,7 +20,8 @@
 import UIKit
 
 final class DMNotificationCell: UITableViewCell {
-	static var reuseIdentifier = "DMNotificationCell"
+	
+	// MARK: - Init
 	
 	override init(style _: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
@@ -31,4 +32,10 @@ final class DMNotificationCell: UITableViewCell {
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has not been implemented")
 	}
+
+	// MARK: - Internal
+	
+	static var reuseIdentifier = "DMNotificationCell"
+
+	
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
@@ -28,7 +28,7 @@ extension UNUserNotificationCenter {
 
 		// Check if Deadman Notification is already scheduled
 		getPendingNotificationRequests(completionHandler: { notificationRequests in
-			if notificationRequests.contains(where: { $0.identifier == UNUserNotificationCenter.deadManNotificationIdentifier }) {
+			if notificationRequests.contains(where: { $0.identifier == UNUserNotificationCenter.deadmanNotificationIdentifier }) {
 				// Deadman Notification already setup -> return
 				return
 			} else {
@@ -44,7 +44,7 @@ extension UNUserNotificationCenter {
 				)
 
 				let request = UNNotificationRequest(
-					identifier: UNUserNotificationCenter.deadManNotificationIdentifier,
+					identifier: UNUserNotificationCenter.deadmanNotificationIdentifier,
 					content: content,
 					trigger: trigger
 				)
@@ -66,10 +66,10 @@ extension UNUserNotificationCenter {
 	
 	// MARK: - Private
 	
-	private static let deadManNotificationIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".notifications.cwa-deadman"
+	private static let deadmanNotificationIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".notifications.cwa-deadman"
 
 	/// Cancels the Deadman Notificatoin
 	private func cancelDeadmanNotification() {
-		removePendingNotificationRequests(withIdentifiers: [UNUserNotificationCenter.deadManNotificationIdentifier])
+		removePendingNotificationRequests(withIdentifiers: [UNUserNotificationCenter.deadmanNotificationIdentifier])
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
@@ -1,0 +1,75 @@
+//
+// Corona-Warn-App
+//
+// SAP SE and all other contributors
+// copyright owners license this file to you under the Apache
+// License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+import UserNotifications
+
+extension UNUserNotificationCenter {
+
+	// MARK: - Internal
+	
+	/// Schedules a local notification to fire 36 hours from now, if there isn´t a notification already scheduled
+	func scheduleDeadmanNotificationIfNeeded() {
+
+		// Check if Deadman Notification is already scheduled
+		getPendingNotificationRequests(completionHandler: { notificationRequests in
+			if notificationRequests.contains(where: { $0.identifier == UNUserNotificationCenter.deadManNotificationIdentifier }) {
+				// Deadman Notification already setup -> return
+				return
+			} else {
+				// No Deadman Notification setup, contiune to setup a new one
+				let content = UNMutableNotificationContent()
+				content.title = AppStrings.Common.deadmanAlertTitle
+				content.body = AppStrings.Common.deadmanAlertBody
+				content.sound = .default
+
+				let trigger = UNTimeIntervalNotificationTrigger(
+					timeInterval: 36 * 60 * 60,
+					repeats: false
+				)
+
+				let request = UNNotificationRequest(
+					identifier: UNUserNotificationCenter.deadManNotificationIdentifier,
+					content: content,
+					trigger: trigger
+				)
+
+				self.add(request) { error in
+				   if error != nil {
+					logError(message: "Deadman notification could not be scheduled.")
+				   }
+				}
+			}
+		})
+	}
+	
+	/// Reset the Deadman Notification, should be called after a successfull risk-calculation.
+	func resetDeadmanNotification() {
+		cancelDeadmanNotification()
+		scheduleDeadmanNotificationIfNeeded()
+	}
+	
+	// MARK: - Private
+	
+	private static let deadManNotificationIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".notifications.cwa-deadman"
+
+	/// Cancels the Deadman Notificatoin
+	private func cancelDeadmanNotification() {
+		removePendingNotificationRequests(withIdentifiers: [UNUserNotificationCenter.deadManNotificationIdentifier])
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNUserNotificationCenter+DeadManSwitch.swift
@@ -25,7 +25,7 @@ extension UNUserNotificationCenter {
 	
 	/// Schedules a local notification to fire 36 hours from now, if there isn´t a notification already scheduled
 	func scheduleDeadmanNotificationIfNeeded() {
-
+		
 		// Check if Deadman Notification is already scheduled
 		getPendingNotificationRequests(completionHandler: { notificationRequests in
 			if notificationRequests.contains(where: { $0.identifier == UNUserNotificationCenter.deadmanNotificationIdentifier }) {
@@ -37,22 +37,22 @@ extension UNUserNotificationCenter {
 				content.title = AppStrings.Common.deadmanAlertTitle
 				content.body = AppStrings.Common.deadmanAlertBody
 				content.sound = .default
-
+				
 				let trigger = UNTimeIntervalNotificationTrigger(
 					timeInterval: 36 * 60 * 60,
 					repeats: false
 				)
-
+				
 				let request = UNNotificationRequest(
 					identifier: UNUserNotificationCenter.deadmanNotificationIdentifier,
 					content: content,
 					trigger: trigger
 				)
-
+				
 				self.add(request) { error in
-				   if error != nil {
-					logError(message: "Deadman notification could not be scheduled.")
-				   }
+					if error != nil {
+						logError(message: "Deadman notification could not be scheduled.")
+					}
 				}
 			}
 		})

--- a/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Task Scheduling/ENATaskScheduler.swift
@@ -42,7 +42,6 @@ final class ENATaskScheduler {
 	// MARK: - Static.
 
 	static let shared = ENATaskScheduler()
-	private static let deadManNotificationIdentifier = (Bundle.main.bundleIdentifier ?? "") + ".notifications.cwa-deadman"
 
 	// MARK: - Attributes.
 
@@ -79,7 +78,6 @@ final class ENATaskScheduler {
 
 	func scheduleTask() {
 		do {
-			ENATaskScheduler.scheduleDeadmanNotificationIfNeeded()
 			let taskRequest = BGProcessingTaskRequest(identifier: ENATaskIdentifier.exposureNotification.backgroundTaskSchedulerIdentifier)
 			taskRequest.requiresNetworkConnectivity = true
 			taskRequest.requiresExternalPower = false
@@ -96,57 +94,6 @@ final class ENATaskScheduler {
 		delegate?.executeENABackgroundTask { success in
 			task.setTaskCompleted(success: success)
 		}
-	}
-
-	// MARK: - Deadman notifications.
-
-	/// Schedules a local notification to fire 36 hours from now, if there isn´t a notification already scheduled
-	static func scheduleDeadmanNotificationIfNeeded() {
-		let notificationCenter = UNUserNotificationCenter.current()
-
-		// Check if Deadman Notification is already scheduled
-		notificationCenter.getPendingNotificationRequests(completionHandler: { notificationRequests in
-			if notificationRequests.contains(where: { $0.identifier == deadManNotificationIdentifier }) {
-				// Deadman Notification already setup -> return
-				return
-			} else {
-				// No Deadman Notification setup, contiune to setup a new one
-				let content = UNMutableNotificationContent()
-				content.title = AppStrings.Common.deadmanAlertTitle
-				content.body = AppStrings.Common.deadmanAlertBody
-				content.sound = .default
-
-				let trigger = UNTimeIntervalNotificationTrigger(
-					timeInterval: 36 * 60 * 60,
-					repeats: false
-				)
-
-				let request = UNNotificationRequest(
-					identifier: deadManNotificationIdentifier,
-					content: content,
-					trigger: trigger
-				)
-
-				notificationCenter.add(request) { error in
-				   if error != nil {
-					  logError(message: "Deadman notification could not be scheduled.")
-				   }
-				}
-			}
-		})
-	}
-	
-	/// Cancels the Deadman Notificatoin
-	private static func cancelDeadmanNotification() {
-		let notificationCenter = UNUserNotificationCenter.current()
-		
-		notificationCenter.removePendingNotificationRequests(withIdentifiers: [deadManNotificationIdentifier])
-	}
-
-	/// Reset the Deadman Notification, should be called after a successfull risk-calculation.
-	static func resetDeadmanNotification() {
-		ENATaskScheduler.cancelDeadmanNotification()
-		ENATaskScheduler.scheduleDeadmanNotificationIfNeeded()
 	}
 	
 }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -155,7 +155,7 @@ extension RiskProvider: RiskProviding {
 			if let detectedSummary = detectedSummary {
 				self.store.summary = .init(detectionSummary: detectedSummary, date: Date())
 				
-				/// We were able to calculate a risk so we have to reset the DeadMan Notification
+				/// We were able to calculate a risk so we have to reset the deadman notification
 				UNUserNotificationCenter.current().resetDeadmanNotification()
 			}
 			self.cancellationToken = nil

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -154,6 +154,9 @@ extension RiskProvider: RiskProviding {
 		self.cancellationToken = exposureSummaryProvider.detectExposure(activityStateDelegate: self) { detectedSummary in
 			if let detectedSummary = detectedSummary {
 				self.store.summary = .init(detectionSummary: detectedSummary, date: Date())
+				
+				/// We were able to calculate a risk so we have to reset the DeadMan Notification
+				UNUserNotificationCenter.current().resetDeadmanNotification()
 			}
 			self.cancellationToken = nil
 			completion(


### PR DESCRIPTION
## Description
This back ports https://github.com/corona-warn-app/cwa-app-ios/pull/1345 and improves it.

The Improvement includes:

- DM Entry to List all pending local Notifications
- Triggering the rest not when a Risk is returned (which could have been a cached on) but only reset the Switch once a "fresh" Risk has been calculated.

## Link to Jira
https://jira.itc.sap.com/browse/EXPOSUREAPP-3185 

## Screenshot
![Screen Shot 2020-10-16 at 13 13 56](https://user-images.githubusercontent.com/10122052/96251937-77e42300-0fb1-11eb-8394-17b385d83a73.png)

