### PR TITLE
Update encounter/visit selection and deselection faster

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -36,9 +36,10 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 		setupTableView()
 
 		viewModel.$day
-			.receive(on: RunLoop.main.ocombine)
 			.sink { [weak self] _ in
-				self?.updateForSelectedEntryType()
+				DispatchQueue.main.async {
+					self?.updateForSelectedEntryType()
+				}
 			}
 			.store(in: &subscriptions)
 


### PR DESCRIPTION
## Description
The selection or deselection of encountered persons and visited locations could sometimes update very slowly and thereby seem to select or deselect the wrong entries. This fix makes the screen update faster.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4579
