### PR TITLE
Fix/3542 Notifications: Removed Obsolete Detail View

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
@@ -47,29 +47,5 @@ extension UNUserNotificationCenter {
 				Log.error(error.localizedDescription, log: .api)
 			}
 		}
-
-		let openActionIdentifier = UserNotificationAction.openExposureDetectionResults
-
-		let viewAction = UNNotificationAction(
-			identifier: openActionIdentifier.rawValue,
-			title: openActionIdentifier.rawValue,
-			options: [.authenticationRequired]
-		)
-
-		let deleteAction = UNNotificationAction(
-			identifier: UserNotificationAction.ignore.rawValue,
-			title: UserNotificationAction.ignore.rawValue,
-			options: [.destructive]
-		)
-
-		let category = UNNotificationCategory(
-			identifier: identifier,
-			actions: [viewAction, deleteAction],
-			intentIdentifiers: [],
-			options: []
-		)
-
-		setNotificationCategories([category])
-
 	}
 }


### PR DESCRIPTION
## Description
Tap and hold a notification. A detail view is displayed showing a technical identifier (see screenshot 1). This confuses the users.
The detail view can be removed without any functional regression (see screenshot 2).
Tapping the notification opens the CWA app.
Slide left opens the standard menue (Verwalten, Anzeigen, Entfernen/Manage, View, Clear)

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3542?filter=58020

## Screenshot
1. Notification with Detail View
![Notifications with Action](https://user-images.githubusercontent.com/7896005/98785916-9ea14800-23fd-11eb-93e3-84e549b9a769.PNG)

2. Notification without Detail View
![Notification without Action](https://user-images.githubusercontent.com/7896005/98786016-c7294200-23fd-11eb-9d8e-c47f3df0e598.PNG)

3. Notification Menue (Slide Left)
![Notification Menue](https://user-images.githubusercontent.com/7896005/98786061-dc05d580-23fd-11eb-8ecf-61d47bb24d48.PNG)





