### PR TITLE
Fix/3775 No increased frequency for exposure checks visible though new hourly packages available

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -518,6 +518,8 @@
 		EB858D2024E700D10048A0AA /* UIView+Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB858D1F24E700D10048A0AA /* UIView+Screenshot.swift */; };
 		EB873540253704D100325C6C /* UNUserNotificationCenter+DeadManSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB87353F253704D100325C6C /* UNUserNotificationCenter+DeadManSwitch.swift */; };
 		EBCD2412250790F400E5574C /* ExposureSubmissionSymptomsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD2411250790F400E5574C /* ExposureSubmissionSymptomsViewController.swift */; };
+		EBDE11B2255EC2C4008C0F51 /* DMDeviceTimeCheckViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDE11B1255EC2C4008C0F51 /* DMDeviceTimeCheckViewController.swift */; };
+		EBDE11BB255EC34C008C0F51 /* DMDeviceTimeCheckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDE11BA255EC34C008C0F51 /* DMDeviceTimeCheckViewModel.swift */; };
 		EBE7DF4A254C2DE8008A0648 /* key_download_parameters.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE7DF48254C2DE8008A0648 /* key_download_parameters.pb.swift */; };
 		EBE7DF4B254C2DE8008A0648 /* exposure_detection_parameters.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE7DF49254C2DE8008A0648 /* exposure_detection_parameters.pb.swift */; };
 		EE20EA072469883900770683 /* RiskLegend.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE20EA062469883900770683 /* RiskLegend.storyboard */; };
@@ -1116,6 +1118,8 @@
 		EB858D1F24E700D10048A0AA /* UIView+Screenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Screenshot.swift"; sourceTree = "<group>"; };
 		EB87353F253704D100325C6C /* UNUserNotificationCenter+DeadManSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+DeadManSwitch.swift"; sourceTree = "<group>"; };
 		EBCD2411250790F400E5574C /* ExposureSubmissionSymptomsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionSymptomsViewController.swift; sourceTree = "<group>"; };
+		EBDE11B1255EC2C4008C0F51 /* DMDeviceTimeCheckViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMDeviceTimeCheckViewController.swift; sourceTree = "<group>"; };
+		EBDE11BA255EC34C008C0F51 /* DMDeviceTimeCheckViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMDeviceTimeCheckViewModel.swift; sourceTree = "<group>"; };
 		EBE7DF48254C2DE8008A0648 /* key_download_parameters.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = key_download_parameters.pb.swift; path = ../../../gen/output/internal/key_download_parameters.pb.swift; sourceTree = "<group>"; };
 		EBE7DF49254C2DE8008A0648 /* exposure_detection_parameters.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = exposure_detection_parameters.pb.swift; path = ../../../gen/output/internal/exposure_detection_parameters.pb.swift; sourceTree = "<group>"; };
 		EE20EA062469883900770683 /* RiskLegend.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RiskLegend.storyboard; sourceTree = "<group>"; };
@@ -2587,7 +2591,6 @@
 				B1FC2D1C24D9C87F00083C81 /* DMKeysViewController.swift */,
 				B16457B424DC11EF002879EB /* DMLastSubmissionRequetViewController.swift */,
 				B16457BA24DC3309002879EB /* DMLogsViewController.swift */,
-				EB6B5D872539AE9400B0ED57 /* DMNotificationsViewController.swift */,
 				ABDA2791251CE308006BAE84 /* DMServerEnvironmentViewController.swift */,
 				9417BA94252B6B5100AD4053 /* DMSQLiteErrorViewController.swift */,
 				EB6B5D872539AE9400B0ED57 /* DMNotificationsViewController.swift */,
@@ -2596,6 +2599,7 @@
 				B1E8C99C2479D4E7006DC678 /* DMSubmissionStateViewController.swift */,
 				B1D8CB2524DD4371008C6010 /* DMTracingHistoryViewController.swift */,
 				BA6D164D255ADD8600ED3492 /* DMWifiClient */,
+				EBDE11B6255EC2D7008C0F51 /* DMDeviceTimeCheck */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -2884,6 +2888,15 @@
 				EB7057D624E6BACA002235B4 /* InfoBoxView.xib */,
 			);
 			path = BackgroundAppRefresh;
