### PR TITLE
Fix/4146 text fix for consent view

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -43,3 +43,5 @@
 "AutomaticSharingConsent_DescriptionPart3" = "Wenn Sie zusätzlich Angaben zum Beginn Ihrer Symptome machen, werden auch diese geteilt.";
 
 "AutomaticSharingConsent_DescriptionPart4" = "Sie können Ihr Einverständnis zurücknehmen, indem Sie oben „Andere warnen“ deaktivieren.";
+
+"AutomaticSharingConsent_DescriptionPart5" = "Ihr Testergebnis wird Ihnen anschließend angezeigt.";

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewModel.swift
@@ -66,7 +66,7 @@ class ExposureSubmissionTestResultConsentViewModel {
 										descriptionPart2Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart2),
 										countries: self.supportedCountries,
 										descriptionPart3Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart3),
-										descriptionPart4Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart4)
+										descriptionPart4Label: NSMutableAttributedString(string: "\(AppStrings.AutomaticSharingConsent.consentDescriptionPart4) \(AppStrings.AutomaticSharingConsent.consentDescriptionPart5)")
 									)
 								}
 							},

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewModel.swift
@@ -60,13 +60,22 @@ class ExposureSubmissionTestResultConsentViewModel {
 									return
 								}
 								if let consentCell = cell as? DynamicTableViewConsentCell {
+									// We use this model in two places but require one super important sentence just once. This HACK figures out which 'mode' we use.
+									// For reference
+									// text needed here: https://www.figma.com/file/BpLyzxHZVa6a8BbSdcL76V/CWA_Submission_Flow_v02?node-id=388%3A3251
+									// but not here: https://www.figma.com/file/BpLyzxHZVa6a8BbSdcL76V/CWA_Submission_Flow_v02?node-id=388%3A3183
+									var part4: String = AppStrings.AutomaticSharingConsent.consentDescriptionPart4
+									if self.onDismiss != nil {
+										part4.append(" \(AppStrings.AutomaticSharingConsent.consentDescriptionPart5)")
+									}
+
 									consentCell.configure(
 										subTitleLabel: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentSubTitle),
 										descriptionPart1Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart1),
 										descriptionPart2Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart2),
 										countries: self.supportedCountries,
 										descriptionPart3Label: NSMutableAttributedString(string: AppStrings.AutomaticSharingConsent.consentDescriptionPart3),
-										descriptionPart4Label: NSMutableAttributedString(string: "\(AppStrings.AutomaticSharingConsent.consentDescriptionPart4) \(AppStrings.AutomaticSharingConsent.consentDescriptionPart5)")
+										descriptionPart4Label: NSMutableAttributedString(string: part4)
 									)
 								}
 							},

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -851,6 +851,7 @@ enum AppStrings {
 		static let consentDescriptionPart2 = NSLocalizedString("AutomaticSharingConsent_DescriptionPart2", tableName: "Localizable.legal", comment: "")
 		static let consentDescriptionPart3 = NSLocalizedString("AutomaticSharingConsent_DescriptionPart3", tableName: "Localizable.legal", comment: "")
 		static let consentDescriptionPart4 = NSLocalizedString("AutomaticSharingConsent_DescriptionPart4", tableName: "Localizable.legal", comment: "")
+		static let consentDescriptionPart5 = NSLocalizedString("AutomaticSharingConsent_DescriptionPart5", tableName: "Localizable.legal", comment: "")
 		static let dataProcessingDetailInfo = NSLocalizedString("AutomaticSharingConsent_DataProcessingDetailInfo", comment: "")
 	}
 	


### PR DESCRIPTION
## Description
This PR adds an extra legal string to be used in the consent view.

## Link to Jira
[EXPOSUREAPP-4146](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4146)
Also, [Figma](https://www.figma.com/file/BpLyzxHZVa6a8BbSdcL76V/CWA_Submission_Flow_v02?node-id=388%3A3251)

## Screenshot
![IMG_86D9300BF14F-1](https://user-images.githubusercontent.com/149976/101349038-f6ac5c80-388c-11eb-9dc2-9f6859b9e4e1.jpeg)

