### PR TITLE
Fix/3790 AppStore Screenshots

### DIFF
--- a/src/xcode/ENA/ENAUITests/ENAUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests.swift
@@ -15,6 +15,7 @@ class ENAUITests: XCTestCase {
 		setupSnapshot(app)
 		app.setDefaults()
 		app.launchEnvironment["IsOnboarded"] = "NO"
+		app.launchArguments.append(contentsOf: ["-userNeedsToBeInformedAboutHowRiskDetectionWorks", "NO"])
 	}
 
 	override func tearDownWithError() throws {


### PR DESCRIPTION
## Description
Fixed an error for the AppStore screenshot UITest functions: removed an alert window on the home screen after onboarding.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3970

## Screenshot with alert
![Homescreen Alert](https://user-images.githubusercontent.com/7896005/100633470-6ae77d00-332e-11eb-8ecd-1e0e0be199fa.jpg)

## Screenshot without alert
![Homescreen NoAlert](https://user-images.githubusercontent.com/7896005/100633492-72a72180-332e-11eb-9cc6-4bd0f1ec682d.jpg)



