### PR TITLE
Fix/fix for leave crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -53,11 +53,11 @@ final class RiskProvider: RiskProviding {
 	}
 
 	func observeRisk(_ consumer: RiskConsumer) {
-		consumers.append(consumer)
+		consumers.insert(consumer)
 	}
 
 	func removeRisk(_ consumer: RiskConsumer) {
-		consumers.removeAll(where: { $0 === consumer })
+		consumers.remove(consumer)
 	}
 
 	/// Called by consumers to request the risk level. This method triggers the risk level process.
@@ -101,8 +101,8 @@ final class RiskProvider: RiskProviding {
 
 	private var subscriptions = [AnyCancellable]()
 	
-	private var _consumers: [RiskConsumer] = []
-	private var consumers: [RiskConsumer] {
+	private var _consumers: Set<RiskConsumer> = Set<RiskConsumer>()
+	private var consumers: Set<RiskConsumer> {
 		get { consumersQueue.sync { _consumers } }
 		set { consumersQueue.sync { _consumers = newValue } }
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -53,11 +53,11 @@ final class RiskProvider: RiskProviding {
 	}
 
 	func observeRisk(_ consumer: RiskConsumer) {
-		consumers.insert(consumer)
+		consumers.append(consumer)
 	}
 
 	func removeRisk(_ consumer: RiskConsumer) {
-		consumers.remove(consumer)
+		consumers.removeAll(where: { $0 === consumer })
 	}
 
 	/// Called by consumers to request the risk level. This method triggers the risk level process.
@@ -101,8 +101,8 @@ final class RiskProvider: RiskProviding {
 
 	private var subscriptions = [AnyCancellable]()
 	
-	private var _consumers: Set<RiskConsumer> = Set<RiskConsumer>()
-	private var consumers: Set<RiskConsumer> {
+	private var _consumers: [RiskConsumer] = []
+	private var consumers: [RiskConsumer] {
 		get { consumersQueue.sync { _consumers } }
 		set { consumersQueue.sync { _consumers = newValue } }
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -409,12 +409,12 @@ final class RiskProviderTests: XCTestCase {
 
 	// MARK: - RiskProvider stress test
 
-	func test_When_RequestRiskIsCalledFromDifferentThreads_Then_ItReturnsWithAlreadyRunningErrorOrCalculatedRisk() throws {
+	func test_When_RequestRiskIsCalledFromDifferentThreads_Then_ItReturnsWithAlreadyRunningErrorOrCalculatedRisk() {
 
 		let numberOfRequestRiskCalls = 30
 		let numberOfExecuteENABackgroundTask = 10
 
-		let riskProvider = try makeSomeRiskProvider()
+		let riskProvider = makeSomeRiskProvider()
 		let riskConsumer = RiskConsumer()
 		riskProvider.observeRisk(riskConsumer)
 
@@ -454,7 +454,7 @@ final class RiskProviderTests: XCTestCase {
 
 	// MARK: - Private
 
-	private func makeSomeRiskProvider() throws -> RiskProvider {
+	private func makeSomeRiskProvider() -> RiskProvider {
 		let duration = DateComponents(day: 1)
 
 		let store = MockTestStore()

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -448,7 +448,7 @@ final class RiskProviderTests: XCTestCase {
 			appDelegate.executeENABackgroundTask { _ in }
 		}
 
-		waitForExpectations(timeout: 20)
+		waitForExpectations(timeout: .extraLong)
 	}
 
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -30,7 +30,7 @@ final class RiskProviderTests: XCTestCase {
 			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
 			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
 			riskCalculation: RiskCalculationFake(),
-			keyPackageDownload: keyPackageDownloadMock(with: store),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			exposureDetectionExecutor: exposureDetectionDelegateStub
 		)
 
@@ -77,7 +77,7 @@ final class RiskProviderTests: XCTestCase {
 			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
 			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
 			riskCalculation: RiskCalculationFake(),
-			keyPackageDownload: keyPackageDownloadMock(with: store),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			exposureDetectionExecutor: exposureDetectionDelegateStub
 		)
 
@@ -143,7 +143,7 @@ final class RiskProviderTests: XCTestCase {
 			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
 			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
 			riskCalculation: RiskCalculationFake(),
-			keyPackageDownload: keyPackageDownloadMock(with: store),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			exposureDetectionExecutor: exposureDetectionDelegateStub
 		)
 
@@ -181,7 +181,7 @@ final class RiskProviderTests: XCTestCase {
 			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
 			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
 			riskCalculation: RiskCalculationFake(),
-			keyPackageDownload: keyPackageDownloadMock(with: store),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			exposureDetectionExecutor: exposureDetectionDelegateStub
 		)
 
@@ -220,7 +220,7 @@ final class RiskProviderTests: XCTestCase {
 			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
 			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
 			riskCalculation: RiskCalculationFake(),
-			keyPackageDownload: keyPackageDownloadMock(with: store),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			exposureDetectionExecutor: exposureDetectionDelegateStub
 		)
 
@@ -407,9 +407,82 @@ final class RiskProviderTests: XCTestCase {
 		XCTAssertFalse(store.shouldShowRiskStatusLoweredAlert)
 	}
 
+	// MARK: - RiskProvider stress test
+
+	func test_When_RequestRiskIsCalledFromDifferentThreads_Then_ItReturnsWithAlreadyRunningErrorOrCalculatedRisk() throws {
+
+		let numberOfRequestRiskCalls = 30
+		let numberOfExecuteENABackgroundTask = 10
+
+		let riskProvider = try makeSomeRiskProvider()
+		let riskConsumer = RiskConsumer()
+		riskProvider.observeRisk(riskConsumer)
+
+		let didCallbackExpectation = expectation(description: "Called didCalculateRisk or didFailCalculateRisk.")
+		didCallbackExpectation.expectedFulfillmentCount = numberOfRequestRiskCalls + numberOfExecuteENABackgroundTask
+		riskConsumer.didCalculateRisk = { _ in
+			didCallbackExpectation.fulfill()
+		}
+
+		riskConsumer.didFailCalculateRisk = { error in
+			didCallbackExpectation.fulfill()
+
+			if error.isAlreadyRunningError {
+				return
+			}
+
+			XCTFail("Error besides of isAlreadyRunningError should not happen.")
+		}
+
+		let concurrentQueue = DispatchQueue(label: "RiskProviderStressTest", attributes: .concurrent)
+		for _ in 0...numberOfRequestRiskCalls - 1 {
+			concurrentQueue.async {
+				riskProvider.requestRisk(userInitiated: false)
+			}
+		}
+
+		let appDelegate = AppDelegate()
+		appDelegate.riskProvider = riskProvider
+
+		for _ in 0...numberOfExecuteENABackgroundTask - 1 {
+			appDelegate.executeENABackgroundTask { _ in }
+		}
+
+		waitForExpectations(timeout: 20)
+	}
+
+
 	// MARK: - Private
 
-	private func keyPackageDownloadMock(with store: Store) -> KeyPackageDownload {
+	private func makeSomeRiskProvider() throws -> RiskProvider {
+		let duration = DateComponents(day: 1)
+
+		let store = MockTestStore()
+		store.riskCalculationResult = nil
+
+		let config = RiskProvidingConfiguration(
+			exposureDetectionValidityDuration: duration,
+			exposureDetectionInterval: duration
+		)
+
+		let exposureDetectionDelegateStub = ExposureDetectionDelegateStub(result: .success([MutableENExposureWindow()]))
+
+		let downloadedPackagesStore: DownloadedPackagesStore = DownloadedPackagesSQLLiteStore.inMemory()
+		downloadedPackagesStore.open()
+
+		return RiskProvider(
+			configuration: config,
+			store: store,
+			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
+			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
+			riskCalculation: RiskCalculationFake(),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
+			exposureDetectionExecutor: exposureDetectionDelegateStub
+		)
+
+	}
+
+	private func makeKeyPackageDownloadMock(with store: Store) -> KeyPackageDownload {
 		let downloadedPackagesStore: DownloadedPackagesStore = DownloadedPackagesSQLLiteStore.inMemory()
 		downloadedPackagesStore.open()
 


### PR DESCRIPTION
## Description
This PR fixes a possibility for the leave crash to occur.
The `Set` in `RiskProvider` prevents that the same consumer is registered more than once and then called more than once.
Possible multiple calls to the `RiskConsumer` lead to multiple calls of `.leave()` in `ENATaskExecutionDelegate`. 

