### PR TITLE
Fix/4375 show large titles correctly

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController.swift
@@ -25,6 +25,14 @@ class AppInformationViewController: DynamicTableViewController {
 			)
 		])
     }
+
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+		// navigationbar is a shared property - so we need to trigger a resizing because others could have set it to false
+		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationController?.navigationBar.sizeToFit()
+	}
+
 }
 
 extension AppInformationViewController {

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/AddAndEditEntry/DiaryAddAndEditEntryViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/AddAndEditEntry/DiaryAddAndEditEntryViewController.swift
@@ -31,10 +31,17 @@ class DiaryAddAndEditEntryViewController: UIViewController, UITextFieldDelegate,
 	override func viewDidLoad() {
 		super.viewDidLoad()
 
-		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationItem.largeTitleDisplayMode = .always
 
 		setupBindings()
 		setupView()
+	}
+
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+
+		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationController?.navigationBar.sizeToFit()
 	}
 
 	override func viewDidAppear(_ animated: Bool) {

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.xib
@@ -23,7 +23,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ayn-Bb-Bzf">
-                    <rect key="frame" x="0.0" y="44" width="414" height="736"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="780"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </tableView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8JE-dq-vsn" customClass="ENAButton" customModule="ENA">
@@ -47,7 +47,7 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8JE-dq-vsn" secondAttribute="trailing" constant="16" id="D6H-Ha-lir"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="8JE-dq-vsn" secondAttribute="bottom" constant="16" id="L8F-mG-CR8"/>
                 <constraint firstItem="8JE-dq-vsn" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="Q83-2O-6aK"/>
-                <constraint firstItem="Ayn-Bb-Bzf" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Tbv-ze-xiZ"/>
+                <constraint firstItem="Ayn-Bb-Bzf" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Tbv-ze-xiZ"/>
                 <constraint firstItem="Ayn-Bb-Bzf" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="aQC-n7-io3"/>
             </constraints>
             <point key="canvasLocation" x="-404.34782608695656" y="152.67857142857142"/>

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/DiaryOverviewTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/DiaryOverviewTableViewController.swift
@@ -55,6 +55,13 @@ class DiaryOverviewTableViewController: UITableViewController {
 		self.navigationItem.setRightBarButton(rightBarButton, animated: false)
 	}
 
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+		// navigationbar is a shared property - so we need to trigger a resizing because others could have set it to false
+		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationController?.navigationBar.sizeToFit()
+	}
+
 	// MARK: - Protocol UITableViewDataSource
 
 	override func numberOfSections(in tableView: UITableView) -> Int {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -111,7 +111,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		setupBarButtonItems()
 		setupTableView()
 
-		navigationItem.largeTitleDisplayMode = .never
+		navigationItem.largeTitleDisplayMode = .automatic
 		tableView.backgroundColor = .enaColor(for: .separator)
 
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshUIAfterResumingFromBackground), name: UIApplication.willEnterForegroundNotification, object: nil)
@@ -122,6 +122,10 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
+
+		/** navigationbar is a shared property - so we need to trigger a resizing because others could have set it to true*/
+		navigationController?.navigationBar.prefersLargeTitles = false
+		navigationController?.navigationBar.sizeToFit()
 
 		viewModel.state.requestRisk(userInitiated: false)
 	}


### PR DESCRIPTION
## Description
On some screens the large titles were not displayed even we have set the property (`prefersLargeTitles`). The clue is to set in in relation to another property (`largeTitleDisplayMode`) and `sizeToFit()` in `viewWillAppear()`.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4375

## Screenshots
![4375-overview](https://user-images.githubusercontent.com/75615785/105715528-0441a280-5f1e-11eb-8433-632426a01e40.png)
![4375-overview-dark](https://user-images.githubusercontent.com/75615785/105715526-03a90c00-5f1e-11eb-8222-6d4ed71daff3.png)
![4375-people](https://user-images.githubusercontent.com/75615785/105715525-03a90c00-5f1e-11eb-948c-4ce70cc8c87b.png)
![4375-people-dark](https://user-images.githubusercontent.com/75615785/105715524-0277df00-5f1e-11eb-9551-cae4dbc8eb3f.png)