### PR TITLE
This fix ensures, that the deltaOnboarding view controller only shows up once

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -525,6 +525,9 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 	
 	private func showDeltaOnboardingIfNeeded(completion: @escaping () -> Void = {}) {
+		
+		guard deltaOnboardingCoordinator == nil else { return }
+		
 		appConfigurationProvider.appConfiguration().sink { [weak self] configuration in
 			guard let self = self else { return }
 


### PR DESCRIPTION
This is a fix for [JIRA ticket 4917](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4917). This solves an issue, that the delta onboarding screen (in this case for new features) cannot be closed.
