### PR TITLE
Fix/xcode not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ commands:
       - run:
           name: Install Bundler
           command: sudo gem install rake bundler:2.1.4
-      - run:
-          name: Install Bundler
-          command: ls -ls /Applications
 
   prepare-dependencies:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ commands:
       - run:
           name: Install Bundler
           command: sudo gem install rake bundler:2.1.4
+      - run:
+          name: Install Bundler
+          command: ls -ls /Applications
 
   prepare-dependencies:
     steps:

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
     setup_circle_ci
 
     if is_ci
-      xcversion(version: "12.1.0")
+      xcversion(version: "12.1.1")
     end
   end
 

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
       skip_codesigning: true,
       export_method: "ad-hoc",
       skip_package_ipa: true,
-      destination: "platform=iOS Simulator,OS=14.1,name=iPhone 11",
+      destination: "platform=iOS Simulator,OS=14.2,name=iPhone 11",
       scheme: "ENA"
     )
   end
@@ -52,7 +52,7 @@ platform :ios do
       skip_codesigning: true,
       export_method: "ad-hoc",
       skip_package_ipa: true,
-      destination: "platform=iOS Simulator,OS=14.1,name=iPhone 11",
+      destination: "platform=iOS Simulator,OS=14.2,name=iPhone 11",
       scheme: "ENACommunity"
     )
   end

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
     setup_circle_ci
 
     if is_ci
-      xcversion(version: "12.1")
+      xcversion(version: "~> 12.1.0")
     end
   end
 

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -26,7 +26,7 @@ platform :ios do
     setup_circle_ci
 
     if is_ci
-      xcversion(version: "12.1.1")
+      xcversion(version: "12.1")
     end
   end
 

--- a/src/xcode/fastlane/Snapfile
+++ b/src/xcode/fastlane/Snapfile
@@ -7,7 +7,7 @@ devices([
 ])
 
 ios_version(
-  "14.1"
+  "14.2"
 )
 
 # Languages are set individually in CI


### PR DESCRIPTION
## Description
Circle-CI silently update Xcode from 12.1.0 to 12.1.1 

For added Bonus, Xcode 12.1.1 only has iOS 14.2 runtime installed 🎉

This fixes this change on our side.
