### PR TITLE
Fix crash on deletion of last journal entry

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
@@ -59,8 +59,7 @@ class DiaryEditEntriesViewController: UIViewController, UITableViewDataSource, U
 	// MARK: - Protocol UITableViewDataSource
 
 	func numberOfSections(in tableView: UITableView) -> Int {
-		// Needs to be set to 0 when empty for the animation of deleting the whole section
-		return viewModel.entries.isEmpty ? 0 : 1
+		return 1
 	}
 
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -152,12 +151,19 @@ class DiaryEditEntriesViewController: UIViewController, UITableViewDataSource, U
 				title: viewModel.alertConfirmButtonTitle,
 				style: .destructive,
 				handler: { [weak self] _ in
-					self?.shouldReload = false
-					self?.viewModel.removeAll()
-					self?.tableView.performBatchUpdates({
-						self?.tableView.deleteSections([0], with: .automatic)
+					guard let self = self else { return }
+
+					let numberOfRows = self.viewModel.entries.count
+
+					self.shouldReload = false
+					self.viewModel.removeAll()
+					self.tableView.performBatchUpdates({
+						self.tableView.deleteRows(
+							at: (0..<numberOfRows).map { IndexPath(row: $0, section: 0) },
+							with: .automatic
+						)
 					}, completion: { _ in
-						self?.shouldReload = true
+						self.shouldReload = true
 					})
 				}
 			)


### PR DESCRIPTION
## Description
Fixes a crash on the deletion of the last entry that was coming from the animation. Now both deleting one and all entries are handled the same way to prevent the need for a different amount of sections.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-3917
