### PR TITLE
Change of text on risk card

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
@@ -39,7 +39,7 @@
 			<key>zero</key>
 			<string>Begegnungen an %u Tagen mit erhöhtem Risiko</string>
 			<key>one</key>
-			<string>Begegnungen an einem Tag mit erhöhtem Risiko</string>
+			<string>Begegnungen an 1 Tag mit erhöhtem Risiko</string>
 			<key>few</key>
 			<string>Begegnungen an %u Tagen mit erhöhtem Risiko</string>
 			<key>many</key>

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
@@ -87,7 +87,7 @@ class ENAUITests_01_Home: XCTestCase {
 		// see HomeRiskLevelCellConfigurator.setupAccessibility()
 		XCTAssert(app.buttons[AccessibilityLabels.localized(AppStrings.Home.riskCardHighTitle)].waitForExistence(timeout: .short))
 		
-		// find an element with localized text "Begegnungen an einem Tag mit erhöhtem Risiko"
+		// find an element with localized text "Begegnungen an 1 Tag mit erhöhtem Risiko"
 		let highRiskTitle = String(format: AccessibilityLabels.localized(AppStrings.Home.riskCardHighNumberContactsItemTitle), numberOfDaysWithHighRisk)
 		XCTAssert(app.otherElements[highRiskTitle].waitForExistence(timeout: .short))
 		


### PR DESCRIPTION
## Description
If there was only one exposure (high or low risk) the text "Begegnungen an einem Tag mit erhöhtem Risiko“ shall be replaced with „Begegnungen an 1 Tag mit erhöhtem Risiko“

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4827

## Screenshots
![Simulator Screen Shot - Clone 1 of iPhone 11 - 2021-01-28 at 21 49 34](https://user-images.githubusercontent.com/77438487/106198599-88ad5300-61b4-11eb-9309-4f6d4bd55396.png)
![Simulator Screen Shot - Clone 1 of iPhone 11 - 2021-01-28 at 21 46 08](https://user-images.githubusercontent.com/77438487/106198638-9531ab80-61b4-11eb-873e-0762a4562c87.png)


