### PR TITLE
4434-create-missing-screenshots

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionUITests.swift
@@ -105,6 +105,29 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 		XCTAssertTrue(consentGivenCell.waitForExistence(timeout: .long))
 	}
 	
+	func test_SubmitTAN_Screenshot_SymptomsOptionYes() {
+		var screenshotCounter = 0
+		
+		// setting up launch arguments
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
+		app.launchArguments += [UITestingParameters.ExposureSubmission.useMock.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.loadSupportedCountriesSuccess.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.getTemporaryExposureKeysSuccess.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.getRegistrationTokenSuccess.rawValue]
+		app.launchArguments += [UITestingParameters.ExposureSubmission.submitExposureSuccess.rawValue]
+		
+		// launch and nagivate to the desired screen
+		launch()
+		navigateToSymptomsScreen()
+		
+		// capturing and selecting Yes button
+		let optionYes = app.buttons["AppStrings.ExposureSubmissionSymptoms.answerOptionYes"]
+		optionYes.tap()
+
+		// take snapshot of the selection
+		snapshot("tan_submissionflow_symptoms_selection\(String(format: "%04d", (screenshotCounter.inc() )))")
+	}
+	
 	func test_SubmitTAN_SymptomsOptionNo() {
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launchArguments += [UITestingParameters.ExposureSubmission.useMock.rawValue]

--- a/src/xcode/ENA/TestPlans/Screenshots.xctestplan
+++ b/src/xcode/ENA/TestPlans/Screenshots.xctestplan
@@ -25,6 +25,7 @@
         "ENAUITests_01_Home\/test_screenshot_homescreen_riskCardLow()",
         "ENAUITests_01_Home\/test_screenshot_homescreen_riskCardLow_activeExposureLogging()",
         "ENAUITests_01_Home\/test_screenshot_homescreen_riskCardLow_noExposureLogging()",
+        "ENAUITests_04_ExposureSubmissionUITests\/test_SubmitTAN_Screenshot_SymptomsOptionYes()",
         "ENAUITests_04_ExposureSubmissionUITests\/test_screenshot_SubmissionNotPossible()",
         "ENAUITests_04_ExposureSubmissionUITests\/test_screenshot_SubmitQR()",
         "ENAUITests_04_ExposureSubmissionUITests\/test_screenshot_SubmitTAN()",


### PR DESCRIPTION
## Description
As mentioned in the task description three screenshots were missing namely 5, 6 and 7. This PR will fix the screenshot for 5 and the screenshot for 6 is already in the folder. The screenshot for 7 is blocked due to the on going task on contact journal, so I will create a separate PR for it once I get a go ahead. The names of screenshots are updated in the ticket. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4434

## Screenshots
![iPhone 11 Pro-tan_submissionflow_symptoms_selection0001](https://user-images.githubusercontent.com/77438487/105032422-0952ad80-5a57-11eb-9026-ee95e7131549.png)
![iPhone 11 Pro-deltaOnboarding_V15_0001](https://user-images.githubusercontent.com/77438487/105032486-1cfe1400-5a57-11eb-969c-5748ef74b911.png)

