### PR TITLE
feature/TASK-3762 Consent to share submission data added to the framework

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
@@ -69,7 +69,7 @@ class MockExposureSubmissionService: ExposureSubmissionService {
 
 	var devicePairingSuccessfulTimestamp: Int64?
 	
-	var isAllowedToAutomaticallyShareTestResults = false
+	var isSubmissionConsentGiven = false
 
 	func preconditions() -> ExposureManagerState {
 		return preconditionsCallback?() ?? ExposureManagerState(authorized: false, enabled: false, status: .unknown)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
@@ -68,6 +68,8 @@ class MockExposureSubmissionService: ExposureSubmissionService {
 	var devicePairingConsentAcceptTimestamp: Int64?
 
 	var devicePairingSuccessfulTimestamp: Int64?
+	
+	var isAllowedToAutomaticallyShareTestResults = false
 
 	func preconditions() -> ExposureManagerState {
 		return preconditionsCallback?() ?? ExposureManagerState(authorized: false, enabled: false, status: .unknown)

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -151,10 +151,13 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 				supportedCountries = []
 			}
 			
+			// As per feature requirement, the delta onboarding should appear with a slight delay of 0.5
 			var delay = 0.5
 			
 			#if DEBUG
 			if isUITesting {
+				// In UI Testing we need to increase the delaye slightly again.
+				// Otherwise UI Tests fail
 				delay = 1.5
 			}
 			#endif

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -151,7 +151,15 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 				supportedCountries = []
 			}
 			
-			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+			var delay = 0.5
+			
+			#if DEBUG
+			if isUITesting {
+				delay = 1.5
+			}
+			#endif
+			
+			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 				let onboardings: [DeltaOnboarding] = [
 					DeltaOnboardingV15(store: self.store, supportedCountries: supportedCountries)
 				]

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
@@ -29,6 +29,7 @@ protocol ExposureSubmissionService: class {
 	var devicePairingConsentAcceptTimestamp: Int64? { get }
 	var devicePairingSuccessfulTimestamp: Int64? { get }
 	
+	/// Indicates wether the user allowed to submit test results automatically to the federation gateway or not. Defaults to `false`.
 	var isSubmissionConsentGiven: Bool { get set }
 	
 	func submitExposure(

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
@@ -29,6 +29,8 @@ protocol ExposureSubmissionService: class {
 	var devicePairingConsentAcceptTimestamp: Int64? { get }
 	var devicePairingSuccessfulTimestamp: Int64? { get }
 	
+	var isAllowedToAutomaticallyShareTestResults: Bool { get set }
+	
 	func submitExposure(
 		symptomsOnset: SymptomsOnset,
 		visitedCountries: [Country],
@@ -53,5 +55,6 @@ protocol ExposureSubmissionService: class {
 	func preconditions() -> ExposureManagerState
 	func acceptPairing()
 	func fakeRequest(completionHandler: ExposureSubmissionHandler?)
+	
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
@@ -29,7 +29,7 @@ protocol ExposureSubmissionService: class {
 	var devicePairingConsentAcceptTimestamp: Int64? { get }
 	var devicePairingSuccessfulTimestamp: Int64? { get }
 	
-	var isAllowedToAutomaticallyShareTestResults: Bool { get set }
+	var isSubmissionConsentGiven: Bool { get set }
 	
 	func submitExposure(
 		symptomsOnset: SymptomsOnset,

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -39,6 +39,11 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 		get { self.store.devicePairingSuccessfulTimestamp }
 		set { self.store.devicePairingSuccessfulTimestamp = newValue }
 	}
+	
+	var isAllowedToAutomaticallyShareTestResults: Bool {
+		get { self.store.isAllowedToAutomaticallyShareTestResults }
+		set { self.store.isAllowedToAutomaticallyShareTestResults = newValue }
+	}
 
 	/// This method submits the exposure keys. Additionally, after successful completion,
 	/// the timestamp of the key submission is updated.

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -40,9 +40,9 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 		set { self.store.devicePairingSuccessfulTimestamp = newValue }
 	}
 	
-	var isAllowedToAutomaticallyShareTestResults: Bool {
-		get { self.store.isAllowedToAutomaticallyShareTestResults }
-		set { self.store.isAllowedToAutomaticallyShareTestResults = newValue }
+	var isSubmissionConsentGiven: Bool {
+		get { self.store.isSubmissionConsentGiven }
+		set { self.store.isSubmissionConsentGiven = newValue }
 	}
 
 	/// This method submits the exposure keys. Additionally, after successful completion,

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -167,7 +167,6 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 		devicePairingConsentAcceptTimestamp = Int64(Date().timeIntervalSince1970)
 	}
 
-
 	/// This method is called randomly sometimes in the foreground and from the background.
 	/// It represents the full-fledged dummy request needed to realize plausible deniability.
 	/// Nothing called in this method is considered a "real" request.

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -27,6 +27,20 @@ class ExposureSubmissionServiceTests: XCTestCase {
 	let keys = [ENTemporaryExposureKey()]
 
 	// MARK: - Exposure Submission Tests
+	
+	func testIsAllowedToAutomaticallyShareTestresults_correctValueExchangeBetweenServiceAndStore() {
+		
+		let store = MockTestStore()
+		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
+		let client = ClientMock()
+		
+		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
+		
+		XCTAssertFalse(service.isAllowedToAutomaticallyShareTestResults, "Expected value is 'false'")
+		
+		service.isAllowedToAutomaticallyShareTestResults = true
+		XCTAssertTrue(store.isAllowedToAutomaticallyShareTestResults, "Expected store value is 'true'")
+	}
 
 	func testSubmitExposure_Success() {
 		// Arrange

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -28,7 +28,7 @@ class ExposureSubmissionServiceTests: XCTestCase {
 
 	// MARK: - Exposure Submission Tests
 	
-	func testIsAllowedToAutomaticallyShareTestresults_correctValueExchangeBetweenServiceAndStore() {
+	func testIsisAutomaticSubmissionConsentGiven_correctValueExchangeBetweenServiceAndStore() {
 		
 		let store = MockTestStore()
 		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
@@ -36,10 +36,10 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		
 		let service = ENAExposureSubmissionService(diagnosiskeyRetrieval: keyRetrieval, client: client, store: store)
 		
-		XCTAssertFalse(service.isAllowedToAutomaticallyShareTestResults, "Expected value is 'false'")
+		XCTAssertFalse(service.isSubmissionConsentGiven, "Expected value is 'false'")
 		
-		service.isAllowedToAutomaticallyShareTestResults = true
-		XCTAssertTrue(store.isAllowedToAutomaticallyShareTestResults, "Expected store value is 'true'")
+		service.isSubmissionConsentGiven = true
+		XCTAssertTrue(store.isSubmissionConsentGiven, "Expected store value is 'true'")
 	}
 
 	func testSubmitExposure_Success() {

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -63,7 +63,7 @@ final class MockTestStore: Store, AppConfigCaching {
 	var lastKeyPackageDownloadDate: Date = .distantPast
 	var isDeviceTimeCorrect = true
 	var wasDeviceTimeErrorShown = false
-	var isAllowedToAutomaticallyShareTestResults = false
+	var isSubmissionConsentGiven = false
 
 	#if !RELEASE
 	// Settings from the debug menu.

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -63,6 +63,7 @@ final class MockTestStore: Store, AppConfigCaching {
 	var lastKeyPackageDownloadDate: Date = .distantPast
 	var isDeviceTimeCorrect = true
 	var wasDeviceTimeErrorShown = false
+	var isAllowedToAutomaticallyShareTestResults = false
 
 	#if !RELEASE
 	// Settings from the debug menu.

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -258,7 +258,12 @@ final class SecureStore: Store {
 		get { kvStore["lastKeyPackageDownloadDate"] as Date? ?? .distantPast }
 		set { kvStore["lastKeyPackageDownloadDate"] = newValue }
 	}
-
+	
+	var isAllowedToAutomaticallyShareTestResults: Bool {
+		get { kvStore["isAllowedToAutomaticallyShareTestResults"] as Bool? ?? false }
+		set { kvStore["isAllowedToAutomaticallyShareTestResults"] = newValue }
+	}
+	
 	#if !RELEASE
 
 	// Settings from the debug menu.

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -259,9 +259,9 @@ final class SecureStore: Store {
 		set { kvStore["lastKeyPackageDownloadDate"] = newValue }
 	}
 	
-	var isAllowedToAutomaticallyShareTestResults: Bool {
-		get { kvStore["isAllowedToAutomaticallyShareTestResults"] as Bool? ?? false }
-		set { kvStore["isAllowedToAutomaticallyShareTestResults"] = newValue }
+	var isSubmissionConsentGiven: Bool {
+		get { kvStore["isSubmissionConsentGiven"] as Bool? ?? false }
+		set { kvStore["isSubmissionConsentGiven"] = newValue }
 	}
 	
 	#if !RELEASE

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -133,7 +133,7 @@ protocol StoreProtocol: AnyObject {
 	
 	var wasDeviceTimeErrorShown: Bool { get set }
 	
-	var isAllowedToAutomaticallyShareTestResults: Bool { get set }
+	var isSubmissionConsentGiven: Bool { get set }
 
 	func clearAll(key: String?)
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -132,6 +132,8 @@ protocol StoreProtocol: AnyObject {
     var isDeviceTimeCorrect: Bool { get set }
 	
 	var wasDeviceTimeErrorShown: Bool { get set }
+	
+	var isAllowedToAutomaticallyShareTestResults: Bool { get set }
 
 	func clearAll(key: String?)
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -264,4 +264,10 @@ final class StoreTests: XCTestCase {
 		store.appConfig = config
 		XCTAssertEqual(store.appConfig, config)
 	}
+	
+	func testConsentForAutomaticSharingTestResults_initial() throws {
+		let store = SecureStore(subDirectory: "test", serverEnvironment: ServerEnvironment())
+		XCTAssertFalse(store.isAllowedToAutomaticallyShareTestResults, "isAllowedToAutomaticallyShareTestResults should be 'false' after initialization")
+
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -267,7 +267,7 @@ final class StoreTests: XCTestCase {
 	
 	func testConsentForAutomaticSharingTestResults_initial() throws {
 		let store = SecureStore(subDirectory: "test", serverEnvironment: ServerEnvironment())
-		XCTAssertFalse(store.isAllowedToAutomaticallyShareTestResults, "isAllowedToAutomaticallyShareTestResults should be 'false' after initialization")
+		XCTAssertFalse(store.isSubmissionConsentGiven, "isAllowedToAutomaticallyShareTestResults should be 'false' after initialization")
 
 	}
 }

--- a/src/xcode/ENA/ENAUITests/DeltaOnboarding/ENAUITestsDeltaOnboarding.swift
+++ b/src/xcode/ENA/ENAUITests/DeltaOnboarding/ENAUITestsDeltaOnboarding.swift
@@ -71,6 +71,15 @@ class ENAUITests_06_DeltaOnboarding: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-onboardingVersion", "1.4"])
 		
 		app.launch()
+		
+		// The "Information zur Funktionsweise der Risiko-Ermittlung"
+		// appears on fresh installs (e.g. every CI-run) but not on already started apps.
+		// We dismiss it if present.
+		let alert = app.alerts.firstMatch
+		if alert.exists {
+			alert.buttons.firstMatch.tap()
+		}
+		
 		var screenshotCounter = 0
 		let screenshotLabel = "deltaOnboarding_V15"
 		


### PR DESCRIPTION
This PR is a framework enhancement to have the consent to share submissions into the `Store` and the `ExposureSubmissionService`.

It is based on this [feature sub-task JIRA item](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3762).