### PR TITLE
Include license in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,6 @@ Licensed under the **Apache License, Version 2.0** (the "License"); you may not 
 
 You may obtain a copy of the License from [here](./LICENSES/Apache-2.0.txt).
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License. 
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License.
+
 Please see the [detailed licensing information](https://api.reuse.software/info/github.com/corona-warn-app/cwa-app-ios) via the [REUSE Tool](https://reuse.software/) for more details.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Copyright (c) 2020 SAP SE or an SAP affiliate company.
 
 Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 
-You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
+You may obtain a copy of the License from [here](./LICENSES/Apache-2.0.txt).
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License. 
+Please see the [detailed licensing information](https://api.reuse.software/info/github.com/corona-warn-app/cwa-app-ios) via the [REUSE Tool](https://reuse.software/) for more details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    Corona Warn App: iOS
+    Corona Warn App - iOS
 </h1>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    Corona Warn App - iOS
+    Corona Warn App: iOS
 </h1>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ Licensed under the **Apache License, Version 2.0** (the "License"); you may not 
 
 You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSE) for the specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -131,3 +131,13 @@ The German government has asked SAP and Deutsche Telekom to develop the Corona-W
 [cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
 [cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
 [cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
+
+## Licensing
+
+Copyright (c) 2020 SAP SE or an SAP affiliate company.
+
+Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSE) for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
## Description
This PR adds the Apache License, Version 2.0 text to the README.md file. This is already done [here](https://github.com/corona-warn-app/cwa-app-android#licensing) in the Android repo.
**THIS PR DOES NOT CHANGE ANY CODE!**


Closes #1740 

---
Internal Tracking ID: [EXPOSUREAPP-4470](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4470)