### PR TITLE
Fix: Submission consent will be revoked when os authorization for key…

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -380,6 +380,7 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 						if case .notAuthorized = error {
 							self?.model.exposureSubmissionService.isSubmissionConsentGiven = false
 						} else {
+							self?.model.exposureSubmissionService.isSubmissionConsentGiven = false
 							self?.showErrorAlert(for: error)
 						}
 					} else {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -374,9 +374,14 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 				self?.model.exposureSubmissionService.isSubmissionConsentGiven = true
 				self?.model.exposureSubmissionService.getTemporaryExposureKeys { error in
 					isLoading(false)
-
+					
 					if let error = error {
-						self?.showErrorAlert(for: error)
+						// User selected "Don't Share" / "Nicht teilen"
+						if case .notAuthorized = error {
+							self?.model.exposureSubmissionService.isSubmissionConsentGiven = false
+						} else {
+							self?.showErrorAlert(for: error)
+						}
 					} else {
 						self?.showThankYouScreen()
 					}


### PR DESCRIPTION
This fixes the [issue filed in JIRA Ticket 4249](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4249)

The user submission consent will be set back to false (not given) if the user does not authorize the Google/Apple framework to exchange results.
