### PR TITLE
fix/4093 Home Screen Text Improvement For Red & Green Risk Card

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
@@ -15,7 +15,7 @@
 			<key>zero</key>
 			<string>Keine Risiko-Begegnungen</string>
 			<key>one</key>
-			<string>Begegnungen mit niedrigem Risiko an %u Tag</string>
+			<string>Begegnungen mit niedrigem Risiko an einem Tag</string>
 			<key>few</key>
 			<string>Begegnungen mit niedrigem Risiko an %u Tagen</string>
 			<key>many</key>
@@ -39,7 +39,7 @@
 			<key>zero</key>
 			<string>Begegnungen an %u Tagen mit erhöhtem Risiko</string>
 			<key>one</key>
-			<string>Begegnungen an %u Tag mit erhöhtem Risiko</string>
+			<string>Begegnungen an einem Tag mit erhöhtem Risiko</string>
 			<key>few</key>
 			<string>Begegnungen an %u Tagen mit erhöhtem Risiko</string>
 			<key>many</key>


### PR DESCRIPTION
## Description
Text improvement for the red/green risk card and one single exposure.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4093

## Screenshot – Red Card, One Day
![Simulator Screen Shot - Red ein Tag](https://user-images.githubusercontent.com/7896005/100760946-9d5aae00-33f2-11eb-9d5d-9a613dd7b035.png)

## Screenshot – Green Card, One Day
![Simulator Screen Shot - Green ein Tag](https://user-images.githubusercontent.com/7896005/100760964-a21f6200-33f2-11eb-954d-84689e86b4f8.png)

