### PR TITLE
Fix/3809 No reminder to share a positive test result if user first register QR code before test result positive

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
@@ -125,7 +125,7 @@ class ExposureSubmissionTestResultViewModel {
 	}
 	
 	func updateWarnOthers() {
-		self.warnOthersReminder.evaluateNotificationState(testResult: self.testResult)
+		warnOthersReminder.evaluateNotificationState(testResult: testResult)
 	}
 	
 	private func updateButtons() {
@@ -163,6 +163,7 @@ class ExposureSubmissionTestResultViewModel {
 				self?.error = error
 			case let .success(testResult):
 				self?.testResult = testResult
+				self?.updateWarnOthers()
 			}
 
 			completion()

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
@@ -84,6 +84,10 @@ class ExposureSubmissionTestResultViewModel {
 		// Update warn others model
 		self.warnOthersReminder.reset()
 	}
+	
+	func updateWarnOthers() {
+		warnOthersReminder.evaluateNotificationState(testResult: testResult)
+	}
 
 	// MARK: - Private
 
@@ -122,10 +126,6 @@ class ExposureSubmissionTestResultViewModel {
 	private func updateForCurrentTestResult() {
 		self.dynamicTableViewModel = DynamicTableViewModel([currentTestResultSection])
 		updateButtons()
-	}
-	
-	func updateWarnOthers() {
-		warnOthersReminder.evaluateNotificationState(testResult: testResult)
 	}
 	
 	private func updateButtons() {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -453,7 +453,7 @@ extension HomeInteractor {
 extension HomeInteractor {
 	func updateTestResults() {
 		
-		// Do warn others evaluation
+		// Do warn others reminder evaluation
 		if let testResult = testResult {
 			self.warnOthersReminder.evaluateNotificationState(testResult: testResult)
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeInteractor.swift
@@ -482,8 +482,8 @@ extension HomeInteractor {
 					}
 				)
 
-			case .success(let result):
-				switch result {
+			case .success(let testResult):
+				switch testResult {
 				case .expired:
 					self?.homeViewController.alertError(
 						message: AppStrings.ExposureSubmissionResult.testExpiredDesc,
@@ -493,13 +493,14 @@ extension HomeInteractor {
 							self?.reloadTestResult(with: .invalid)
 						}
 					)
-				default:
+				case .invalid, .negative, .positive, .pending:
 					let requestTime = Date().timeIntervalSince(requestStart)
 					let delay = requestTime < minRequestTime && self?.testResult == nil ? minRequestTime : 0
 					DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-						self?.testResult = result
-						self?.reloadTestResult(with: result)
+						self?.testResult = testResult
+						self?.reloadTestResult(with: testResult)
 					}
+					self?.warnOthersReminder.evaluateNotificationState(testResult: testResult)
 				}
 			}
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -187,6 +187,10 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 	@objc
 	func refreshUIAfterResumingFromBackground() {
 		homeInteractor.refreshTimerAfterResumingFromBackground()
+		
+		// (kga) fix for not showing notifications if the app is resuming from background
+		homeInteractor.updateTestResults()
+		
 	}
 
 	// Called by HomeInteractor

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeViewController.swift
@@ -187,10 +187,7 @@ final class HomeViewController: UIViewController, RequiresAppDependencies {
 	@objc
 	func refreshUIAfterResumingFromBackground() {
 		homeInteractor.refreshTimerAfterResumingFromBackground()
-		
-		// (kga) fix for not showing notifications if the app is resuming from background
 		homeInteractor.updateTestResults()
-		
 	}
 
 	// Called by HomeInteractor


### PR DESCRIPTION
This PR fixes an issue if the test result changes while the user has the app in the background (so the test result was `pending` and changed to `positive` on the server.

Also, this PR fixes an issue with "updating" an existing `pending` result and the updated state is `positive`.

Now in both situations, the two "warn others reminder" get scheduled as expected.

The PR is [based on this JIRA Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3809)