### PR TITLE
Describe origin of public keys

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/PublicKeyStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/PublicKeyStore.swift
@@ -33,6 +33,9 @@ enum PublicKeyEnv {
 	case development
 
 	/// Returns the string representation of the PK.
+	/// Note that the values are taken from the regular PK in PEM format but without the first 36 characters,
+	/// which denote PEM header information. These 36 characters are typically:
+	/// `MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE`
 	///
 	/// We don't want to rely on `rawValue` but make accessing the key an explicit action.
 	var stringRepresentation: StaticString {


### PR DESCRIPTION
This PR adds a comment to `PublicKeyStore.swift` describing the format of the hard-coded public keys.

Reason for this is that we were wondering why they are different than on Android. To answer this, we had to reach out to Engineers from the early phase of the project. That's why I though it would might be a good idea to add the finding as a comment for our future selves and and other Engineers 😅 