### PR TITLE
change dateFormatter to utcDateFormatter

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/__test__/DiaryOverviewViewModelTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/__test__/DiaryOverviewViewModelTest.swift
@@ -104,7 +104,7 @@ class DiaryOverviewViewModelTest: XCTestCase {
 	func testGIVEN_DiaryOverviewViewModel_WHEN_lowHistoryExposureIsInStore_THEN_LowHistoryExposureIsReturned() throws {
 
 		// GIVEN
-		let dateFormatter = ISO8601DateFormatter.contactDiaryFormatter
+		let dateFormatter = ISO8601DateFormatter.contactDiaryUTCFormatter
 
 		let todayString = dateFormatter.string(from: Date())
 		let today = try XCTUnwrap(dateFormatter.date(from: todayString))
@@ -137,7 +137,7 @@ class DiaryOverviewViewModelTest: XCTestCase {
 	func testGIVEN_DiaryOverviewViewModel_WHEN_highHistoryExposureIsInStore_THEN_HighHistoryExposureIsReturned() throws {
 
 		// GIVEN
-		let dateFormatter = ISO8601DateFormatter.contactDiaryFormatter
+		let dateFormatter = ISO8601DateFormatter.contactDiaryUTCFormatter
 
 		let todayString = dateFormatter.string(from: Date())
 		let today = try XCTUnwrap(dateFormatter.date(from: todayString))


### PR DESCRIPTION
## Description
We discovered, that 2 unit tests for the contact journal could failed due to the wrong dateFormatter
