### PR TITLE
fix/flaky_unit_test

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -19,6 +19,8 @@
 import ExposureNotification
 import XCTest
 
+
+// swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 class ExposureSubmissionServiceTests: XCTestCase {
 	let expectationsTimeout: TimeInterval = 2

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -401,7 +401,8 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		let client = ClientMock()
 		store.registrationToken = "dummyRegistrationToken"
 
-		let testResult = TestResult.allCases.randomElement() ?? TestResult.positive
+		let storedResults: [TestResult] = [.pending, .negative, .positive, .invalid]
+		let testResult = storedResults.randomElement() ?? TestResult.positive
 		client.onGetTestResult = { result, isFake, completion in
 			expectation.fulfill()
 			XCTAssertFalse(isFake)

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -386,62 +386,24 @@ class ExposureSubmissionServiceTests: XCTestCase {
 
 	// MARK: Plausible deniability tests.
 
-	func test_getTestResultPlaybook() {
+	func test_getTestResultPlaybookPositive() {
+		getTestResultPlaybookTest(with: .positive)
+	}
 
-		// Counter to track the execution order.
-		var count = 0
+	func test_getTestResultPlaybookNegative() {
+		getTestResultPlaybookTest(with: .negative)
+	}
 
-		let expectation = self.expectation(description: "execute all callbacks")
-		expectation.expectedFulfillmentCount = 4
+	func test_getTestResultPlaybookPending() {
+		getTestResultPlaybookTest(with: .pending)
+	}
 
-		// Initialize.
+	func test_getTestResultPlaybookInvalid() {
+		getTestResultPlaybookTest(with: .invalid)
+	}
 
-		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
-		let store = MockTestStore()
-		let client = ClientMock()
-		store.registrationToken = "dummyRegistrationToken"
-
-		let storedResults: [TestResult] = [.pending, .negative, .positive, .invalid]
-		let testResult = storedResults.randomElement() ?? TestResult.positive
-		client.onGetTestResult = { result, isFake, completion in
-			expectation.fulfill()
-			XCTAssertFalse(isFake)
-			XCTAssertEqual(count, 0)
-			count += 1
-			completion(.success(testResult.rawValue))
-		}
-
-		client.onGetTANForExposureSubmit = { _, isFake, completion in
-			expectation.fulfill()
-			XCTAssertTrue(isFake)
-			XCTAssertEqual(count, 1)
-			count += 1
-			completion(.failure(.fakeResponse))
-		}
-
-		client.onSubmitCountries = { _, isFake, completion in
-			expectation.fulfill()
-			XCTAssertTrue(isFake)
-			XCTAssertEqual(count, 2)
-			count += 1
-			completion(.success(()))
-		}
-
-		// Run test.
-
-		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
-		service.getTestResult { response in
-			switch response {
-			case .failure(let error):
-				XCTFail(error.localizedDescription)
-			case .success(let result):
-				XCTAssertEqual(result.rawValue, testResult.rawValue)
-			}
-
-			expectation.fulfill()
-		}
-
-		waitForExpectations(timeout: .short)
+	func test_getTestResultPlaybookExpired() {
+		getTestResultPlaybookTest(with: .expired)
 	}
 
 	func test_getRegistrationTokenPlaybook() {
@@ -589,4 +551,72 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		let regex = try? NSRegularExpression(pattern: pattern, options: [])
 		XCTAssertNotNil(regex?.firstMatch(in: str, options: [], range: .init(location: 0, length: str.count)))
 	}
+
+	// MARK: - Private
+
+	private func getTestResultPlaybookTest(with testResult: TestResult) {
+
+		// Counter to track the execution order.
+		var count = 0
+
+		let expectation = self.expectation(description: "execute all callbacks")
+		expectation.expectedFulfillmentCount = 4
+
+		// Initialize.
+
+		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
+		let store = MockTestStore()
+		let client = ClientMock()
+		store.registrationToken = "dummyRegistrationToken"
+
+		client.onGetTestResult = { result, isFake, completion in
+			expectation.fulfill()
+			XCTAssertFalse(isFake)
+			XCTAssertEqual(count, 0)
+			count += 1
+			completion(.success(testResult.rawValue))
+		}
+
+		client.onGetTANForExposureSubmit = { _, isFake, completion in
+			expectation.fulfill()
+			XCTAssertTrue(isFake)
+			XCTAssertEqual(count, 1)
+			count += 1
+			completion(.failure(.fakeResponse))
+		}
+
+		client.onSubmitCountries = { _, isFake, completion in
+			expectation.fulfill()
+			XCTAssertTrue(isFake)
+			XCTAssertEqual(count, 2)
+			count += 1
+			completion(.success(()))
+		}
+
+		// Run test.
+
+		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
+		service.getTestResult { response in
+			switch response {
+			case .failure(let error):
+				if testResult == .expired {
+					XCTAssertEqual(error, .qrExpired)
+				} else {
+					XCTFail(error.localizedDescription)
+				}
+
+			case .success(let result):
+				if testResult == .expired {
+					XCTFail("Expired test result should lead to failure case")
+				} else {
+					XCTAssertEqual(result.rawValue, testResult.rawValue)
+				}
+			}
+
+			expectation.fulfill()
+		}
+
+		waitForExpectations(timeout: .short)
+	}
+
 }


### PR DESCRIPTION
## Description
fixed a flaky unit test, success callbacks only work in stored test results
.expired state is no longer stored
