### PR TITLE
Remove whitespace in the navigationBar for iOS 12.5

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController.swift
@@ -46,7 +46,7 @@ final class OnboardingInfoViewController: UIViewController {
 		viewRespectsSystemMinimumLayoutMargins = false
 		view.layoutMargins = .zero
 		setupAccessibility()
-
+		setupNavigationBar()
 		if pageType == .togetherAgainstCoronaPage { loadCountryList() }
 	}
 
@@ -112,6 +112,14 @@ final class OnboardingInfoViewController: UIViewController {
 		)
 	}
 
+	private func setupNavigationBar() {
+		if #available(iOS 13, *) {
+			navigationItem.largeTitleDisplayMode = .always
+		} else {
+			navigationItem.largeTitleDisplayMode = .never
+		}
+	}
+	
 	private func openSettings() {
 		guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
 		UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
## Description
There is a large whitespace in the fresh install on-boarding for iOS 12.5

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4831

## Screenshots
![IMG_2039](https://user-images.githubusercontent.com/15270737/106272837-fba8df00-6231-11eb-8cd1-90a1d20e1b11.PNG)
![IMG_2040](https://user-images.githubusercontent.com/15270737/106272843-fd72a280-6231-11eb-8fa1-2c98240b9d18.PNG)
![IMG_2041](https://user-images.githubusercontent.com/15270737/106272852-ffd4fc80-6231-11eb-8a93-c6e02bcd97f3.PNG)

