### PR TITLE
Update Localizable.legal.strings

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -52,7 +52,7 @@
 
 "ContactDiary_Information_Legal_SubHeadline_1" = "Sie behalten über alle erfassten Informationen die volle Kontrolle.";
 
-"ContactDiary_Information_Legal_Text_1" = "Die Nutzung dieser zusätzlichen Funktion der Corona-Warn-App ist freiwillig und nur Sie entscheiden welche Personen und Orte Sie eintragen.";
+"ContactDiary_Information_Legal_Text_1" = "Die Nutzung dieser zusätzlichen Funktion der Corona-Warn-App ist freiwillig und nur Sie entscheiden, welche Personen und Orte Sie eintragen.";
 
 "ContactDiary_Information_Legal_Text_2" = "Auf die von Ihnen im Kontakt-Tagebuch erfassten Informationen hat weder das RKI noch eine andere Stelle Zugriff. Die Informationen sind nur in verschlüsselter Form in Ihrem iPhone gespeichert.";
 


### PR DESCRIPTION
## Description
Missing comma in legal text (reported by RKI). 
German only, not translation relevant.