### PR TITLE
Feature/3755 handle legal texts

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		351E6306256BEC8D00D89B29 /* LabeledCountriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351E6305256BEC8D00D89B29 /* LabeledCountriesView.swift */; };
 		351E630C256C5B9C00D89B29 /* LabeledCountriesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351E630A256C5B9C00D89B29 /* LabeledCountriesCell.swift */; };
 		351E630D256C5B9C00D89B29 /* LabeledCountriesCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 351E630B256C5B9C00D89B29 /* LabeledCountriesCell.xib */; };
+		3523F8A82570F819004B0424 /* NSAttributedString+BulletPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3523F8A72570F819004B0424 /* NSAttributedString+BulletPoint.swift */; };
 		352E0F19255D537C00DC3E20 /* AppConfiguration+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352E0F18255D537C00DC3E20 /* AppConfiguration+Validation.swift */; };
 		352F25A824EFCBDE00ACDFF3 /* ServerEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352F25A724EFCBDE00ACDFF3 /* ServerEnvironment.swift */; };
 		35327FF6256D4CE600C36A44 /* UIStackView+prune.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35327FF5256D4CE600C36A44 /* UIStackView+prune.swift */; };
@@ -738,6 +739,7 @@
 		351E630A256C5B9C00D89B29 /* LabeledCountriesCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledCountriesCell.swift; sourceTree = "<group>"; };
 		351E630B256C5B9C00D89B29 /* LabeledCountriesCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabeledCountriesCell.xib; sourceTree = "<group>"; };
 		3523CA31252DC617002E6DEC /* Screenshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Screenshots.xctestplan; path = TestPlans/Screenshots.xctestplan; sourceTree = "<group>"; };
+		3523F8A72570F819004B0424 /* NSAttributedString+BulletPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+BulletPoint.swift"; sourceTree = "<group>"; };
 		352E0F18255D537C00DC3E20 /* AppConfiguration+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppConfiguration+Validation.swift"; sourceTree = "<group>"; };
 		352F25A724EFCBDE00ACDFF3 /* ServerEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerEnvironment.swift; sourceTree = "<group>"; };
 		35327FF5256D4CE600C36A44 /* UIStackView+prune.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+prune.swift"; sourceTree = "<group>"; };
@@ -1762,6 +1764,7 @@
 				B153096B24706F2400A4A1BD /* URLSessionConfiguration+Default.swift */,
 				AB7E2A7F255ACC06005C90F6 /* Date+Utils.swift */,
 				5270E9B7256D20A900B08606 /* NSTextAttachment+ImageHeight.swift */,
+				3523F8A72570F819004B0424 /* NSAttributedString+BulletPoint.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3463,6 +3466,7 @@
 				A3552CC424DD6E16008C91BE /* AppDelegate+PlausibleDeniability.swift in Sources */,
 				2FA9E39924D2F4350030561C /* ExposureSubmission+ErrorParsing.swift in Sources */,
 				514EE99D246D4CFB00DE4884 /* TableViewCellConfigurator.swift in Sources */,
+				3523F8A82570F819004B0424 /* NSAttributedString+BulletPoint.swift in Sources */,
 				AB5F84AD24F8F7A1000400D4 /* SerialMigrator.swift in Sources */,
 				01D3078A2562B03C00ADB67B /* RiskState.swift in Sources */,
 				01F52FF42552DB9600997A26 /* DMAppConfigurationViewController.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -31,14 +31,6 @@
 
 "ExposureSubmissionQRInfo_acknowledgement_2_2" = "Sie können Ihr Einverständnis jederzeit zurücknehmen. Die Einstellung hierfür finden Sie unter „Test anzeigen“. Vor dem Teilen werden Sie nochmal auf Ihr Einverständnis hingewiesen und um Freigabe Ihres Testergebnisses gebeten.";
 
-"ExposureSubmissionQRInfo_acknowledgement_3" = "Ihr Einverständnis ist freiwillig.";
-
-"ExposureSubmissionQRInfo_acknowledgement_4" = "Sie können Ihr Testergebnis auch abrufen, wenn Sie dies nicht teilen. Wenn Sie ihr Testergebnis teilen, helfen Sie jedoch mit, Ihre Mitmenschen vor Ansteckungen zu schützen.";
-
-"ExposureSubmissionQRInfo_acknowledgement_5" = "Ihre Identität bleibt geheim. Andere Nutzer erfahren nicht, wer sein Testergebnis geteilt hat.";
-
-"ExposureSubmissionQRInfo_acknowledgement_6" = "Sie können Ihr Einverständnis abgeben, wenn Sie mindestens 16 Jahre alt sind.";
-
 /* Automatic share submission result consent */
 
 "AutomaticSharingConsent_Subtitle" = "Einverständnis";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -492,6 +492,14 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionQRInfo_body_section_2" = "Wenn Sie positiv auf Corona getestet wurden, können Sie Ihre Mitmenschen über die App warnen. Die Warnung funktioniert in mehreren Ländern. Derzeit nehmen folgende Länder teil:";
 
