### PR TITLE
Fix test result color

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionTestResultHeaderView.xib
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionTestResultHeaderView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +25,6 @@
                                     <subviews>
                                         <view clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zNO-5U-YCi">
                                             <rect key="frame" x="0.0" y="0.0" width="4" height="131"/>
-                                            <color key="backgroundColor" name="ENA Risk Low Color"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="4" id="OYK-VX-Qrw"/>
                                             </constraints>
@@ -47,7 +47,7 @@
                                     <rect key="frame" x="28" y="0.0" width="203" height="131"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" text="Footnote" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OU3-fJ-eEo" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="203" height="16"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="203" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" name="ENA Text Primary 2 Color"/>
                                             <nil key="highlightedColor"/>
@@ -56,10 +56,10 @@
                                             </userDefinedRuntimeAttributes>
                                         </label>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="249" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z2n-69-Pgc">
-                                            <rect key="frame" x="0.0" y="24" width="203" height="83"/>
+                                            <rect key="frame" x="0.0" y="28.5" width="203" height="74"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="249" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" text="Title 2" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="203" translatesAutoresizingMaskIntoConstraints="NO" id="Tam-Om-CJ8" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="203" height="67"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="203" height="58"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" name="ENA Text Primary 1 Color"/>
                                                     <nil key="highlightedColor"/>
@@ -76,7 +76,7 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" text="Footnote" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dGr-ET-QNF" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="115" width="203" height="16"/>
+                                            <rect key="frame" x="0.0" y="110.5" width="203" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" name="ENA Text Primary 1 Color"/>
                                             <nil key="highlightedColor"/>
@@ -125,11 +125,19 @@
             <point key="canvasLocation" x="-255.79710144927537" y="-13.058035714285714"/>
         </view>
     </objects>
+    <designables>
+        <designable name="OU3-fJ-eEo">
+            <size key="intrinsicContentSize" width="68.5" height="20.5"/>
+        </designable>
+        <designable name="Tam-Om-CJ8">
+            <size key="intrinsicContentSize" width="47.5" height="20.5"/>
+        </designable>
+        <designable name="dGr-ET-QNF">
+            <size key="intrinsicContentSize" width="68.5" height="20.5"/>
+        </designable>
+    </designables>
     <resources>
         <image name="Illu_Submission_NegativesTestErgebnis" width="90" height="112"/>
-        <namedColor name="ENA Risk Low Color">
-            <color red="0.1803921568627451" green="0.52156862745098043" blue="0.29411764705882354" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="ENA Separator Color">
             <color red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
## Description
Fix: Show the positive test result with a red colored bar on the left. On iOS 12 Interface Builder color definitions sometimes overrule colors set in code, so I removed the color from the xib file.

## Screenshots
![IMG_4364EB1E46DA-1](https://user-images.githubusercontent.com/1157991/104158501-c9a01c00-53ed-11eb-9872-bcfbf705345e.jpeg)

