### PR TITLE
fix/4376 Fixed typo on Contact Journal info screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1408,7 +1408,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ContactDiary_Information_DescriptionTitle" = "Behalten Sie den Überblick.";
 
-"ContactDiary_Information_DescriptionSubHeadline" = "Erstellen Sie eine Übersicht über Ihre Kontakte der letzten 16 Tage. So haben Sie bei Bedarf schnell eine vollständige Liste zur Hand.";
+"ContactDiary_Information_DescriptionSubHeadline" = "Erstellen Sie eine Übersicht über Ihre Kontakte der letzten 14 Tage. So haben Sie bei Bedarf schnell eine vollständige Liste zur Hand.";
 
 "ContactDiary_Information_Item_Person_Title" = "Tragen Sie ein, mit wem Sie sich getroffen haben.";
 


### PR DESCRIPTION
## Description
Fixed typo on Contact Journal info screen: first paragraph, "14" instead of "16" days

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4376

## Screenshots
![Info Screen](https://user-images.githubusercontent.com/7896005/102516186-dfd8e780-408e-11eb-80d1-38f9a5232631.png)