+"ExposureSubmissionQRInfo_acknowledgement_3" = "Ihr Einverständnis ist freiwillig.";
+
+"ExposureSubmissionQRInfo_acknowledgement_4" = "Sie können Ihr Testergebnis auch abrufen, wenn Sie dies nicht teilen. Wenn Sie ihr Testergebnis teilen, helfen Sie jedoch mit, Ihre Mitmenschen vor Ansteckungen zu schützen.";
+
+"ExposureSubmissionQRInfo_acknowledgement_5" = "Ihre Identität bleibt geheim. Andere Nutzer erfahren nicht, wer sein Testergebnis geteilt hat.";
+
+"ExposureSubmissionQRInfo_acknowledgement_6" = "Sie können Ihr Einverständnis abgeben, wenn Sie mindestens 16 Jahre alt sind.";
+
 "ExposureSubmissionQRInfo_primaryButtonTitle" = "Einverstanden";
 
 "ExposureSubmissionQRInfo_QRCodeExpired_Alert_Title" = "QR-Code nicht mehr gültig";

--- a/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
@@ -6,7 +6,6 @@ import UIKit
 
 extension NSAttributedString {
 
-
 	/// Prefixes an attributed string with a bullet point (\u{2022}).
 	///
 	///  Line breaks will add further bullet points, tabs (`\t`) will not.

--- a/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
@@ -1,0 +1,60 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import UIKit
+
+extension NSAttributedString {
+
+
+	/// Prefixes an attributed string with a bullet point (\u{2022}).
+	///
+	///  Line breaks will add further bullet points, tabs (`\t`) will not.
+	///
+	/// - Parameters:
+	///   - from: The initial attributed string.
+	///   - bulletPointFont: The Font for the bullet point and first part of the `from` string. Required to align and scale the bullet point.
+	/// - Returns: An attributed string that is prefixed with a bullet point.
+	static func bulletPointString(_ from: NSAttributedString, bulletPointFont font: UIFont) -> NSAttributedString {
+		// <bullet point>|--- indentation ---|<rest of text>
+		let indentation: CGFloat = 20.0
+		let paragraphStyle = NSMutableParagraphStyle()
+		paragraphStyle.tabStops = [NSTextTab(textAlignment: .natural, location: indentation, options: [:])]
+		paragraphStyle.defaultTabInterval = indentation
+		paragraphStyle.headIndent = indentation
+		paragraphStyle.paragraphSpacing = 8
+
+		let bulletAttributes: [NSAttributedString.Key: Any] = [
+			.font: font.scaledFont(size: font.pointSize, weight: .black),
+			.foregroundColor: UIColor.label
+		]
+
+		let bullet = "\u{2022}"
+		let prefixString = "\(bullet)\t"
+		let attributedString = NSMutableAttributedString(string: prefixString)
+		attributedString.append(from)
+
+		// style bullet point
+		let string = NSString(string: prefixString)
+		let rangeForBullet = string.range(of: bullet)
+		attributedString.addAttributes(bulletAttributes, range: rangeForBullet)
+
+		// style text paragraphs
+		attributedString.addAttributes(
+			[NSAttributedString.Key.paragraphStyle: paragraphStyle],
+			range: NSRange(location: 0, length: attributedString.length))
+
+		return attributedString
+	}
+
+	/// Prefixes an attributed string with a bullet point (\u{2022}).
+	///
+	///  Line breaks will add further bullet points, tabs (`\t`) will not.
+	///
+	/// - Parameters:
+	///   - bulletPointFont: The Font for the bullet point and first part of the `from` string. Required to align and scale the bullet point.
+	/// - Returns: An attributed string that is prefixed with a bullet point.
+	func bulletPointString(bulletPointFont font: UIFont) -> NSAttributedString {
+		return NSAttributedString.bulletPointString(self, bulletPointFont: font)
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
@@ -8,7 +8,8 @@ extension NSAttributedString {
 
 	/// Prefixes an attributed string with a bullet point (\u{2022}).
 	///
-	///  Line breaks will add further bullet points, tabs (`\t`) will not.
+	///  Line breaks will add further bullet points, tabs on line-start (`\t`) will not. Example:
+	///  `"TEXT_A\n\tTEXT_B"` would create a 2 paragraph text with one bullet point.
 	///
 	/// - Parameters:
 	///   - from: The initial attributed string.

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
@@ -115,6 +115,25 @@ extension DynamicCell {
 	static func bulletPoint(
 		text: String,
 		spacing: DynamicTableViewBulletPointCell.Spacing = .normal,
+		alignment: DynamicTableViewBulletPointCell.Alignment = .normal,
+		accessibilityIdentifier: String? = nil,
+		accessibilityTraits: UIAccessibilityTraits = .staticText,
+		action: DynamicAction = .none,
+		configure: CellConfigurator? = nil
+	) -> Self {
+		.bulletPoint(attributedText: NSAttributedString(string: text),
+					 spacing: spacing,
+					 alignment: alignment,
+					 accessibilityIdentifier: accessibilityIdentifier,
+					 accessibilityTraits: accessibilityTraits,
+					 action: action,
+					 configure: configure)
+	}
+
+	static func bulletPoint(
+		attributedText: NSAttributedString,
+		spacing: DynamicTableViewBulletPointCell.Spacing = .normal,
+		alignment: DynamicTableViewBulletPointCell.Alignment = .normal,
 		accessibilityIdentifier: String? = nil,
 		accessibilityTraits: UIAccessibilityTraits = .staticText,
 		action: DynamicAction = .none,
@@ -122,8 +141,9 @@ extension DynamicCell {
 	) -> Self {
 		.identifier(CellReuseIdentifier.bulletPoint, action: action, accessoryAction: .none) { viewController, cell, indexPath in
 			(cell as? DynamicTableViewBulletPointCell)?.configure(
-				text: text,
+				attributedString: attributedText,
 				spacing: spacing,
+				alignment: alignment,
 				accessibilityTraits: accessibilityTraits,
 				accessibilityIdentifier: accessibilityIdentifier
 			)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewModel.swift
@@ -69,7 +69,11 @@ struct ExposureSubmissionQRInfoViewModel {
 				.acknowledgement(title: NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgementTitle),
 								 description: NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgementBody),
 								 bulletPoints: bulletPoints,
-								 accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionQRInfo.acknowledgementTitle)
+								 accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionQRInfo.acknowledgementTitle),
+				.bulletPoint(text: AppStrings.ExposureSubmissionQRInfo.acknowledgement3, alignment: .legal),
+				.bulletPoint(text: AppStrings.ExposureSubmissionQRInfo.acknowledgement4, alignment: .legal),
+				.bulletPoint(text: AppStrings.ExposureSubmissionQRInfo.acknowledgement5, alignment: .legal),
+				.bulletPoint(text: AppStrings.ExposureSubmissionQRInfo.acknowledgement6, alignment: .legal)
 			])
 		)
 
@@ -114,11 +118,6 @@ struct ExposureSubmissionQRInfoViewModel {
 		points.append(ack1)
 		points.append(ack2)
 
-		// simpler strings
-		points.append(NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgement3))
-		points.append(NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgement4))
-		points.append(NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgement5))
-		points.append(NSAttributedString(string: AppStrings.ExposureSubmissionQRInfo.acknowledgement6))
 		return points
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionQRInfoModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionQRInfoModelTests.swift
@@ -17,7 +17,7 @@ class ExposureSubmissionQRInfoModelTests: XCTestCase {
 		XCTAssertEqual(dynamicTableViewModel.section(1).cells.count, 4)
 		XCTAssertEqual(dynamicTableViewModel.section(2).cells.count, 2)
 		XCTAssertEqual(dynamicTableViewModel.section(3).cells.count, 1)
-		XCTAssertEqual(dynamicTableViewModel.section(4).cells.count, 1)
+		XCTAssertEqual(dynamicTableViewModel.section(4).cells.count, 5)
 		XCTAssertEqual(dynamicTableViewModel.section(5).cells.count, 1)
 	}
 

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -156,10 +156,10 @@ enum AppStrings {
 		static let acknowledgement1_2 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_1_2", tableName: "Localizable.legal", comment: "")
 		static let acknowledgement2_1 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_2_1", tableName: "Localizable.legal", comment: "")
 		static let acknowledgement2_2 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_2_2", tableName: "Localizable.legal", comment: "")
-		static let acknowledgement3 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_3", tableName: "Localizable.legal", comment: "")
-		static let acknowledgement4 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_4", tableName: "Localizable.legal", comment: "")
-		static let acknowledgement5 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_5", tableName: "Localizable.legal", comment: "")
-		static let acknowledgement6 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_6", tableName: "Localizable.legal", comment: "")
+		static let acknowledgement3 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_3", comment: "")
+		static let acknowledgement4 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_4", comment: "")
+		static let acknowledgement5 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_5", comment: "")
+		static let acknowledgement6 = NSLocalizedString("ExposureSubmissionQRInfo_acknowledgement_6", comment: "")
 		static let primaryButtonTitle = NSLocalizedString("ExposureSubmissionQRInfo_primaryButtonTitle", comment: "")
 	}
 

--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicAcknowledgementCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicAcknowledgementCell.swift
@@ -40,7 +40,7 @@ class DynamicAcknowledgementCell: UITableViewCell {
 			label.style = .body
 			label.numberOfLines = 0
 			label.lineBreakMode = .byWordWrapping
-			label.attributedText = bulletPointString(string, font: label.font)
+			label.attributedText = string.bulletPointString(bulletPointFont: label.font)
 			contentStackView.addArrangedSubview(label)
 		}
 	}
