### PR TITLE
Call completion instead of failing on target queue

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -196,7 +196,7 @@ final class RiskProvider: RiskProviding {
 		// 1. The exposureManagerState is bad (turned off, not authorized, etc.)
 		if !exposureManagerState.isGood {
 			Log.info("RiskProvider: Precondition not met for ExposureManagerState", log: .riskDetection)
-			failOnTargetQueue(error: .inactive)
+			completion(.failure(.inactive))
 			return
 		}
 


### PR DESCRIPTION
## Description
Removes an accidental 8 minute lock that came from a missing completion call. This was the cause for a bug, that the risk calculation was not run for 8 minutes after it was attempted to run in the inactive state.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3949
