### PR TITLE
Fix/4961 Missing Paragraph On Diary Info Screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1515,7 +1515,7 @@ sein.";
 
 "ContactDiary_Information_Dataprivacy_Title" = "Weitere Hinweise finden Sie in der Datenschutzerklärung.";
 
-"ContactDiary_Information_PrimaryButton_Title" = "Tagebuch führen";
+"ContactDiary_Information_PrimaryButton_Title" = "Tagebuch öffnen";
 
 /* AddEditEntry */
 "ContactDiary_AddEditEntry_PrimaryButton_Title" = "Speichern";

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Info/DiaryInfoViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Info/DiaryInfoViewModel.swift
@@ -78,6 +78,15 @@ struct DiaryInfoViewModel {
 						color: .enaColor(for: .background)
 					),
 					.icon(
+						UIImage(imageLiteralResourceName: "Icons_Diary_Export_Textformat"),
+						text: .string(AppStrings.ContactDiary.Information.exportTextformat),
+						alignment: .top
+					),
+					.space(
+						height: 15.0,
+						color: .enaColor(for: .background)
+					),
+					.icon(
 						UIImage(imageLiteralResourceName: "Icons_Attention_high_small"),
 						text: .string(AppStrings.ContactDiary.Information.exposureHistory),
 						alignment: .top

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Info/__test__/DiaryInfoViewModelTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Info/__test__/DiaryInfoViewModelTest.swift
@@ -46,7 +46,7 @@ class DiaryInfoViewModelTest: XCTestCase {
 		let numberOfCells = viewModel.dynamicTableViewModel.numberOfRows(section: 0)
 
 		// THEN
-		XCTAssertEqual(numberOfCells, 12)
+		XCTAssertEqual(numberOfCells, 14)
 	}
 
 	/// test if number of cells in legal section (1) is correct


### PR DESCRIPTION
## Description
1. adds the missing paragraph (Kontakt-Tagebuch exportieren) to the diary info screen.
2. fixes the button text ("Tagebuch öffnen") on the diary info screen

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4961
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4951

## Screenshots

![Simulator Screen Shot - iPhone 12 - 2021-02-02 at 18 25 50](https://user-images.githubusercontent.com/7896005/106638831-92540380-6584-11eb-822b-3efaf2de0a47.png)
