### PR TITLE
fix test result is not updated on the home screen + app crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/NewHome/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/NewHome/HomeTableViewController.swift
@@ -40,6 +40,14 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 
 		super.init(style: .plain)
 
+		viewModel.state.$testResult
+		   .sink { [weak self] _ in
+			DispatchQueue.main.async {
+			 self?.reload()
+			}
+		   }
+		   .store(in: &subscriptions)
+
 		viewModel.state.$testResultLoadingError
 			.sink { [weak self] testResultLoadingError in
 				guard let self = self, let testResultLoadingError = testResultLoadingError else { return }


### PR DESCRIPTION
## Description
1-Test result card was not updated on the home screen after dismissing the test result
2- the app crashed when user taps on the "test result available" card

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4570

## Screenshots

https://user-images.githubusercontent.com/15270737/104343431-399cc800-54fc-11eb-9bb2-12c51d65193a.MP4


https://user-images.githubusercontent.com/15270737/104343447-3dc8e580-54fc-11eb-9cc4-4b02bc227383.MP4

![IMG_0051](https://user-images.githubusercontent.com/15270737/104343472-43263000-54fc-11eb-85e4-047334be47bc.PNG)
![IMG_0052](https://user-images.githubusercontent.com/15270737/104343473-43bec680-54fc-11eb-9b8e-60850e9fa9b1.PNG)

