### PR TITLE
Fix UI freeze: Don't dispatch to main in URLSession

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/URLSession+Default.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/URLSession+Default.swift
@@ -18,7 +18,7 @@ extension URLSession {
 		return URLSession(
 			configuration: .coronaWarnSessionConfiguration(),
 			delegate: coronaWarnURLSessionDelegate,
-			delegateQueue: .main
+			delegateQueue: nil
 		)
 		
 	}


### PR DESCRIPTION
## Description
This removes the dispatch of URLSession completions to the main thread so the completions don't freeze up the UI anymore

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3918
