### PR TITLE
Fix/3291 Update Status for BackgroundAppRefresh

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA/ENA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "7f36441e3372665b1b414f8ac93b5905cc42a405",
-          "version": "1.9.0"
+          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
+          "version": "1.12.0"
         }
       },
       {

--- a/src/xcode/ENA/ENA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA/ENA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "0279688c9fc5a40028e1b5bb0cb56534a45a6020",
-          "version": "1.12.0"
+          "revision": "7f36441e3372665b1b414f8ac93b5905cc42a405",
+          "version": "1.9.0"
         }
       },
       {

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/SettingsViewController.swift
@@ -84,6 +84,7 @@ final class SettingsViewController: UITableViewController {
 
 		checkTracingStatus()
 		checkNotificationSettings()
+		checkBackgroundAppRefresh()
 	}
 
 	override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {


### PR DESCRIPTION
## Description
The status for BackgroundAppRefresh on the settings screen might not always show the correct state. The Jira item shows such a case when switching between the iPhone Settings app and the CWA app.

The bug has been verified on an iPhoneSE (1st Gen) with iOS 13.6.1. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3291 

## Screenshot
Obsolete, no UI change
