### PR TITLE
fix no new risk calculation in automatic mode

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -88,18 +88,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	}
 
 	func applicationWillEnterForeground(_ application: UIApplication) {
+		let detectionMode = DetectionMode.fromBackgroundStatus()
+		riskProvider.riskProvidingConfiguration.detectionMode = detectionMode
 		checkForRisks()
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
 	}
 	
 	private func checkForRisks() {
-		let detectionMode = DetectionMode.fromBackgroundStatus()
-		riskProvider.riskProvidingConfiguration.detectionMode = detectionMode
-
 		riskProvider.requestRisk(userInitiated: false)
-
 		let state = exposureManager.exposureManagerState
-
 		updateExposureState(state)
 	}
 

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -83,21 +83,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		NotificationCenter.default.addObserver(self, selector: #selector(isOnboardedDidChange(_:)), name: .isOnboardedDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(backgroundRefreshStatusDidChange), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: nil)
 
-		checkForRisks()
 		return true
 	}
 
 	func applicationWillEnterForeground(_ application: UIApplication) {
 		let detectionMode = DetectionMode.fromBackgroundStatus()
 		riskProvider.riskProvidingConfiguration.detectionMode = detectionMode
-		checkForRisks()
-		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
-	}
-	
-	private func checkForRisks() {
 		riskProvider.requestRisk(userInitiated: false)
 		let state = exposureManager.exposureManagerState
 		updateExposureState(state)
+		
+		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
 	}
 
 	func applicationDidBecomeActive(_ application: UIApplication) {

--- a/src/xcode/ENA/ENA/Source/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate.swift
@@ -83,10 +83,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		NotificationCenter.default.addObserver(self, selector: #selector(isOnboardedDidChange(_:)), name: .isOnboardedDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(backgroundRefreshStatusDidChange), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: nil)
 
+		checkForRisks()
 		return true
 	}
 
 	func applicationWillEnterForeground(_ application: UIApplication) {
+		checkForRisks()
+		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
+	}
+	
+	private func checkForRisks() {
 		let detectionMode = DetectionMode.fromBackgroundStatus()
 		riskProvider.riskProvidingConfiguration.detectionMode = detectionMode
 
@@ -95,7 +101,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		let state = exposureManager.exposureManagerState
 
 		updateExposureState(state)
-		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
 	}
 
 	func applicationDidBecomeActive(_ application: UIApplication) {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Model/RiskProvidingConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Model/RiskProvidingConfiguration.swift
@@ -14,7 +14,7 @@ struct RiskProvidingConfiguration: Equatable {
 		return RiskProvidingConfiguration(
 			exposureDetectionValidityDuration: DateComponents(day: 2),
 			exposureDetectionInterval: DateComponents(hour: defaultExposureDetectionsInterval),
-			detectionMode: .default
+			detectionMode: DetectionMode.fromBackgroundStatus()
 		)
 	}
 


### PR DESCRIPTION
## Description
In automatic mode, if 2 phones where next to each other for 30 min, then you switch one phone off, and submit a **Positive test result** with the other phone, then switch the first phone on again and open the app, the app doesn't detect the high risk exposure.
this is because the **detection mode is manual by default** and we should check the mode every time we enter the app from both background or from first load from memory.

PS: the risk exposure interval is 4 hours.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4564

## Screenshots
![IMG_0070](https://user-images.githubusercontent.com/15270737/104979480-acc6a280-5a04-11eb-8fc6-14245417d507.PNG)
![IMG_0069](https://user-images.githubusercontent.com/15270737/104979485-af28fc80-5a04-11eb-9627-af211992ad02.PNG)

