### PR TITLE
Fix/4743 text formatting statistics info screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1596,9 +1596,9 @@ sein.";
 
 "Statistics_Info_ReproductionNumber_Text" = "Die Reproduktionszahl R gibt an, wie viele Personen im Durchschnitt von einer infizierten Person angesteckt wurden. Der aktuelle Wert berücksichtigt Daten bis vor 5 Tagen.";
 
-"Statistics_Info_FAQLink_Text" = "Weitere Informationen finden Sie in der";
+"Statistics_Info_FAQLink_Text" = "Weitere Informationen finden Sie in den FAQ:";
 
-"Statistics_Info_FAQLink_Title" = "FAQ zu den Statistiken.";
+"Statistics_Info_FAQLink_Title" = "FAQ zu den Statistiken";
 
 "Statistics_Info_Definitions_Title" = "Legende";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1598,7 +1598,7 @@ sein.";
 
 "Statistics_Info_FAQLink_Text" = "Weitere Informationen finden Sie in den FAQ:";
 
-"Statistics_Info_FAQLink_Title" = "FAQ zu den Statistiken";
+"Statistics_Info_FAQLink_Title" = "FAQ zu Statistiken";
 
 "Statistics_Info_Definitions_Title" = "Legende";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/StatisticsInfo/StatisticsInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/StatisticsInfo/StatisticsInfoViewController.swift
@@ -233,13 +233,4 @@ private extension DynamicCell {
 		}
 	}
 
-	static func dotBodyCell(color: UIColor, text: String, accessibilityLabelColor: String, accessibilityIdentifier: String?) -> Self {
-		.identifier(RiskLegendViewController.CellReuseIdentifier.dotBody) { _, cell, _ in
-			guard let cell = cell as? RiskLegendDotBodyCell else { return }
-			cell.dotView.backgroundColor = color
-			cell.textLabel?.text = text
-			cell.accessibilityLabel = "\(text)\n\n\(accessibilityLabelColor)"
-			cell.accessibilityIdentifier = accessibilityIdentifier
-		}
-	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/StatisticsInfo/StatisticsInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/StatisticsInfo/StatisticsInfoViewController.swift
@@ -168,7 +168,7 @@ class StatisticsInfoViewController: DynamicTableViewController {
 						color: .enaColor(for: .textPrimary2),
 						accessibilityIdentifier: nil
 					),
-					.body(
+					.bodyWithoutTopInset(
 						text: AppStrings.Statistics.Info.yesterdayText,
 						accessibilityIdentifier: nil
 					),
@@ -178,7 +178,7 @@ class StatisticsInfoViewController: DynamicTableViewController {
 						color: .enaColor(for: .textPrimary2),
 						accessibilityIdentifier: nil
 					),
-					.body(
+					.bodyWithoutTopInset(
 						text: AppStrings.Statistics.Info.meanText,
 						accessibilityIdentifier: nil
 					),
@@ -188,7 +188,7 @@ class StatisticsInfoViewController: DynamicTableViewController {
 						color: .enaColor(for: .textPrimary2),
 						accessibilityIdentifier: nil
 					),
-					.body(
+					.bodyWithoutTopInset(
 						text: AppStrings.Statistics.Info.totalText,
 						accessibilityIdentifier: nil
 					)
@@ -202,7 +202,7 @@ class StatisticsInfoViewController: DynamicTableViewController {
 						text: AppStrings.Statistics.Info.trendTitle,
 						accessibilityIdentifier: nil
 					),
-					.body(
+					.bodyWithoutTopInset(
 						text: AppStrings.Statistics.Info.trendText,
 						accessibilityIdentifier: nil
 					),
@@ -227,6 +227,7 @@ class StatisticsInfoViewController: DynamicTableViewController {
 private extension DynamicCell {
 	static func headlineWithoutBottomInset(text: String, color: UIColor? = nil, accessibilityIdentifier: String?) -> Self {
 		.headline(text: text, color: color, accessibilityIdentifier: accessibilityIdentifier) { _, cell, _ in
+			cell.contentView.preservesSuperviewLayoutMargins = false
 			cell.contentView.layoutMargins.bottom = 0
 			cell.accessibilityIdentifier = accessibilityIdentifier
 		}


### PR DESCRIPTION
## Description
Fixes the large vertical space between headlines and body on the "Statistics Info Screen". 

### Discussion
One problem remains: the space between "Weitere Informationen finden Sie" and the link "FAQ zu den Statistiken" remains (see source code, "section" starting in line 137. 

Semantically the text and the link are one sentence, but the implementation splits it into two separate cells (.body and .link). 
Option 1: how can we put text and link together in one element?
Option 2: change the UI into two separate elements. First the text on "Weitere Informationen finden Sie in den FAQ zu den Statistiken:" and then the link on a separate line. In this case the vertical space would be OK. 

## Solution
UA changed the text. See Figma: https://www.figma.com/proto/T2QlEOXuazU6XZ8ztd8mTU/COVID19_Master_1.12?node-id=1177%3A652&viewport=-67%2C1128%2C1.0778052806854248&scaling=min-zoom

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4743

## Screenshots
![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 08 21 01](https://user-images.githubusercontent.com/7896005/105958651-36b4e200-607b-11eb-8a97-a0ddf1a743bc.png)

![Simulator Screen Shot - iPhone 11 - 2021-01-27 at 09 46 39](https://user-images.githubusercontent.com/7896005/105966547-1ab63e00-6085-11eb-8f3d-cc15a500d39c.png)


