### PR TITLE
Fix/4490 set time zone in contact journal date formatter

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		01734B6E255D73E400E60A8B /* ENExposureConfiguration+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01734B6D255D73E400E60A8B /* ENExposureConfiguration+Convenience.swift */; };
 		0177F48825501111009DD568 /* RiskCalculationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177F48125501111009DD568 /* RiskCalculationResult.swift */; };
 		0177F4B125503805009DD568 /* ScanInstanceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177F4B025503805009DD568 /* ScanInstanceTest.swift */; };
+		017AD122259DDED100FA2B3F /* ISO8601DateFormatter+ContactDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017AD121259DDE6B00FA2B3F /* ISO8601DateFormatter+ContactDiary.swift */; };
 		0190986A257E64A70065D050 /* DiaryOverviewTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01909845257E61350065D050 /* DiaryOverviewTableViewController.swift */; };
 		01909874257E64BD0065D050 /* DiaryDayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01909862257E63810065D050 /* DiaryDayViewController.swift */; };
 		01909875257E64BD0065D050 /* DiaryAddAndEditEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0190984C257E62C70065D050 /* DiaryAddAndEditEntryViewController.swift */; };
@@ -717,6 +718,7 @@
 		01734B6D255D73E400E60A8B /* ENExposureConfiguration+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ENExposureConfiguration+Convenience.swift"; sourceTree = "<group>"; };
 		0177F48125501111009DD568 /* RiskCalculationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RiskCalculationResult.swift; sourceTree = "<group>"; };
 		0177F4B025503805009DD568 /* ScanInstanceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanInstanceTest.swift; sourceTree = "<group>"; };
+		017AD121259DDE6B00FA2B3F /* ISO8601DateFormatter+ContactDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ISO8601DateFormatter+ContactDiary.swift"; sourceTree = "<group>"; };
 		0190982B257E5AF70065D050 /* DiaryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCoordinator.swift; sourceTree = "<group>"; };
 		01909834257E606C0065D050 /* DiaryEditEntriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditEntriesViewController.swift; sourceTree = "<group>"; };
 		0190983C257E60760065D050 /* DiaryEditEntriesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditEntriesViewModel.swift; sourceTree = "<group>"; };
@@ -2045,6 +2047,7 @@
 				B1C7EE4324938E9E00F1F284 /* ExposureDetection_DidEndPrematurelyReason+ErrorHandling.swift */,
 				2F96739A24AB70FA008E3147 /* ExposureSubmissionParsable.swift */,
 				EB17144525716EA80088D7A9 /* FileManager+KeyPackageStorage.swift */,
+				017AD121259DDE6B00FA2B3F /* ISO8601DateFormatter+ContactDiary.swift */,
 				51D420D324586DCA00AD70CA /* NotificationName.swift */,
 				2FF1D62D2487850200381FFB /* NSMutableAttributedString+Generation.swift */,
 				51D420B624583B7200AD70CA /* NSObject+Identifier.swift */,
@@ -4093,6 +4096,7 @@
 				51C77910248684F5004582F8 /* HomeRiskListItemViewConfigurator.swift in Sources */,
 				B1D6B004247DA4920079DDD3 /* UIApplication+CoronaWarn.swift in Sources */,
 				51CE1BC32460B28D002CF42A /* HomeInfoCellConfigurator.swift in Sources */,
+				017AD122259DDED100FA2B3F /* ISO8601DateFormatter+ContactDiary.swift in Sources */,
 				138910C5247A909000D739F6 /* ENATaskScheduler.swift in Sources */,
 				71B804492484D37300D53506 /* RiskLegendViewController.swift in Sources */,
 				01C2D43E2501225100FB23BF /* MockExposureSubmissionService.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Extensions/ISO8601DateFormatter+ContactDiary.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/ISO8601DateFormatter+ContactDiary.swift
@@ -1,0 +1,17 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+
+extension ISO8601DateFormatter {
+
+	static var contactDiaryFormatter: ISO8601DateFormatter {
+		let dateFormatter = ISO8601DateFormatter()
+		dateFormatter.formatOptions = [.withFullDate]
+		dateFormatter.timeZone = TimeZone.autoupdatingCurrent
+
+		return dateFormatter
+	}
+
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Model/DiaryDay.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Model/DiaryDay.swift
@@ -36,8 +36,7 @@ struct DiaryDay: Equatable {
 	// MARK: - Private
 
 	private var date: Date {
-		let dateFormatter = ISO8601DateFormatter()
-		dateFormatter.formatOptions = [.withFullDate]
+		let dateFormatter = ISO8601DateFormatter.contactDiaryFormatter
 
 		guard let date = dateFormatter.date(from: dateString) else {
 			Log.error("Could not get date from date string", log: .contactdiary)

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Store/ContactDiaryStoreV1.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Store/ContactDiaryStoreV1.swift
@@ -633,8 +633,7 @@ class ContactDiaryStoreV1: DiaryStoring, DiaryProviding {
 	}
 
 	private var dateFormatter: ISO8601DateFormatter = {
-		let dateFormatter = ISO8601DateFormatter()
-		dateFormatter.formatOptions = [.withFullDate]
+		let dateFormatter = ISO8601DateFormatter.contactDiaryFormatter
 		return dateFormatter
 	}()
 


### PR DESCRIPTION
## Description
Sets the time zone in contact journal date formatter so the correct day is returned right after midnight.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4490

## Screenshots
![IMG_CB910D87A5C3-1](https://user-images.githubusercontent.com/1157991/103408080-57b01300-4b61-11eb-8009-dcb27bec4789.jpeg)

