### PR TITLE
Fix/4228 - App reset does not reset 'submission consent given'

### DIFF
--- a/src/xcode/ENA/ENA/Source/Coordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Coordinator.swift
@@ -8,7 +8,7 @@ import UIKit
 	A delegate protocol for reseting the state of the app, when Reset functionality is used.
 */
 protocol CoordinatorDelegate: AnyObject {
-	func coordinatorUserDidRequestReset()
+	func coordinatorUserDidRequestReset(exposureSubmissionService: ExposureSubmissionService)
 }
 
 /**
@@ -270,7 +270,7 @@ extension Coordinator: SettingsViewControllerDelegate {
 	}
 
 	func settingsViewControllerUserDidRequestReset(_ controller: SettingsViewController) {
-		delegate?.coordinatorUserDidRequestReset()
+		delegate?.coordinatorUserDidRequestReset(exposureSubmissionService: exposureSubmissionService)
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/SceneDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/SceneDelegate.swift
@@ -86,7 +86,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, RequiresAppDepend
 	// MARK: - Protocol CoordinatorDelegate
 
 	/// Resets all stores and notifies the Onboarding and resets all pending notifications
-	func coordinatorUserDidRequestReset() {
+	func coordinatorUserDidRequestReset(exposureSubmissionService: ExposureSubmissionService) {
+		
+		exposureSubmissionService.reset()
+		
 		do {
 			let newKey = try KeychainHelper().generateDatabaseKey()
 			store.clearAll(key: newKey)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/Mock Objects/MockExposureSubmissionService.swift
@@ -75,6 +75,10 @@ class MockExposureSubmissionService: ExposureSubmissionService {
 	func acceptPairing() {
 		acceptPairingCallback?()
 	}
+	
+	func reset() {
+		isSubmissionConsentGiven = false
+	}
 
 }
 #endif

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+Protocol.swift
@@ -42,5 +42,6 @@ protocol ExposureSubmissionService: class {
 	func deleteTest()
 	func acceptPairing()
 	func fakeRequest(completionHandler: ExposureSubmissionHandler?)
+	func reset()
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -242,6 +242,11 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 			})
 		}
 	}
+	
+	func reset() {
+		Log.info("ExposureSubmissionServce: isConsentGiven value resetted to 'false'")
+		isSubmissionConsentGiven = false
+	}
 
 	// MARK: - Internal
 

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/ExposureSubmissionServiceTests.swift
@@ -29,6 +29,19 @@ class ExposureSubmissionServiceTests: XCTestCase {
 		service.isSubmissionConsentGiven = true
 		XCTAssertTrue(store.isSubmissionConsentGiven, "Expected store value is 'true'")
 	}
+	
+	func testReset_shouldResetValues() {
+		let store = MockTestStore()
+		let keyRetrieval = MockDiagnosisKeysRetrieval(diagnosisKeysResult: (keys, nil))
+		let client = ClientMock()
+		let appConfigurationProvider = CachedAppConfigurationMock()
+		
+		let service = ENAExposureSubmissionService(diagnosisKeysRetrieval: keyRetrieval, appConfigurationProvider: appConfigurationProvider, client: client, store: store, warnOthersReminder: WarnOthersReminder(store: store))
+		
+		service.isSubmissionConsentGiven = true
+		service.reset()
+		XCTAssertFalse(store.isSubmissionConsentGiven, "Expected store value is 'false'")
+	}
 
 	func testSubmitExposure_Success() {
 		// Arrange

--- a/src/xcode/ENA/ENA/Source/__tests__/CoordinatorTests.swift
+++ b/src/xcode/ENA/ENA/Source/__tests__/CoordinatorTests.swift
@@ -26,7 +26,7 @@ private class MockNavigationController: UINavigationController {
 }
 
 private class MockCoordinatorDelegate: CoordinatorDelegate {
-	func coordinatorUserDidRequestReset() { }
+	func coordinatorUserDidRequestReset(exposureSubmissionService: ExposureSubmissionService) { }
 }
 
 class MockCoordinator: Coordinator {


### PR DESCRIPTION
This PR is a bug fix for [JIRA Ticket 4248](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4248).
If the app gets reset, now the 'submission consent given' gets reset either.
