### PR TITLE
quick fix to tests run via Xcode instead of Fastlane

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/xcshareddata/xcschemes/ENA.xcscheme
+++ b/src/xcode/ENA/ENA.xcodeproj/xcshareddata/xcschemes/ENA.xcscheme
@@ -63,6 +63,15 @@
       region = "DE"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Ensure the hardware keyboard is DISCONNECTED from the simulators to prevent issues where the software keyboard is not shown.&#10;# Solution stolen from: https://stackoverflow.com/a/57269479/194585&#10;&#10;killall Simulator&#10;&#10;defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false&#10;&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/src/xcode/ENA/TestPlans/AllTests.xctestplan
+++ b/src/xcode/ENA/TestPlans/AllTests.xctestplan
@@ -9,6 +9,7 @@
       }
     },
     {
+      "enabled" : false,
       "id" : "1A0C143D-8EB4-4EDC-90D0-2D24EAC78C4B",
       "name" : "EN",
       "options" : {
@@ -17,6 +18,7 @@
       }
     },
     {
+      "enabled" : false,
       "id" : "923744F6-0D40-4591-9147-70780A54A89E",
       "name" : "RO",
       "options" : {
@@ -25,6 +27,7 @@
       }
     },
     {
+      "enabled" : false,
       "id" : "76F58801-D234-473B-92BB-F77A906BC887",
       "name" : "PL",
       "options" : {
@@ -33,6 +36,7 @@
       }
     },
     {
+      "enabled" : false,
       "id" : "1C2ECF54-A91A-4614-823F-9F010BCC63ED",
       "name" : "TR",
       "options" : {


### PR DESCRIPTION
This quick-fix:

1. disables testplan configurations for non-DE languages (will be tackled later)
1. adds the 'force software keyboard' script in the ENA schema as well

to prevent failing UI tests locally started in Xcode.