### PR TITLE
Fix/3275 reset riskcalculation after config change

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -119,7 +119,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 			preconditionFailure("Ensure to provide a proper app config cache")
 		}
 		
-		return CachedAppConfiguration(client: appFetchingClient, store: store)
+		return CachedAppConfiguration(client: appFetchingClient, store: store, configurationDidChange: { [weak self] in
+			// Recalculate risk with new app configuration
+			self?.riskProvider.requestRisk(userInitiated: false, ignoreCachedSummary: true)
+		})
 	}()
 
 	lazy var riskProvider: RiskProvider = {

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -37,13 +37,13 @@ extension AppDelegate: CoronaWarnAppDelegate {
 
 extension AppDelegate: ExposureSummaryProvider {
 	func detectExposure(
+		appConfiguration: SAP_ApplicationConfiguration,
 		activityStateDelegate: ActivityStateProviderDelegate? = nil,
 		completion: @escaping (ENExposureDetectionSummary?) -> Void
 	) -> CancellationToken {
-
 		exposureDetection = ExposureDetection(
 			delegate: exposureDetectionExecutor,
-			appConfigurationProvider: appConfigurationProvider
+			appConfiguration: appConfiguration
 		)
 		
 		exposureDetection?

--- a/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/CachingHTTPClientMock.swift
+++ b/src/xcode/ENA/ENA/Source/Client/__tests__/Mocks/CachingHTTPClientMock.swift
@@ -23,8 +23,7 @@ import Foundation
 final class CachingHTTPClientMock: CachingHTTPClient {
 
 	convenience init() {
-		let serverEnvironment = ServerEnvironment()
-		let store = SecureStore(subDirectory: "database", serverEnvironment: serverEnvironment)
+		let store = MockTestStore()
 		let configuration = HTTPClient.Configuration.makeDefaultConfiguration(store: store)
 
 		self.init(clientConfiguration: configuration)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -104,24 +104,31 @@ final class ExposureDetection {
 	typealias Completion = (Result<ENExposureDetectionSummary, DidEndPrematurelyReason>) -> Void
 
 	func start(completion: @escaping Completion) {
-		self.completion = completion
 		Log.info("ExposureDetection: Start downloading packages.", log: .riskDetection)
 
+		self.completion = completion
 		activityState = .downloading
 
 		downloadKeyPackages { [weak self] in
 			guard let self = self else { return }
+
 			Log.info("ExposureDetection: Completed downloading packages.", log: .riskDetection)
 			Log.info("ExposureDetection: Start writing packages to file system.", log: .riskDetection)
+
 			self.writeKeyPackagesToFileSystem { [weak self] writtenPackages in
 				guard let self = self else { return }
+
 				Log.info("ExposureDetection: Completed writing packages to file system.", log: .riskDetection)
+
 				self.activityState = .detecting
 
 				if let exposureConfiguration = self.exposureConfiguration {
-          Log.info("ExposureDetection: Start detecting summary.", log: .riskDetection)
+					Log.info("ExposureDetection: Start detecting summary.", log: .riskDetection)
+
 					self.detectSummary(writtenPackages: writtenPackages, exposureConfiguration: exposureConfiguration)
 				} else {
+					Log.error("ExposureDetection: End prematurely.", log: .riskDetection, error: DidEndPrematurelyReason.noExposureConfiguration)
+
 					self.endPrematurely(reason: .noExposureConfiguration)
 				}
 			}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -395,7 +395,7 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 		)
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		XCTAssertNotEqual(packageStore.allDays(country: "DE").count, 0)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -312,7 +312,7 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 		let sut = ExposureDetectionExecutor.makeWith(exposureDetector: MockExposureDetector((mockSummary, nil)))
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		_ = sut.exposureDetection(
@@ -343,7 +343,7 @@ final class ExposureDetectionExecutorTests: XCTestCase {
 		let sut = ExposureDetectionExecutor.makeWith(exposureDetector: MockExposureDetector((nil, expectedError)))
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		_ = sut.exposureDetection(

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
@@ -65,15 +65,12 @@ final class ExposureDetectionTransactionTests: XCTestCase {
 			return .success(MutableENExposureDetectionSummary(daysSinceLastExposure: 5))
 		}
 
-		let appConfigurationProviderSpy = AppConfigurationProviderSpy()
-
 		let startCompletionCalled = expectation(description: "start completion called")
 		let detection = ExposureDetection(
 			delegate: delegate,
-			appConfigurationProvider: appConfigurationProviderSpy
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 		detection.start { _ in
-			XCTAssertTrue(appConfigurationProviderSpy.didCallAppConfiguration)
 			startCompletionCalled.fulfill()
 		}
 
@@ -103,7 +100,7 @@ final class ExposureDetectionTransactionTests: XCTestCase {
 		let detection = ExposureDetection(
 			delegate: delegate,
 			countryKeypackageDownloader: packageDownloader,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		let expectationNoDaysAndHours = expectation(description: "completion with NoDaysAndHours error called.")
@@ -148,7 +145,7 @@ final class ExposureDetectionTransactionTests: XCTestCase {
 		let detection = ExposureDetection(
 			delegate: delegate,
 			countryKeypackageDownloader: packageDownloader,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		let expectationFailureResult = expectation(description: "Detection should fail.")
@@ -183,7 +180,7 @@ final class ExposureDetectionTransactionTests: XCTestCase {
 		let detection = ExposureDetection(
 			delegate: delegate,
 			countryKeypackageDownloader: packageDownloader,
-			appConfigurationProvider: AppConfigurationProviderFake()
+			appConfiguration: SAP_ApplicationConfiguration()
 		)
 
 		let expectationFailureResult = expectation(description: "Detection should fail.")
@@ -208,20 +205,6 @@ final class AppConfigurationProviderFake: AppConfigurationProviding {
 	}
 
 	func appConfiguration(completion: @escaping Completion) {
-		completion(.success(SAP_ApplicationConfiguration()))
-	}
-}
-
-final class AppConfigurationProviderSpy: AppConfigurationProviding {
-	var didCallAppConfiguration = false
-
-	func appConfiguration(forceFetch: Bool, completion: @escaping Completion) {
-		didCallAppConfiguration = true
-		completion(.success(SAP_ApplicationConfiguration()))
-	}
-
-	func appConfiguration(completion: @escaping Completion) {
-		didCallAppConfiguration = true
 		completion(.success(SAP_ApplicationConfiguration()))
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/RiskCalculation.swift
@@ -53,7 +53,6 @@ enum RiskCalculation {
 		- dateLastExposureDetection: The date of the most recent exposure detection
 		- numberOfTracingActiveDays: A count of how many days tracing has been active for
 		- preconditions: Current state of the `ExposureManager`
-		- currentDate: The current `Date` to use in checks. Defaults to `Date()`
 	*/
 	private static func riskLevel(
 		summary: CodableExposureDetectionSummary?,
@@ -61,8 +60,7 @@ enum RiskCalculation {
 		dateLastExposureDetection: Date?,
 		activeTracing: ActiveTracing, // Get this from the `TracingStatusHistory`
 		preconditions: ExposureManagerState,
-		providerConfiguration: RiskProvidingConfiguration,
-		currentDate: Date = Date()
+		providerConfiguration: RiskProvidingConfiguration
 	) -> Result<RiskLevel, RiskLevelCalculationError> {
 
 		//
@@ -160,7 +158,6 @@ enum RiskCalculation {
 		dateLastExposureDetection: Date?,
 		activeTracing: ActiveTracing,
 		preconditions: ExposureManagerState,
-		currentDate: Date = Date(),
 		previousRiskLevel: EitherLowOrIncreasedRiskLevel?,
 		providerConfiguration: RiskProvidingConfiguration
 	) -> Risk? {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -17,7 +17,7 @@
 // under the License.
 //
 
-import UIKit
+import Foundation
 
 final class CachedAppConfiguration {
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -17,9 +17,9 @@
 // under the License.
 //
 
-import Foundation
+import UIKit
 
-final class CachedAppConfiguration {
+final class CachedAppConfiguration: RequiresAppDependencies {
 
 	enum CacheError: Error {
 		case dataFetchError(message: String?)
@@ -57,6 +57,9 @@ final class CachedAppConfiguration {
 
 				// keep track of last successful fetch
 				self?.store.lastAppConfigFetch = Date()
+
+				// Recalculate risk with new app configuration
+				self?.riskProvider.requestRisk(userInitiated: false, ignoreCachedSummary: true)
 			case .failure(let error):
 				switch error {
 				case CachedAppConfiguration.CacheError.notModified where self?.store.appConfig != nil:

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -54,6 +54,9 @@ final class CachedAppConfiguration {
 				self?.store.lastAppConfigETag = response.eTag
 				self?.store.appConfig = response.config
 				self?.completeOnMain(completion: completion, result: .success(response.config))
+
+				// keep track of last successful fetch
+				self?.store.lastAppConfigFetch = Date()
 			case .failure(let error):
 				switch error {
 				case CachedAppConfiguration.CacheError.notModified where self?.store.appConfig != nil:

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/CachedAppConfigurationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/CachedAppConfigurationTests.swift
@@ -35,8 +35,6 @@ final class CachedAppConfigurationTests: XCTestCase {
 
 		let expectedConfig = SAP_ApplicationConfiguration()
 		client.onFetchAppConfiguration = { _, completeWith in
-			store.lastAppConfigFetch = Date()
-
 			let config = AppConfigurationFetchingResponse(expectedConfig, "etag")
 			completeWith(.success(config))
 			expectation.fulfill()

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -256,7 +256,8 @@ extension RiskProvider: RiskProviding {
 			}
 		}
 
-		guard let unwrappedAppConfiguration = appConfiguration, group.wait(timeout: .now() + .seconds(60 * 8)) == .success else {
+		guard group.wait(timeout: .now() + .seconds(60 * 8)) == .success,
+			  let unwrappedAppConfiguration = appConfiguration else {
 			cancellationToken?.cancel()
 			cancellationToken = nil
 			completeOnTargetQueue(risk: nil, completion: completion)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProviding.swift
@@ -23,7 +23,7 @@ protocol RiskProviding: AnyObject {
 	typealias Completion = (Risk?) -> Void
 
 	func observeRisk(_ consumer: RiskConsumer)
-	func requestRisk(userInitiated: Bool, completion: Completion?)
+	func requestRisk(userInitiated: Bool, ignoreCachedSummary: Bool, completion: Completion?)
 	func nextExposureDetectionDate() -> Date
 
 	var configuration: RiskProvidingConfiguration { get set }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -24,9 +24,11 @@ import ExposureNotification
 private final class Summary: ENExposureDetectionSummary {}
 
 private final class ExposureSummaryProviderMock: ExposureSummaryProvider {
+
 	var onDetectExposure: ((ExposureSummaryProvider.Completion) -> Void)?
 
 	func detectExposure(
+		appConfiguration: SAP_ApplicationConfiguration,
 		activityStateDelegate: ActivityStateProviderDelegate? = nil,
 		completion: (ENExposureDetectionSummary?) -> Void
 	) -> CancellationToken {
@@ -34,6 +36,7 @@ private final class ExposureSummaryProviderMock: ExposureSummaryProvider {
 		onDetectExposure?(completion)
 		return token
 	}
+
 }
 
 final class RiskProviderTests: XCTestCase {


### PR DESCRIPTION
## Description
Invoke the risk detection immediately after a changed app configuration is loaded to get an updated risk score. If the detection fails, the previous summary is kept and the calculation is still applied on the cached summary.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3275
