### PR TITLE
Differentiate with ENManager.authorizationStatus when .unauthorized

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ENStateHandler.swift
@@ -54,20 +54,20 @@ final class ENStateHandler {
 		case .disabled:
 			return .disabled
 		case .restricted:
-			return differentiateRestrictedCase()
+			return differentiateWithAuthorizationStatus()
 		case .unknown:
 			return .disabled
 		case .paused:
 			return .disabled
 		case .unauthorized:
-			return .notAuthorized
+			return differentiateWithAuthorizationStatus()
 		@unknown default:
 			Log.error("New state was added that is not being covered by ENStateHandler", log: .api)
 			return .unknown
 		}
 	}
 
-	private func differentiateRestrictedCase() -> State {
+	private func differentiateWithAuthorizationStatus() -> State {
 		switch ENManager.authorizationStatus {
 		case .notAuthorized:
 			return .notAuthorized


### PR DESCRIPTION
## Description
In EN2.0 ENStatus is .unauthorized when the user was never asked for permission.
To distinguish in detail we need to check ENManager.authorizationStatus.
ENManager.authorizationStatus is .unknown in case the user was never asked for permission.

## Link to Jira
[4040](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4040)
