### PR TITLE
Fix: Remove the close button from the screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultConsentViewController.swift
@@ -27,6 +27,7 @@ class ExposureSubmissionTestResultConsentViewController: DynamicTableViewControl
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		self.title = AppStrings.AutomaticSharingConsent.consentTitle
+		self.navigationController?.navigationItem.rightBarButtonItem = nil
 		setupView()
 	}
 


### PR DESCRIPTION
## Description
The close button in the navigation bar  is not working.

**Update**: according to figma the close button was removed from the design so it should be removed from the screen as well.
Please check the comments inside the ticket below.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4181

## Screenshot
![IMG_0005](https://user-images.githubusercontent.com/15270737/101635664-90f5d700-3a2a-11eb-8d9b-c22a3e542e3b.PNG)
![IMG_0006](https://user-images.githubusercontent.com/15270737/101635669-92270400-3a2a-11eb-9ee4-2f7c3d02e1d6.PNG)

