### PR TITLE
Remove buggy display of nextTriggerDate from the DM

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -60,7 +60,7 @@ final class DMNotificationsViewController: UITableViewController {
 		
 		cell.textLabel?.text = notificationRequest.identifier
 		
-		// Dear future Develeoper that thinks it would be nice to display the nextTriggerDate of the notificationRequest
+		// Dear future developer that thinks it would be nice to display the nextTriggerDate of the notificationRequest
 		// https://stackoverflow.com/questions/51618620/nexttriggerdate-doesnt-return-the-expected-value-is-there-another-way-to-o
 		// Please check first if Apple was so kind to fix the nextTriggerDate ✌️
 		return cell

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -60,14 +60,9 @@ final class DMNotificationsViewController: UITableViewController {
 		
 		cell.textLabel?.text = notificationRequest.identifier
 		
-		guard let trigger = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger, let triggerDate = trigger.nextTriggerDate() else {
-			return cell
-		}
-		
-		let df = DateFormatter()
-		df.dateFormat = "yyyy-MM-dd hh:mm:ss"
-
-		cell.detailTextLabel?.text = df.string(from: triggerDate)
+		// Dear future Develeoper that thinks it would be nice to display the nextTriggerDate of the notificationRequest
+		// https://stackoverflow.com/questions/51618620/nexttriggerdate-doesnt-return-the-expected-value-is-there-another-way-to-o
+		// Please check first if Apple was so kind to fix the nextTriggerDate ✌️
 		return cell
 	}
 	


### PR DESCRIPTION
## Description
`nextTriggerDate` does not return the `nextTriggerDate` but the currentDate + the timeInterval with which the notification was setup with.  Since this bug seems not to get fixed by Apple soon (https://stackoverflow.com/questions/51618620/nexttriggerdate-doesnt-return-the-expected-value-is-there-another-way-to-o) we have to remove the display of the `nextTriggerDate` because it causes more confusion than it does good.
## Link to Jira
<!-- Please add the link to the related Jira issue -->

## Screenshot
![Screen Shot 2020-10-20 at 15 27 36](https://user-images.githubusercontent.com/10122052/96592561-d1698c00-12e8-11eb-99fe-c76fe22836f9.png)
