### PR TITLE
Fix/4572 button to system notifications does not work

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/NotificationSettingsViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/NotificationSettingsViewController.xib
@@ -104,6 +104,9 @@
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="73l-bO-Ic1" userLabel="Open Settings Button" customClass="ENAButton" customModule="ENA" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="110.5" width="350" height="50"/>
                                                             <state key="normal" title="# App-Einstellungen öffnen"/>
+                                                            <connections>
+                                                                <action selector="openSettings:" destination="-1" eventType="touchUpInside" id="e0L-61-1q7"/>
+                                                            </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>


### PR DESCRIPTION
## Description
Fixed: in case of disabled notifications for CWA: navigation to the system settings didn't work (button "Open Settings").

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4572?filter=58020

## Screenshots

![Activate Notifications](https://user-images.githubusercontent.com/7896005/104333333-68fa0780-54f1-11eb-9eca-a7fed9c1221a.PNG)


