### PR TITLE
Fix/4872 contact diary layout not centric

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/Cells/DiaryEditEntriesTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/Cells/DiaryEditEntriesTableViewCell.swift
@@ -6,14 +6,40 @@ import UIKit
 
 class DiaryEditEntriesTableViewCell: UITableViewCell {
 
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		addBackground()
+	}
+
+	required init?(coder: NSCoder) {
+		super.init(coder: coder)
+		addBackground()
+	}
+
 	// MARK: - Internal
 
 	func configure(model: DiaryEditEntriesCellModel) {
 		label.text = model.text
+
 	}
 
 	// MARK: - Private
 
 	@IBOutlet private weak var label: ENALabel!
 
+	private func addBackground() {
+		let _backgroundView = UIView(frame: .zero)
+		_backgroundView.translatesAutoresizingMaskIntoConstraints = false
+		_backgroundView.layer.cornerRadius = 14
+		_backgroundView.backgroundColor = .enaColor(for: .cellBackground)
+		_backgroundView.tintColor = .enaColor(for: .tint)
+		insertSubview(_backgroundView, belowSubview: contentView)
+
+		NSLayoutConstraint.activate([
+			_backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+			_backgroundView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+			_backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+			_backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
+		])
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/Cells/DiaryEditEntriesTableViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/Cells/DiaryEditEntriesTableViewCell.xib
@@ -18,48 +18,22 @@
                 <rect key="frame" x="0.0" y="0.0" width="280" height="106"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gLq-Pk-WqT">
-                        <rect key="frame" x="-32" y="5" width="344" height="96"/>
-                        <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Hye-vn-7dV">
-                                <rect key="frame" x="32" y="16" width="312" height="64"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ngm-Ku-E5a" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="22" width="280" height="20.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="body"/>
-                                        </userDefinedRuntimeAttributes>
-                                    </label>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="Ngm-Ku-E5a" secondAttribute="trailing" constant="36" id="2MN-4i-V5S"/>
-                                </constraints>
-                                <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="16" bottom="8" trailing="16"/>
-                            </stackView>
-                        </subviews>
-                        <color key="backgroundColor" name="ENA Cell Background Color"/>
-                        <constraints>
-                            <constraint firstAttribute="bottom" secondItem="Hye-vn-7dV" secondAttribute="bottom" constant="16" id="OVR-1v-x9h"/>
-                            <constraint firstAttribute="trailing" secondItem="Hye-vn-7dV" secondAttribute="trailing" id="Wit-Qr-f26"/>
-                            <constraint firstItem="Hye-vn-7dV" firstAttribute="leading" secondItem="gLq-Pk-WqT" secondAttribute="leading" constant="32" id="bCJ-ap-pJo"/>
-                            <constraint firstItem="Hye-vn-7dV" firstAttribute="top" secondItem="gLq-Pk-WqT" secondAttribute="top" constant="16" id="cQv-nC-gkR"/>
-                        </constraints>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ngm-Ku-E5a" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
+                        <rect key="frame" x="16" y="32" width="248" height="42"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                <integer key="value" value="14"/>
-                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="body"/>
                         </userDefinedRuntimeAttributes>
-                    </view>
+                    </label>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="gLq-Pk-WqT" firstAttribute="top" secondItem="Rn5-Sr-V5h" secondAttribute="top" constant="5" id="dQK-6Q-Md4"/>
-                    <constraint firstAttribute="bottom" secondItem="gLq-Pk-WqT" secondAttribute="bottom" constant="5" id="h1g-45-LAS"/>
-                    <constraint firstItem="gLq-Pk-WqT" firstAttribute="leading" secondItem="Rn5-Sr-V5h" secondAttribute="leading" constant="-32" id="jSg-Gm-apx"/>
-                    <constraint firstAttribute="trailing" secondItem="gLq-Pk-WqT" secondAttribute="trailing" constant="-32" id="oJM-s5-hGv"/>
+                    <constraint firstItem="Ngm-Ku-E5a" firstAttribute="top" secondItem="Rn5-Sr-V5h" secondAttribute="top" constant="32" id="AXQ-1o-0jC"/>
+                    <constraint firstAttribute="bottom" secondItem="Ngm-Ku-E5a" secondAttribute="bottom" constant="32" id="BLd-lN-iOU"/>
+                    <constraint firstAttribute="trailing" secondItem="Ngm-Ku-E5a" secondAttribute="trailing" constant="16" id="HEv-Cr-SsE"/>
+                    <constraint firstItem="Ngm-Ku-E5a" firstAttribute="leading" secondItem="Rn5-Sr-V5h" secondAttribute="leading" constant="16" id="ugC-ex-AcK"/>
                 </constraints>
                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="32" bottom="8" trailing="32"/>
             </tableViewCellContentView>
@@ -78,9 +52,6 @@
         </designable>
     </designables>
     <resources>
-        <namedColor name="ENA Cell Background Color">
-            <color red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="ENA Tint Color">
             <color red="0.0" green="0.49803921568627452" blue="0.67843137254901964" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
## Description
This PR moves the background view (grey view with rounded corners) of DiaryEditEntriesTableViewCell from the contentView (and its boundaries) to the view of the cell. This way the layout is simpler and works on 12.5 devices.

## Link to Jira
[4872](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4872)

## Screenshots
![IMG_E49963FECEC9-1](https://user-images.githubusercontent.com/1941000/106428820-d7cfde00-6469-11eb-8ffa-632332436d88.jpeg)
![IMG_E2554B781CF3-1](https://user-images.githubusercontent.com/1941000/106428826-da323800-6469-11eb-8abd-b610562b0763.jpeg)

