### PR TITLE
Feature/4874-TASK-time check

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -115,6 +115,7 @@ final class CachedAppConfiguration {
 			self.client.fetchAppConfiguration(etag: etag) { [weak self] result in
 				queue.async(flags: .barrier) {
 					guard let self = self else { return }
+                    var updatedSuccessful = true
 
 					switch result.0 {
 					case .success(let response):
@@ -151,6 +152,7 @@ final class CachedAppConfiguration {
 
 						default:
 							defaultFailureHandler()
+                            updatedSuccessful = false
 						}
 					}
 
@@ -158,10 +160,11 @@ final class CachedAppConfiguration {
 					if let serverTime = result.1 {
 						self.deviceTimeCheck.updateDeviceTimeFlags(
 							serverTime: serverTime,
-							deviceTime: Date()
+							deviceTime: Date(),
+							configUpdateSuccessful: updatedSuccessful
 						)
 					} else {
-						self.deviceTimeCheck.resetDeviceTimeFlags()
+						self.deviceTimeCheck.resetDeviceTimeFlags(configUpdateSuccessful: updatedSuccessful)
 					}
 				}
 			}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -164,7 +164,7 @@ final class CachedAppConfiguration {
 							configUpdateSuccessful: updatedSuccessful
 						)
 					} else {
-						self.deviceTimeCheck.resetDeviceTimeFlags(configUpdateSuccessful: updatedSuccessful)
+						self.deviceTimeCheck.resetDeviceTimeFlags(configUpdateSuccessful: false)
 					}
 				}
 			}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/DeviceTimeCheck.swift
