### PR TITLE
fix/negavie calculation days interval

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/ActiveTracing.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/ActiveTracing.swift
@@ -14,8 +14,11 @@ struct ActiveTracing: Equatable {
 	let interval: TimeInterval
 	let maximumNumberOfDays: Int
 
+	/** a negative interval is invalid and will be handled as 0
+		this shall only happen if a risk calcultion was done in the future before
+	*/
 	init(interval: TimeInterval, maximumNumberOfDays: Int = TracingStatusHistory.maxStoredDays) {
-		self.interval = interval
+		self.interval = max(interval, 0)
 		self.maximumNumberOfDays = maximumNumberOfDays
 	}
 

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/ActiveTracingTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/ActiveTracingTests.swift
@@ -88,6 +88,15 @@ final class ActiveTracingTests: XCTestCase {
 			"Risiko-Ermittlung dauerhaft aktiv"
 		)
 	}
+
+	func testGIVEN_ActiveTracingWithNegativeInterval_THEN_InDaysIsZero() {
+		// GIVEN
+		let activeTracing = ActiveTracing(interval: -250)
+
+		// THEN
+		XCTAssertEqual(activeTracing.inDays, 0)
+		XCTAssertEqual(activeTracing.inHours, 0)
+	}
 }
 
 private func _activeTracing(interval: TimeInterval) -> ActiveTracing {


### PR DESCRIPTION
## Description
Risk calculation could show some wrong interval if the first calculation was done in the future
Now it will show 0 Days if the active interval is negative

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4573

## Screenshots
![Screen Shot 2021-01-12 at 16 22 40](https://user-images.githubusercontent.com/2675578/104334256-6b109600-54f2-11eb-9abc-98c719dca1d2.png)

