### PR TITLE
Fix/4648 cell animation crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -284,8 +284,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		guard tableView.visibleCells.contains(cell) else { return }
 
 		// Animate the changed cell height
-		tableView.beginUpdates()
-		tableView.endUpdates()
+		tableView.performBatchUpdates(nil, completion: nil)
 
 		// Keep the other visible cells maskToBounds off during the animation to avoid flickering shadows due to them being cut off (https://stackoverflow.com/a/59581645)
 		for cell in tableView.visibleCells {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -281,8 +281,15 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func animateChanges(of cell: UITableViewCell) {
-		// Only animate changes as long as the risk and the test result cell are both still supposed to be there
-		guard tableView.visibleCells.contains(cell), viewModel.riskAndTestRows.count == 2 else { return }
+		guard tableView.visibleCells.contains(cell) else {
+			return
+		}
+
+		// Only animate changes as long as the risk and the test result cell are both still supposed to be there, otherwise reload the table view
+		guard viewModel.riskAndTestRows.count == 2 else {
+			tableView.reloadData()
+			return
+		}
 
 		// Animate the changed cell height
 		tableView.performBatchUpdates(nil, completion: nil)

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -281,7 +281,8 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func animateChanges(of cell: UITableViewCell) {
-		guard tableView.visibleCells.contains(cell) else { return }
+		// Only animate changes as long as the risk and the test result cell are both still supposed to be there
+		guard tableView.visibleCells.contains(cell), viewModel.riskAndTestRows.count == 2 else { return }
 
 		// Animate the changed cell height
 		tableView.performBatchUpdates(nil, completion: nil)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -72,8 +72,18 @@ final class RiskProvider: RiskProviding {
 		Log.info("RiskProvider: Request risk was called. UserInitiated: \(userInitiated)", log: .riskDetection)
 
 		guard activityState == .idle else {
-			Log.info("RiskProvider: Risk detection is allready running. Don't start new risk detection", log: .riskDetection)
+			Log.info("RiskProvider: Risk detection is already running. Don't start new risk detection.", log: .riskDetection)
 			failOnTargetQueue(error: .riskProviderIsRunning, updateState: false)
+			return
+		}
+
+		guard !WarnOthersReminder(store: store).positiveTestResultWasShown else {
+			Log.info("RiskProvider: Positive test result was already shown. Don't start new risk detection.", log: .riskDetection)
+			return
+		}
+
+		guard store.lastSuccessfulSubmitDiagnosisKeyTimestamp == nil else {
+			Log.info("RiskProvider: Keys were already submitted. Don't start new risk detection.", log: .riskDetection)
 			return
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -167,6 +167,8 @@ final class RiskProviderTests: XCTestCase {
 
 		let store = MockTestStore()
 		store.riskCalculationResult = nil
+		store.positiveTestResultWasShown = false
+		store.lastSuccessfulSubmitDiagnosisKeyTimestamp = nil
 
 		let config = RiskProvidingConfiguration(
 			exposureDetectionValidityDuration: duration,
@@ -187,12 +189,22 @@ final class RiskProviderTests: XCTestCase {
 
 		let consumer = RiskConsumer()
 
-		let didCalculateRiskCalled = expectation(description: "expect didCalculateRisk to be called")
+		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk to be called")
+
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
+		didFailCalculateRiskExpectation.isInverted = true
+
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called 3 times")
+		didChangeActivityStateExpectation.expectedFulfillmentCount = 3
+
 		consumer.didCalculateRisk = { _ in
-			didCalculateRiskCalled.fulfill()
+			didCalculateRiskExpectation.fulfill()
 		}
 		consumer.didFailCalculateRisk = { _ in
-			XCTFail("didFailCalculateRisk should not be called.")
+			didFailCalculateRiskExpectation.fulfill()
+		}
+		consumer.didChangeActivityState = { _ in
+			didChangeActivityStateExpectation.fulfill()
 		}
 
 		riskProvider.observeRisk(consumer)
@@ -206,6 +218,8 @@ final class RiskProviderTests: XCTestCase {
 
 		let store = MockTestStore()
 		store.riskCalculationResult = nil
+		store.positiveTestResultWasShown = false
+		store.lastSuccessfulSubmitDiagnosisKeyTimestamp = nil
 
 		let config = RiskProvidingConfiguration(
 			exposureDetectionValidityDuration: duration,
@@ -225,21 +239,130 @@ final class RiskProviderTests: XCTestCase {
 		)
 
 		let consumer = RiskConsumer()
-		let didCalculateRiskFailedCalled = expectation(
-			description: "expect didFailCalculateRisk to be called"
-		)
+
+		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk to be called")
+		didCalculateRiskExpectation.isInverted = true
+
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
+
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called 3 times")
+		didChangeActivityStateExpectation.expectedFulfillmentCount = 3
 
 		consumer.didCalculateRisk = { _ in
-			XCTFail("didCalculateRisk should not be called.")
+			didCalculateRiskExpectation.fulfill()
 		}
-
 		consumer.didFailCalculateRisk = { _ in
-			didCalculateRiskFailedCalled.fulfill()
+			didFailCalculateRiskExpectation.fulfill()
+		}
+		consumer.didChangeActivityState = { _ in
+			didChangeActivityStateExpectation.fulfill()
 		}
 
 		sut.observeRisk(consumer)
 		sut.requestRisk(userInitiated: true)
 		
+		waitForExpectations(timeout: .medium)
+	}
+
+	func testThatDetectionIsNotRequestedIfPositiveTestResultWasShown() throws {
+		let duration = DateComponents(day: 1)
+
+		let store = MockTestStore()
+		store.riskCalculationResult = nil
+		store.positiveTestResultWasShown = true
+
+		let config = RiskProvidingConfiguration(
+			exposureDetectionValidityDuration: duration,
+			exposureDetectionInterval: duration
+		)
+
+		let exposureDetectionDelegateStub = ExposureDetectionDelegateStub(result: .success([MutableENExposureWindow()]))
+
+		let riskProvider = RiskProvider(
+			configuration: config,
+			store: store,
+			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
+			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
+			riskCalculation: RiskCalculationFake(),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
+			exposureDetectionExecutor: exposureDetectionDelegateStub
+		)
+
+		let consumer = RiskConsumer()
+
+		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk not to be called")
+		didCalculateRiskExpectation.isInverted = true
+
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
+		didFailCalculateRiskExpectation.isInverted = true
+
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
+		didChangeActivityStateExpectation.isInverted = true
+
+		consumer.didCalculateRisk = { _ in
+			didCalculateRiskExpectation.fulfill()
+		}
+		consumer.didFailCalculateRisk = { _ in
+			didFailCalculateRiskExpectation.fulfill()
+		}
+		consumer.didChangeActivityState = { _ in
+			didChangeActivityStateExpectation.fulfill()
+		}
+
+		riskProvider.observeRisk(consumer)
+		riskProvider.requestRisk(userInitiated: true)
+
+		waitForExpectations(timeout: .medium)
+	}
+
+	func testThatDetectionIsNotRequestedIfKeysWereSubmitted() throws {
+		let duration = DateComponents(day: 1)
+
+		let store = MockTestStore()
+		store.riskCalculationResult = nil
+		store.lastSuccessfulSubmitDiagnosisKeyTimestamp = Int64(Date().timeIntervalSince1970)
+
+		let config = RiskProvidingConfiguration(
+			exposureDetectionValidityDuration: duration,
+			exposureDetectionInterval: duration
+		)
+
+		let exposureDetectionDelegateStub = ExposureDetectionDelegateStub(result: .success([MutableENExposureWindow()]))
+
+		let riskProvider = RiskProvider(
+			configuration: config,
+			store: store,
+			appConfigurationProvider: CachedAppConfigurationMock(with: SAP_Internal_V2_ApplicationConfigurationIOS()),
+			exposureManagerState: .init(authorized: true, enabled: true, status: .active),
+			riskCalculation: RiskCalculationFake(),
+			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
+			exposureDetectionExecutor: exposureDetectionDelegateStub
+		)
+
+		let consumer = RiskConsumer()
+
+		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk not to be called")
+		didCalculateRiskExpectation.isInverted = true
+
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
+		didFailCalculateRiskExpectation.isInverted = true
+
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
+		didChangeActivityStateExpectation.isInverted = true
+
+		consumer.didCalculateRisk = { _ in
+			didCalculateRiskExpectation.fulfill()
+		}
+		consumer.didFailCalculateRisk = { _ in
+			didFailCalculateRiskExpectation.fulfill()
+		}
+		consumer.didChangeActivityState = { _ in
+			didChangeActivityStateExpectation.fulfill()
+		}
+
+		riskProvider.observeRisk(consumer)
+		riskProvider.requestRisk(userInitiated: true)
+
 		waitForExpectations(timeout: .medium)
 	}
 


### PR DESCRIPTION
## Description
- Reloads the table view cell instead of animating cell changes if the number of cells changes from 2 to 1
- Disables the risk provider once the positive test result was shown or the keys were submitted.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4648
