### PR TITLE
3316 - Don't enter Reader on SFSafariViewController

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/LinkHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/LinkHelper.swift
@@ -42,7 +42,7 @@ enum LinkHelper {
 
 	static func openLink(withUrl url: URL, from viewController: UIViewController) {
 		let config = SFSafariViewController.Configuration()
-		config.entersReaderIfAvailable = true
+		config.entersReaderIfAvailable = false
 		config.barCollapsingEnabled = true
 
 		let vc = SFSafariViewController(url: url, configuration: config)


### PR DESCRIPTION
## Description
If we open a link with an Anker and the Website supports ReaderMode, the Website opens in Readermode but does not jump to the Anker. 
To avoid this we have to disable this behaviour.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3316
