### PR TITLE
fix: open the "More Information" link using the In-App-Browser

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
@@ -147,7 +147,7 @@ extension DynamicTableViewController {
 	final func execute(action: DynamicAction, cell: UITableViewCell? = nil) {
 		switch action {
 		case let .open(url):
-			if let url = url { UIApplication.shared.open(url) }
+			if let url = url { LinkHelper.openLink(withUrl: url, from: self) }
 
 		case let .call(number):
 			if let url = URL(string: "tel://\(number)") { UIApplication.shared.open(url) }


### PR DESCRIPTION
## Description
 The Link "More Information" which is showed at the bottom of the Risk Card if you had a Low Risk Encounter is opened in the devices standard Browser While is should be opening in the In-App-Browser.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3405

## Screenshot

![Simulator Screen Shot - iPhone 11 Pro - 2020-12-03 at 16 02 10](https://user-images.githubusercontent.com/15270737/101045937-f22c2f00-3580-11eb-8aa8-175239c10c2e.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-12-03 at 16 02 14](https://user-images.githubusercontent.com/15270737/101045953-f5271f80-3580-11eb-9d56-ac4deafdf649.png)

