### PR TITLE
fix(submission): Popping multiple navigation children results results in broken footer state (closes #1463)

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionIntroViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionIntroViewController.swift
@@ -53,15 +53,6 @@ class ExposureSubmissionIntroViewController: DynamicTableViewController, ENANavi
 		footerView?.secondaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.secondaryButton
 	}
 
-	override func didMove(toParent parent: UIViewController?) {
-		// Make sure to update to the correct footer state based on the attached view controller
-		// This is especially important for iOS 14, since it allows the user to close multiple
-		// child view-controllers at once
-		if let parent = parent as? ExposureSubmissionNavigationController, parent.children.count == 1 {
-			footerView?.apply(navigationItem: navigationItem)
-		}
-	}
-
 	// MARK: - Setup helpers.
 
 	private func setupView() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionIntroViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionIntroViewController.swift
@@ -53,6 +53,15 @@ class ExposureSubmissionIntroViewController: DynamicTableViewController, ENANavi
 		footerView?.secondaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.secondaryButton
 	}
 
+	override func didMove(toParent parent: UIViewController?) {
+		// Make sure to update to the correct footer state based on the attached view controller
+		// This is especially important for iOS 14, since it allows the user to close multiple
+		// child view-controllers at once
+		if let parent = parent as? ExposureSubmissionNavigationController, parent.children.count == 1 {
+			footerView?.apply(navigationItem: navigationItem)
+		}
+	}
+
 	// MARK: - Setup helpers.
 
 	private func setupView() {

--- a/src/xcode/ENA/ENA/Source/Scenes/NavigationControllerWithFooter/ENANavigationControllerWithFooter.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/NavigationControllerWithFooter/ENANavigationControllerWithFooter.swift
@@ -67,12 +67,6 @@ class ENANavigationControllerWithFooter: UINavigationController {
 		updateAdditionalSafeAreaInsets()
 		layoutFooterView()
 	}
-
-	override func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
-		let viewController = super.popToViewController(viewController, animated: animated)
-		transitionFooterView(to: topViewController)
-		return viewController
-	}
 }
 
 private extension ENANavigationControllerWithFooter {
@@ -155,6 +149,12 @@ extension ENANavigationControllerWithFooter {
 	override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
 		super.setViewControllers(viewControllers, animated: animated)
 		transitionFooterView(to: topViewController)
+	}
+
+	override func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
+		let viewController = super.popToViewController(viewController, animated: animated)
+		transitionFooterView(to: topViewController)
+		return viewController
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/NavigationControllerWithFooter/ENANavigationControllerWithFooter.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/NavigationControllerWithFooter/ENANavigationControllerWithFooter.swift
@@ -67,6 +67,12 @@ class ENANavigationControllerWithFooter: UINavigationController {
 		updateAdditionalSafeAreaInsets()
 		layoutFooterView()
 	}
+
+	override func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
+		let viewController = super.popToViewController(viewController, animated: animated)
+		transitionFooterView(to: topViewController)
+		return viewController
+	}
 }
 
 private extension ENANavigationControllerWithFooter {


### PR DESCRIPTION
## Checklist

* [x] This PR does not change text that hasn't been signed off with the RKI. Have a look at the pinned issue [440](https://github.com/corona-warn-app/cwa-app-ios/issues)
* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed.
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description

When using the iOS 14+ navigation flow feature of closing multiple child views at once using force touch on the "Back" button of the navigation bar, the footer view moves to a broken state and prevent further inputs until the view is manually closed and reopened. This is only an issue for the submission view controller and can be seen in this video:

https://www.dropbox.com/s/fpqcyulaj1uhoqp/CWA_iOS_Submission_Nav_Bug_Repro.mov?dl=0

<img src="https://user-images.githubusercontent.com/10667698/98129604-9905a880-1eb9-11eb-8912-c154753194d5.png" width="400" />