+			sourceTree = "<group>";
+		};
+		EBDE11B6255EC2D7008C0F51 /* DMDeviceTimeCheck */ = {
+			isa = PBXGroup;
+			children = (
+				EBDE11B1255EC2C4008C0F51 /* DMDeviceTimeCheckViewController.swift */,
+				EBDE11BA255EC34C008C0F51 /* DMDeviceTimeCheckViewModel.swift */,
+			);
+			path = DMDeviceTimeCheck;
 			sourceTree = "<group>";
 		};
 		EE20EA0824699A3A00770683 /* RiskLegend */ = {
@@ -3428,6 +3441,7 @@
 				AB5F84B224F8F7E3000400D4 /* Migration0To1.swift in Sources */,
 				A3EE6E5D249BB9B900C64B61 /* UITestingParameters.swift in Sources */,
 				EB08F17A2541CE3300D11FA9 /* risk_level.pb.swift in Sources */,
+				EBDE11B2255EC2C4008C0F51 /* DMDeviceTimeCheckViewController.swift in Sources */,
 				B1A31F6924DAE6C000E263DF /* DMKeyCell.swift in Sources */,
 				710224F42490E7A3000C5DEF /* ExposureSubmissionStepCell.swift in Sources */,
 				AB7420CB251B7D93006666AC /* DeltaOnboardingV15ViewController.swift in Sources */,
@@ -3505,6 +3519,7 @@
 				71B804492484D37300D53506 /* RiskLegendViewController.swift in Sources */,
 				01C2D43E2501225100FB23BF /* MockExposureSubmissionService.swift in Sources */,
 				514EE99B246D4C4C00DE4884 /* UITableView+Dequeue.swift in Sources */,
+				EBDE11BB255EC34C008C0F51 /* DMDeviceTimeCheckViewModel.swift in Sources */,
 				713EA25F24798A9100AB7EE8 /* ExposureDetectionRiskCell.swift in Sources */,
 				01F5F7222487B9C000229720 /* AppInformationViewController.swift in Sources */,
 				01C6AC32252B29C00052814D /* QRScannerError.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMViewController.swift
@@ -133,6 +133,8 @@ final class DMViewController: UITableViewController, RequiresAppDependencies {
 			vc = DMNotificationsViewController()
 		case .warnOthersNotifications:
 			vc = DMWarnOthersNotificationViewController(warnOthersReminder: warnOthersReminder, store: store)
+		case .deviceTimeCheck:
+			vc = DMDeviceTimeCheckViewController(store: store)
 		}
 		
 		

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewController.swift
@@ -1,0 +1,59 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+#if !RELEASE
+
+import UIKit
+
+final class DMDeviceTimeCheckViewController: UITableViewController {
+
+	// MARK: - Init
+
+	init(store: Store) {
+		self.viewModel = DMDeviceTimeCheckViewModel(store: store)
+		super.init(style: .insetGrouped)
+	}
+
+	required init?(coder: NSCoder) {
+		fatalError("not supported")
+	}
+
+	// MARK: - Overrides
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		setupTableView()
+		title = "Device Time Check 📱 🕰"
+	}
+
+	// MARK: - Protocol UITableViewDataSource
+
+	override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		return viewModel.itemsCount
+	}
+
+	override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		guard let cell = tableView.dequeueReusableCell(withIdentifier: "DMSwitchTableViewCell") as? DMSwitchTableViewCell else {
+			let dummy = UITableViewCell(style: .default, reuseIdentifier: "DummyFallBackCell")
+			dummy.textLabel?.text = "Fallback cell"
+			return dummy
+		}
+		cell.configure(cellViewModel: viewModel.cellViewModel(for: indexPath))
+		return cell
+	}
+
+	// MARK: - Public
+
+	// MARK: - Internal
+
+	// MARK: - Private
+
+	private let viewModel: DMDeviceTimeCheckViewModel
+
+	private func setupTableView() {
+		tableView.register(UINib(nibName: "DMSwitchTableViewCell", bundle: nil), forCellReuseIdentifier: "DMSwitchTableViewCell")
+	}
+}
+
+#endif

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
@@ -1,0 +1,56 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+#if !RELEASE
+
+import Foundation
+import UIKit
+
+final class DMDeviceTimeCheckViewModel {
+
+	// MARK: - Init
+
+	init(store: Store) {
+		self.store = store
+	}
+
+	// MARK: - Overrides
+
+	// MARK: - Public
+
+	// MARK: - Internal
+
+	var itemsCount: Int {
+		return menuItems.allCases.count
+	}
+
+	func cellViewModel(for indexPath: IndexPath) -> DMSwitchCellViewModel {
+		guard let item = menuItems(rawValue: indexPath.row) else {
+			fatalError("failed to create cellViewModel")
+		}
+		switch item {
+
+		case .killDeviceTimeCheck:
+			return DMSwitchCellViewModel(
+				labelText: "Disable device time check",
+				isEnabled: { [store] in
+					store.dmKillDeviceTimeCheck ?? false
+				}, toggle: { [store] in
+					store.dmKillDeviceTimeCheck = !(store.dmKillDeviceTimeCheck ?? false)
+					Log.info("Device time check: \((store.dmKillDeviceTimeCheck ?? false) ? "disabled" :"enabled")")
+				})
+		}
+	}
+
+	// MARK: - Private
+	
+	private let store: Store
+
+	private enum menuItems: Int, CaseIterable {
+		case killDeviceTimeCheck
+	}
+
+}
+
+#endif

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
@@ -35,10 +35,10 @@ final class DMDeviceTimeCheckViewModel {
 			return DMSwitchCellViewModel(
 				labelText: "Disable device time check",
 				isOn: { [store] in
-					store.dmKillDeviceTimeCheck ?? false
+					store.dmKillDeviceTimeCheck
 				}, toggle: { [store] in
-					store.dmKillDeviceTimeCheck = !(store.dmKillDeviceTimeCheck ?? false)
-					Log.info("Device time check: \((store.dmKillDeviceTimeCheck ?? false) ? "disabled" :"enabled")")
+					store.dmKillDeviceTimeCheck.toggle()
+					Log.info("Device time check: \(store.dmKillDeviceTimeCheck ? "disabled" :"enabled")")
 				})
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMDeviceTimeCheck/DMDeviceTimeCheckViewModel.swift
@@ -34,7 +34,7 @@ final class DMDeviceTimeCheckViewModel {
 		case .killDeviceTimeCheck:
 			return DMSwitchCellViewModel(
 				labelText: "Disable device time check",
-				isEnabled: { [store] in
+				isOn: { [store] in
 					store.dmKillDeviceTimeCheck ?? false
 				}, toggle: { [store] in
 					store.dmKillDeviceTimeCheck = !(store.dmKillDeviceTimeCheck ?? false)

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchCellViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 struct DMSwitchCellViewModel {
 
 	let labelText: String
-	let isEnabled: () -> Bool
+	let isOn: () -> Bool
 	let toggle: () -> Void
 
 }

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchCellViewModel.swift
@@ -1,11 +1,5 @@
-// http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// 🦠 Corona-Warn-App
 //
 
 #if !RELEASE

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchTableViewCell.swift
@@ -1,11 +1,5 @@
-// http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// 🦠 Corona-Warn-App
 //
 
 #if !RELEASE

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/Cell/DMSwitchTableViewCell.swift
@@ -23,7 +23,7 @@ class DMSwitchTableViewCell: UITableViewCell {
 
 	func configure(cellViewModel: DMSwitchCellViewModel) {
 		infoLabel.text = cellViewModel.labelText
-		toggleSwitch.isOn = cellViewModel.isEnabled()
+		toggleSwitch.isOn = cellViewModel.isOn()
 		self.cellViewModel = cellViewModel
 	}
 

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewController.swift
@@ -1,20 +1,5 @@
 //
-// Corona-Warn-App
-//
-// SAP SE and all other contributors
-// copyright owners license this file to you under the Apache
-// License, Version 2.0 (the "License"); you may not use this
-// file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// 🦠 Corona-Warn-App
 //
 
 #if !RELEASE

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewModel.swift
@@ -1,11 +1,5 @@
-// http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// 🦠 Corona-Warn-App
 //
 
 #if !RELEASE

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMWifiClient/DMWifiClientViewModel.swift
@@ -34,7 +34,7 @@ final class DMWifiClientViewModel {
 		case .wifiMode:
 			return DMSwitchCellViewModel(
 				labelText: "Disable hourly packages download",
-				isEnabled: { [wifiClient] in
+				isOn: { [wifiClient] in
 					wifiClient.disableHourlyDownload
 				}, toggle: { [wifiClient] in
 					wifiClient.disableHourlyDownload = !wifiClient.disableHourlyDownload
@@ -44,7 +44,7 @@ final class DMWifiClientViewModel {
 		case .disableClient:
 			return DMSwitchCellViewModel(
 				labelText: "Hourly packages over WiFi only",
-				isEnabled: { [wifiClient] in
+				isOn: { [wifiClient] in
 					return wifiClient.isWifiOnlyActive
 				},
 				toggle: { [wifiClient] in

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMMenuItem.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Helper/DMMenuItem.swift
@@ -23,6 +23,7 @@ enum DMMenuItem: Int, CaseIterable {
 	case simulateNoDiskSpace
 	case listPendingNotifications
 	case warnOthersNotifications
+	case deviceTimeCheck
 }
 
 extension DMMenuItem {
@@ -55,6 +56,7 @@ extension DMMenuItem {
 		case .simulateNoDiskSpace: return "Simulate SQLite Error"
 		case .listPendingNotifications: return "Pending Notifications"
 		case .warnOthersNotifications: return "Warn Others Notifications"
+		case .deviceTimeCheck: return "Device Time Check"
 		}
 	}
 	var subtitle: String {
@@ -75,6 +77,7 @@ extension DMMenuItem {
 		case .simulateNoDiskSpace: return "Simulates SQLite returns defined error"
 		case .listPendingNotifications: return "List all pending Notifications"
 		case .warnOthersNotifications: return "Settings for the warn others notifications"
+		case .deviceTimeCheck: return "Enable or Disable Device Time Check"
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -52,6 +52,15 @@ final class CachedAppConfiguration {
 
 		client.fetchAppConfiguration(etag: etag) { [weak self] result in
 			guard let self = self else { return }
+			
+			if let serverTime = result.1 {
+				self.deviceTimeCheck.updateDeviceTimeFlags(
+					serverTime: serverTime,
+					deviceTime: Date()
+				)
+			} else {
+				self.deviceTimeCheck.resetDeviceTimeFlags()
+			}
 
 			switch result.0 /* fyi, `result.1` would be the server time */{
 			case .success(let response):
@@ -103,15 +112,6 @@ final class CachedAppConfiguration {
 				default:
 					self.completeOnMain(completion: completion, result: .failure(error))
 				}
-			}
-
-			if let serverTime = result.1 {
-				self.deviceTimeCheck.updateDeviceTimeFlags(
-					serverTime: serverTime,
-					deviceTime: Date()
-				)
-			} else {
-				self.deviceTimeCheck.resetDeviceTimeFlags()
 			}
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
@@ -72,7 +72,7 @@ final class DeviceTimeCheck: DeviceTimeCheckProtocol {
 
 	private func isDeviceTimeCheckKillSwitchActive(config: SAP_Internal_ApplicationConfiguration?) -> Bool {
 		#if !RELEASE
-		if store.dmKillDeviceTimeCheck ?? false {
+		if store.dmKillDeviceTimeCheck {
 			return true
 		}
 		#endif

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
@@ -71,6 +71,11 @@ final class DeviceTimeCheck: DeviceTimeCheckProtocol {
 	}
 
 	private func isDeviceTimeCheckKillSwitchActive(config: SAP_Internal_ApplicationConfiguration?) -> Bool {
+		#if !RELEASE
+		if store.dmKillDeviceTimeCheck ?? false {
+			return true
+		}
+		#endif
 		guard let config = config else {
 			return false
 		}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -348,8 +348,16 @@ extension RiskProvider: RiskProviding {
 
 		let config = riskProvidingConfiguration
 		let shouldDetectExposures = (config.detectionMode == .manual && userInitiated) || config.detectionMode == .automatic
-
-		return !enoughTimeHasPassed || !exposureManagerState.isGood || !shouldDetectExposures || !shouldDetectExposureBecauseOfNewPackages
+		
+		/// If the User is in manual mode and wants to refresh we should let him. Case: Manual Mode and Wifi disabled will lead to no new packages in the last 23 hours and 59 Minutes, but a refresh interval of 4 Hours should allow this.
+		let shouldDetectExposureBecauseOfNewPackagesConsideringDetectionMode = shouldDetectExposureBecauseOfNewPackages || (config.detectionMode == .manual && userInitiated)
+		
+		Log.info("RiskProvider: Precondition fulfilled for fresh risk detection: enoughTimeHasPassed = \(enoughTimeHasPassed)", log: .riskDetection)
+		Log.info("RiskProvider: Precondition fulfilled for fresh risk detection: exposureManagerState.isGood = \(exposureManagerState.isGood)", log: .riskDetection)
+		Log.info("RiskProvider: Precondition fulfilled for fresh risk detection: shouldDetectExposures = \(shouldDetectExposures)", log: .riskDetection)
+		Log.info("RiskProvider: Precondition fulfilled for fresh risk detection: shouldDetectExposureBecauseOfNewPackagesConsideringDetectionMode = \(shouldDetectExposureBecauseOfNewPackagesConsideringDetectionMode)", log: .riskDetection)
+		
+		return !(enoughTimeHasPassed && exposureManagerState.isGood && shouldDetectExposures && shouldDetectExposureBecauseOfNewPackagesConsideringDetectionMode)
 	}
 
 	private var shouldDetectExposureBecauseOfNewPackages: Bool {

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -54,6 +54,7 @@ final class MockTestStore: Store, AppConfigCaching {
 	#if !RELEASE
 	// Settings from the debug menu.
 	var fakeSQLiteError: Int32?
+	var dmKillDeviceTimeCheck: Bool?
 	#endif
 
 	// MARK: - AppConfigCaching

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -54,7 +54,7 @@ final class MockTestStore: Store, AppConfigCaching {
 	#if !RELEASE
 	// Settings from the debug menu.
 	var fakeSQLiteError: Int32?
-	var dmKillDeviceTimeCheck: Bool?
+	var dmKillDeviceTimeCheck = false
 	#endif
 
 	// MARK: - AppConfigCaching

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -252,6 +252,11 @@ final class SecureStore: Store {
 		get { kvStore["fakeSQLiteError"] as Int32? }
 		set { kvStore["fakeSQLiteError"] = newValue }
 	}
+	
+	var dmKillDeviceTimeCheck: Bool? {
+		get { kvStore["dmKillDeviceTimeCheck"] as Bool? }
+		set { kvStore["dmKillDeviceTimeCheck"] = newValue }
+	}
 
 	#endif
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -253,8 +253,8 @@ final class SecureStore: Store {
 		set { kvStore["fakeSQLiteError"] = newValue }
 	}
 	
-	var dmKillDeviceTimeCheck: Bool? {
-		get { kvStore["dmKillDeviceTimeCheck"] as Bool? }
+	var dmKillDeviceTimeCheck: Bool {
+		get { kvStore["dmKillDeviceTimeCheck"] as Bool? ?? false }
 		set { kvStore["dmKillDeviceTimeCheck"] = newValue }
 	}
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -125,7 +125,7 @@ protocol StoreProtocol: AnyObject {
 	#if !RELEASE
 	/// Settings from the debug menu.
 	var fakeSQLiteError: Int32? { get set }
-	var dmKillDeviceTimeCheck: Bool? { get set }
+	var dmKillDeviceTimeCheck: Bool { get set }
 	#endif
 
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -125,6 +125,7 @@ protocol StoreProtocol: AnyObject {
 	#if !RELEASE
 	/// Settings from the debug menu.
 	var fakeSQLiteError: Int32? { get set }
+	var dmKillDeviceTimeCheck: Bool? { get set }
 	#endif
 
 }


### PR DESCRIPTION
## Description
- Adds a Switch in the DM to disable Device-Time-Check.
- Fixes an Issue where Device-Time-Check is not done if the Etag of the AppConfig does not change
- Fixes an Edge-Case in manual mode where the user gets requested to update his risk-score but nothing happens.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3775

## Screenshot
![Simulator Screen Shot - iPhone 12 Pro Max - 2020-11-13 at 16 49 29](https://user-images.githubusercontent.com/10122052/99091446-33f43600-25d0-11eb-914c-fdef8dcbcdca.png)