@@ -49,37 +49,5 @@ class DynamicAcknowledgementCell: UITableViewCell {
 
 	private func setup() {
 		cardView.layer.cornerRadius = 16
-	}
-
-	private func bulletPointString(_ from: NSAttributedString, font: UIFont) -> NSAttributedString {
-		// <bullet point>|--- indentation ---|<rest of text>
-		let indentation: CGFloat = 20.0
-		let paragraphStyle = NSMutableParagraphStyle()
-		paragraphStyle.tabStops = [NSTextTab(textAlignment: .natural, location: indentation, options: [:])]
-		paragraphStyle.defaultTabInterval = indentation
-		paragraphStyle.headIndent = indentation
-		paragraphStyle.paragraphSpacing = 8
-
-		let bulletAttributes: [NSAttributedString.Key: Any] = [
-			.font: font.scaledFont(size: font.pointSize, weight: .black),
-			.foregroundColor: UIColor.label
-		]
-
-		let bullet = "\u{2022}"
-		let prefixString = "\(bullet)\t"
-		let attributedString = NSMutableAttributedString(string: prefixString)
-		attributedString.append(from)
-
-		// style bullet point
-		let string = NSString(string: prefixString)
-		let rangeForBullet = string.range(of: bullet)
-		attributedString.addAttributes(bulletAttributes, range: rangeForBullet)
-
-		// style text paragraphs
-		attributedString.addAttributes(
-			[NSAttributedString.Key.paragraphStyle: paragraphStyle],
-			range: NSRange(location: 0, length: attributedString.length))
-
-		return attributedString
 	}
 }


### PR DESCRIPTION
This PR splits the bullet points in legal texts (grey background) and non-legal texts. **This is not a bug or graphics glitch…**

Also the `DynamicTableViewBulletPointCell` was refactored to align bullet point rendering with `DynamicAcknowledgementCell`.

![Simulator Screen Shot - iPhone 12 mini - 2020-11-27 at 12 38 51](https://user-images.githubusercontent.com/149976/100445723-dec72280-30ad-11eb-9592-5cb4edf0d40d.png)

Fixes again [EXPOSUREAPP-3755](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3755)