### PR TITLE
Fix/small fixes

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskTableViewCell.swift
@@ -29,6 +29,20 @@ final class HomeRiskTableViewCell: UITableViewCell {
 		containerView.setHighlighted(highlighted, animated: animated)
 	}
 
+	override var accessibilityElements: [Any]? {
+		get {
+			var accessibilityElements = [topContainer as Any, riskViewStackView as Any]
+
+			if !button.isHidden, let button = self.button {
+				accessibilityElements.append(button)
+			}
+
+			return accessibilityElements
+		}
+		// swiftlint:disable:next unused_setter_value
+		set { }
+	}
+
 	// Ignore touches on the button when it's disabled
 	override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
 		let buttonPoint = convert(point, to: button)
@@ -149,8 +163,6 @@ final class HomeRiskTableViewCell: UITableViewCell {
 		topContainer.accessibilityIdentifier = AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer
 		bodyLabel.accessibilityIdentifier = AccessibilityIdentifiers.Home.RiskTableViewCell.bodyLabel
 		button.accessibilityIdentifier = AccessibilityIdentifiers.Home.RiskTableViewCell.updateButton
-
-		accessibilityElements = [topContainer as Any, riskViewStackView as Any, button as Any]
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskTableViewCell.swift
@@ -57,6 +57,8 @@ final class HomeRiskTableViewCell: UITableViewCell {
 	// MARK: - Internal
 
 	func configure(with cellModel: HomeRiskCellModel) {
+		guard !isConfigured else { return }
+
 		cellModel.$title.assign(to: \.text, on: titleLabel).store(in: &subscriptions)
 		cellModel.$title.assign(to: \.accessibilityLabel, on: topContainer).store(in: &subscriptions)
 		cellModel.$titleAccessibilityValue.assign(to: \.accessibilityValue, on: topContainer).store(in: &subscriptions)
@@ -123,6 +125,8 @@ final class HomeRiskTableViewCell: UITableViewCell {
 
 		// Retaining cell model so it gets updated
 		self.cellModel = cellModel
+
+		isConfigured = true
 	}
 
 	// MARK: - Private
@@ -140,6 +144,8 @@ final class HomeRiskTableViewCell: UITableViewCell {
 
 	private var subscriptions = Set<AnyCancellable>()
 	private var cellModel: HomeRiskCellModel?
+
+	private var isConfigured: Bool = false
 
 	@IBAction private func buttonTapped(_: UIButton) {
 		cellModel?.onButtonTap()

--- a/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/RiskLegendViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/RiskLegendViewController.swift
@@ -37,6 +37,8 @@ class RiskLegendViewController: DynamicTableViewController {
 		navigationController?.navigationBar.prefersLargeTitles = true
 		navigationItem.title = AppStrings.RiskLegend.title
 
+		view.backgroundColor = .enaColor(for: .background)
+
 		dynamicTableViewModel = model
 	}
 


### PR DESCRIPTION
## Description
This PR contains a three small fixes / improvements that came up while implementing the statistics UI:

- Fixes VoiceOver on the home risk cell in automatic mode when the button is not visible.
- Improves scrolling performance by only configuring the home risk cell once.
- Sets the correct background color on the risk legend view controller.