@@ -9,7 +9,6 @@ protocol DeviceTimeCheckProtocol {
 	func resetDeviceTimeFlags()
 
 	var isDeviceTimeCorrect: Bool { get }
-	var wasDeviceTimeErrorShown: Bool { get }
 }
 
 final class DeviceTimeCheck: DeviceTimeCheckProtocol {
@@ -24,28 +23,35 @@ final class DeviceTimeCheck: DeviceTimeCheckProtocol {
 
 	// MARK: - Internal
 
-	var isDeviceTimeCorrect: Bool {
-		store.isDeviceTimeCorrect
+	enum TimeCheckResult: Int, Codable {
+		case correct
+		case assumedCorrect
+		case incorrect
 	}
 
-	var wasDeviceTimeErrorShown: Bool {
-		store.isDeviceTimeCorrect
+	var isDeviceTimeCorrect: Bool {
+		return store.deviceTimeCheckResult == .correct
 	}
 
 	func updateDeviceTimeFlags(serverTime: Date, deviceTime: Date) {
-		self.persistDeviceTimeCheckFlags(
-			isDeviceTimeCorrect: self.isDeviceTimeCorrect(
-				serverTime: serverTime,
-				deviceTime: deviceTime
-			),
-			isDeviceTimeCheckKillSwitchActive: self.isDeviceTimeCheckKillSwitchActive(
-				config: self.store.appConfigMetadata?.appConfig
-			)
-		)
+		let oldState = store.deviceTimeCheckResult
+		store.deviceTimeCheckResult = isDeviceTimeCorrect(
+            serverTime: serverTime,
+            deviceTime: deviceTime
+        )
+		// store change date only if a state change was detected
+		if oldState != store.deviceTimeCheckResult {
+			store.deviceTimeLastStateChange = Date()
+		}
+
+        if store.deviceTimeCheckResult == .correct {
+            store.wasDeviceTimeErrorShown = false
+        }
 	}
 
 	func resetDeviceTimeFlags() {
-		store.isDeviceTimeCorrect = true
+		store.deviceTimeCheckResult = .correct
+		store.deviceTimeLastStateChange = Date()
 		store.wasDeviceTimeErrorShown = false
 	}
 
@@ -53,21 +59,15 @@ final class DeviceTimeCheck: DeviceTimeCheckProtocol {
 
 	private let store: Store
 
-	private func persistDeviceTimeCheckFlags(
-		isDeviceTimeCorrect: Bool,
-		isDeviceTimeCheckKillSwitchActive: Bool
-	) {
-		store.isDeviceTimeCorrect = isDeviceTimeCheckKillSwitchActive ? true : isDeviceTimeCorrect
-		if store.isDeviceTimeCorrect {
-			store.wasDeviceTimeErrorShown = false
-		}
-	}
-
-	private func isDeviceTimeCorrect(serverTime: Date, deviceTime: Date) -> Bool {
+	private func isDeviceTimeCorrect(serverTime: Date, deviceTime: Date) -> TimeCheckResult {
+        let killSwitchActive = isDeviceTimeCheckKillSwitchActive(config: store.appConfigMetadata?.appConfig)
+		guard !killSwitchActive else {
+            return .assumedCorrect
+        }
 		let twoHourIntevall: Double = 2 * 60 * 60
 		let serverTimeMinus2Hours = serverTime.addingTimeInterval(-twoHourIntevall)
 		let serverTimePlus2Hours = serverTime.addingTimeInterval(twoHourIntevall)
-		return (serverTimeMinus2Hours ... serverTimePlus2Hours).contains(deviceTime)
+		return (serverTimeMinus2Hours ... serverTimePlus2Hours).contains(deviceTime) ? .correct : .incorrect
 	}
 
 	private func isDeviceTimeCheckKillSwitchActive(config: SAP_Internal_V2_ApplicationConfigurationIOS?) -> Bool {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/DeviceTimeCheckTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/DeviceTimeCheckTests.swift
@@ -17,7 +17,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
@@ -35,7 +36,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
@@ -53,7 +55,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
@@ -71,7 +74,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .incorrect)
@@ -89,7 +93,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .incorrect)
@@ -109,7 +114,8 @@ final class DeviceTimeCheckTest: XCTestCase {
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.updateDeviceTimeFlags(
 			serverTime: serverTime,
-			deviceTime: deviceTime
+			deviceTime: deviceTime,
+			configUpdateSuccessful: true
 		)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .assumedCorrect)
@@ -122,7 +128,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 		fakeStore.wasDeviceTimeErrorShown = true
 
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
-		deviceTimeCheck.resetDeviceTimeFlags()
+		deviceTimeCheck.resetDeviceTimeFlags(configUpdateSuccessful: true)
 
 		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/DeviceTimeCheckTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/DeviceTimeCheckTests.swift
@@ -20,7 +20,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertTrue(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
@@ -38,7 +38,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertTrue(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
@@ -56,7 +56,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertTrue(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
@@ -74,7 +74,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertFalse(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .incorrect)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
@@ -92,7 +92,7 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertFalse(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .incorrect)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
@@ -112,19 +112,19 @@ final class DeviceTimeCheckTest: XCTestCase {
 			deviceTime: deviceTime
 		)
 
-		XCTAssertTrue(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .assumedCorrect)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 
 	func test_WHEN_ResetDeviceTimeFlagsToDefault_THEN_DeviceTimeIsCorrectIsSavedToStore() {
 		let fakeStore = MockTestStore()
-		fakeStore.isDeviceTimeCorrect = false
+		fakeStore.deviceTimeCheckResult = .incorrect
 		fakeStore.wasDeviceTimeErrorShown = true
 
 		let deviceTimeCheck = DeviceTimeCheck(store: fakeStore)
 		deviceTimeCheck.resetDeviceTimeFlags()
 
-		XCTAssertTrue(fakeStore.isDeviceTimeCorrect)
+		XCTAssertEqual(fakeStore.deviceTimeCheckResult, .correct)
 		XCTAssertFalse(fakeStore.wasDeviceTimeErrorShown)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -47,7 +47,8 @@ final class MockTestStore: Store, AppConfigCaching {
 	var wasRecentDayKeyDownloadSuccessful = false
 	var wasRecentHourKeyDownloadSuccessful = false
 	var lastKeyPackageDownloadDate: Date = .distantPast
-	var isDeviceTimeCorrect = true
+	var deviceTimeLastStateChange: Date = Date()
+	var deviceTimeCheckResult: DeviceTimeCheck.TimeCheckResult = .correct
 	var wasDeviceTimeErrorShown = false
 	var isSubmissionConsentGiven = false
 	var submissionKeys: [SAP_External_Exposurenotification_TemporaryExposureKey]?

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -214,10 +214,15 @@ final class SecureStore: Store {
 		get { kvStore["wasRecentHourKeyDownloadSuccessful"] as Bool? ?? false }
 		set { kvStore["wasRecentHourKeyDownloadSuccessful"] = newValue }
     }
-    
-	var isDeviceTimeCorrect: Bool {
-		get { kvStore["isDeviceTimeCorrect"] as Bool? ?? true }
-		set { kvStore["isDeviceTimeCorrect"] = newValue }
+
+	var deviceTimeCheckResult: DeviceTimeCheck.TimeCheckResult {
+		get { kvStore["deviceTimeCheckResult"] as DeviceTimeCheck.TimeCheckResult? ?? .correct }
+		set { kvStore["deviceTimeCheckResult"] = newValue }
+	}
+
+	var deviceTimeLastStateChange: Date {
+		get { kvStore["deviceTimeLastStateChange"] as Date? ?? Date() }
+		set { kvStore["deviceTimeLastStateChange"] = newValue }
 	}
 
 	var wasDeviceTimeErrorShown: Bool {

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -84,8 +84,10 @@ protocol StoreProtocol: AnyObject {
 
 	var lastKeyPackageDownloadDate: Date { get set }
 
-    var isDeviceTimeCorrect: Bool { get set }
-	
+	var deviceTimeCheckResult: DeviceTimeCheck.TimeCheckResult { get set }
+
+	var deviceTimeLastStateChange: Date { get set }
+
 	var wasDeviceTimeErrorShown: Bool { get set }
 
 	var positiveTestResultWasShown: Bool { get set }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -132,13 +132,13 @@ final class StoreTests: XCTestCase {
 	}
 	
 	func testDeviceTimeSettings_initalAfterInitialization() {
-		XCTAssertEqual(store.isDeviceTimeCorrect, true)
+		XCTAssertEqual(store.deviceTimeCheckResult, .correct)
 		XCTAssertEqual(store.wasDeviceTimeErrorShown, false)
 		
-		store.isDeviceTimeCorrect = false
+		store.deviceTimeCheckResult = .incorrect
 		store.wasDeviceTimeErrorShown = true
 		
-		XCTAssertEqual(store.isDeviceTimeCorrect, false)
+		XCTAssertEqual(store.deviceTimeCheckResult, .incorrect)
 		XCTAssertEqual(store.wasDeviceTimeErrorShown, true)
 	}
 


### PR DESCRIPTION
## Description
extended device time check to 3 different states (correct, assumedCorrect and incorrect)

## Link to Jira
Story: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4778
Task: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4874

## Link to Tech Spec change
https://github.com/corona-warn-app/cwa-app-tech-spec/compare/release/1.11.x..proposal/privacy-preserving-analytics#diff-797fa889d039ff7fc826beaca77b68f4b0a9b5d2f27397a97675d8968e1657a9

