### PR TITLE
Clear the key packages and app config on ENError = 2

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -23,7 +23,7 @@ import UIKit
 protocol CoronaWarnAppDelegate: AnyObject {
 	var client: HTTPClient { get }
 	var downloadedPackagesStore: DownloadedPackagesStore { get }
-	var store: Store { get }
+	var store: Store & AppConfigCaching { get }
 	var appConfigurationProvider: AppConfigurationProviding { get }
 	var riskProvider: RiskProvider { get }
 	var exposureManager: ExposureManager { get }
@@ -99,7 +99,7 @@ extension AppDelegate: ExposureSummaryProvider {
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-	let store: Store
+	let store: Store & AppConfigCaching
 	let serverEnvironment: ServerEnvironment
 	
 	private let consumer = RiskConsumer()
@@ -109,11 +109,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// use a custom http client that uses/recognized caching mechanisms
 		let appFetchingClient = CachingHTTPClient(clientConfiguration: client.configuration)
 
-		// we currently use the store as common place for temporal persistency
-		guard let store = store as? AppConfigCaching else {
-			preconditionFailure("Ensure to provide a proper app config cache")
-		}
-		
 		return CachedAppConfiguration(client: appFetchingClient, store: store)
 	}()
 

--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/__tests__/DownloadedPackagesSQLLiteStoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/__tests__/DownloadedPackagesSQLLiteStoreTests.swift
@@ -235,4 +235,39 @@ final class DownloadedPackagesSQLLiteStoreTests: XCTestCase {
 		XCTAssertEqual(store.allDays(country: "DE").count, 7)
 		XCTAssertEqual(store.allDays(country: "IT").count, 2)
 	}
+
+	func test_ResetRemovesAllKeys() {
+		let database = FMDatabase.inMemory()
+		let store = DownloadedPackagesSQLLiteStore(database: database, migrator: SerialMigratorFake(), latestVersion: 0)
+		store.open()
+
+		let keysBin = Data("keys".utf8)
+		let signature = Data("sig".utf8)
+
+		let package = SAPDownloadedPackage(
+			keysBin: keysBin,
+			signature: signature
+		)
+
+		// Add days
+		store.set(country: "DE", day: "2020-06-01", package: package)
+		store.set(country: "DE", day: "2020-06-02", package: package)
+		store.set(country: "DE", day: "2020-06-03", package: package)
+		store.set(country: "IT", day: "2020-06-03", package: package)
+		store.set(country: "DE", day: "2020-06-04", package: package)
+		store.set(country: "DE", day: "2020-06-05", package: package)
+		store.set(country: "DE", day: "2020-06-06", package: package)
+		store.set(country: "IT", day: "2020-06-06", package: package)
+		store.set(country: "DE", day: "2020-06-07", package: package)
+
+		XCTAssertEqual(store.allDays(country: "DE").count, 7)
+		XCTAssertEqual(store.allDays(country: "IT").count, 2)
+
+		store.reset()
+		store.open()
+
+		XCTAssertEqual(store.allDays(country: "DE").count, 0)
+		XCTAssertEqual(store.allDays(country: "IT").count, 0)
+		XCTAssertEqual(database.lastErrorCode(), 0)
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -171,7 +171,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 
 		// Clear the key packages and app config on ENError = 2 = .badParameter
 		// For more details, see: https://jira.itc.sap.com/browse/EXPOSUREAPP-3297
-		func clearCacheOnError2(error: Error) {
+		func clearCacheOnErrorBadParameter(error: Error) {
 			if let enError = error as? ENError, enError.code == .badParameter {
 				// Clear the key packages
 				downloadedPackagesStore.reset()
@@ -189,7 +189,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 				error: Error?
 		) -> Result<ENExposureDetectionSummary, Error> {
 			if let error = error {
-				clearCacheOnError2(error: error)
+				clearCacheOnErrorBadParameter(error: error)
 				return .failure(error)
 			}
 			if let summary = summary {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -179,6 +179,8 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 
 				// Clear the app config
 				store.appConfig = nil
+				store.lastAppConfigETag = nil
+				store.lastAppConfigFetch = nil
 			}
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -11,13 +11,13 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 	private let client: Client
 
 	private let downloadedPackagesStore: DownloadedPackagesStore
-	private let store: Store
+	private let store: Store & AppConfigCaching
 	private let exposureDetector: ExposureDetector
 
 	init(
 		client: Client,
 		downloadedPackagesStore: DownloadedPackagesStore,
-		store: Store,
+		store: Store & AppConfigCaching,
 		exposureDetector: ExposureDetector
 	) {
 		self.client = client
@@ -168,11 +168,26 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 			writtenPackages: WrittenPackages,
 			completion: @escaping (Result<ENExposureDetectionSummary, Error>) -> Void
 	) -> Progress {
+
+		// Clear the key packages and app config on ENError = 2 = .badParameter
+		// For more details, see: https://jira.itc.sap.com/browse/EXPOSUREAPP-3297
+		func clearCacheOnError2(error: Error) {
+			if let enError = error as? ENError, enError.code == .badParameter {
+				// Clear the key packages
+				downloadedPackagesStore.reset()
+				downloadedPackagesStore.open()
+
+				// Clear the app config
+				store.appConfig = nil
+			}
+		}
+
 		func withResultFrom(
 				summary: ENExposureDetectionSummary?,
 				error: Error?
 		) -> Result<ENExposureDetectionSummary, Error> {
 			if let error = error {
+				clearCacheOnError2(error: error)
 				return .failure(error)
 			}
 			if let summary = summary {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -409,6 +409,8 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 
 				XCTAssertEqual(packageStore.allDays(country: "DE").count, 0)
 				XCTAssertNil(store.appConfig)
+				XCTAssertNil(store.lastAppConfigETag)
+				XCTAssertNil(store.lastAppConfigFetch)
 
 				completionExpectation.fulfill()
 			}


### PR DESCRIPTION
## Description
Resets the key packages and app config when ENError = 2 (badParameter) occurs.

## Link to Jira
[3297](https://jira.itc.sap.com/browse/EXPOSUREAPP-3297)
