### PR TITLE
Fix: close button is not working in ExposureSubmissionTestResultConse…

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -232,7 +232,9 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 					self?.model.exposureSubmissionService.loadSupportedCountries(
 						isLoading: isLoading,
 						onSuccess: { supportedCountries in
-							self?.showTestResultSubmissionConsentScreen(supportedCountries: supportedCountries, onDismiss: nil)
+							self?.showTestResultSubmissionConsentScreen(supportedCountries: supportedCountries, onDismiss: {
+								self?.dismiss()
+							})
 						}
 					)
 				},


### PR DESCRIPTION
…ntViewController

## Description
When user submits a result with QR code and then enters the warn others consent screen ->
close button is not working in this screen. more specifically in **ExposureSubmissionTestResultConsentViewController**.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4181

## Screenshot
![IMG_FBC1EB45A541-1](https://user-images.githubusercontent.com/15270737/101566379-30857c00-39cf-11eb-91b5-b96d0fe3e702.jpeg)

