### PR TITLE
Add close button to debug menu.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
@@ -83,6 +83,16 @@ final class DMDeveloperMenu {
 			wifiClient: wifiClient,
 			exposureSubmissionService: exposureSubmissionService
 		)
+
+		let closeBarButtonItem = UIBarButtonItem(
+			title: "❌",
+			style: .done,
+			target: self,
+			action: #selector(self.closeDeveloperMenu)
+		)
+
+		vc.navigationItem.rightBarButtonItem = closeBarButtonItem
+
 		let navigationController = UINavigationController(
 			rootViewController: vc
 		)
@@ -93,6 +103,10 @@ final class DMDeveloperMenu {
 		)
 	}
 
+	@objc
+	func closeDeveloperMenu() {
+		presentingViewController.dismiss(animated: true)
+	}
 
 	private func isAllowed() -> Bool {
 		true

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMDeveloperMenu.swift
@@ -88,7 +88,7 @@ final class DMDeveloperMenu {
 			title: "❌",
 			style: .done,
 			target: self,
-			action: #selector(self.closeDeveloperMenu)
+			action: #selector(closeDeveloperMenu)
 		)
 
 		vc.navigationItem.rightBarButtonItem = closeBarButtonItem


### PR DESCRIPTION
## Description
Adds a close button to debug menu. Which is required for iOS12.

## Screenshots
![Simulator Screen Shot - iPhone 8 - 2021-01-05 at 14 18 01](https://user-images.githubusercontent.com/1941000/103650754-d392cc80-4f60-11eb-99e7-7e41defc760b.png)
