### PR TITLE
Feature/4833 fetch enable flag from server

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -140,7 +140,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		#if DEBUG
 		if isUITesting {
 			// provide a static app configuration for ui tests to prevent validation errors
-			return CachedAppConfigurationMock()
+			return CachedAppConfigurationMock(isEventSurvayEnabled: true, isEventSurvayUrlAvailable: true)
 		}
 		#endif
 		// use a custom http client that uses/recognized caching mechanisms

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -140,7 +140,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		#if DEBUG
 		if isUITesting {
 			// provide a static app configuration for ui tests to prevent validation errors
-			return CachedAppConfigurationMock(isEventSurvayEnabled: true, isEventSurvayUrlAvailable: true)
+			return CachedAppConfigurationMock(isEventSurveyEnabled: true, isEventSurveyUrlAvailable: true)
 		}
 		#endif
 		// use a custom http client that uses/recognized caching mechanisms

--- a/src/xcode/ENA/ENA/Source/Coordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Coordinator.swift
@@ -242,7 +242,8 @@ class Coordinator: RequiresAppDependencies {
 			rootViewController: rootViewController,
 			store: store,
 			homeState: homeState,
-			exposureManager: exposureManager
+			exposureManager: exposureManager,
+			appConfigurationProvider: appConfigurationProvider
 		)
 		exposureDetectionCoordinator?.start()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationDynamicCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationDynamicCell.swift
@@ -59,7 +59,7 @@ extension DynamicCell {
 			cell.textView.delegate = viewController as? UITextViewDelegate
 			cell.textView.isUserInteractionEnabled = true
 			cell.textView.dataDetectorTypes = [.link, .phoneNumber]
-			
+
 			if let url = url {
 				cell.textView.load(from: url)
 			}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
@@ -34,7 +34,7 @@ final class ExposureDetectionCoordinator {
 				appConfigurationProvider: appConfigurationProvider,
 				onSurveyTap: { [weak self] urlString in
 					self?.showSurveyConsent(for: urlString)
-				}, 
+				},
 				onInactiveButtonTap: { [weak self] completion in
 					self?.setExposureManagerEnabled(true, then: completion)
 				}
@@ -49,10 +49,10 @@ final class ExposureDetectionCoordinator {
 		rootViewController.present(_navigationController, animated: true)
 	}
 
-	private func showSurveyConsent(for survayURL: String?) {
+	private func showSurveyConsent(for surveyURL: String?) {
 		setNavigationBarHidden(false)
 		
-		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel(urlString: survayURL)) { [weak self] url in
+		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel(urlString: surveyURL)) { [weak self] url in
 			self?.showSurveyWebpage(url: url)
 		}
 		navigationController?.pushViewController(surveyConsentViewController, animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
@@ -11,28 +11,31 @@ final class ExposureDetectionCoordinator {
 	private let store: Store
 	private let homeState: HomeState
 	private let exposureManager: ExposureManager
+	private let appConfigurationProvider: AppConfigurationProviding
 
 	init(
 		rootViewController: UIViewController,
 		store: Store,
 		homeState: HomeState,
-		exposureManager: ExposureManager
+		exposureManager: ExposureManager,
+		appConfigurationProvider: AppConfigurationProviding
 	) {
 		self.rootViewController = rootViewController
 		self.store = store
 		self.homeState = homeState
 		self.exposureManager = exposureManager
+		self.appConfigurationProvider = appConfigurationProvider
 	}
 
 	func start() {
 		let exposureDetectionController = ExposureDetectionViewController(
 			viewModel: ExposureDetectionViewModel(
 				homeState: homeState,
-				onInactiveButtonTap: { [weak self] completion in
+				appConfigurationProvider: appConfigurationProvider,
+				onSurveyTap: { [weak self] urlString in
+					self?.showSurveyConsent(for: urlString)
+				}, onInactiveButtonTap: { [weak self] completion in
 					self?.setExposureManagerEnabled(true, then: completion)
-				},
-				onSurveyTap: { [weak self] in
-					self?.showSurveyConsent()
 				}
 			),
 			store: store
@@ -45,10 +48,10 @@ final class ExposureDetectionCoordinator {
 		rootViewController.present(_navigationController, animated: true)
 	}
 
-	private func showSurveyConsent() {
+	private func showSurveyConsent(for survayURL: String?) {
 		setNavigationBarHidden(false)
-
-		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel()) { [weak self] url in
+		
+		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel(urlString: survayURL)) { [weak self] url in
 			self?.showSurveyWebpage(url: url)
 		}
 		navigationController?.pushViewController(surveyConsentViewController, animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
@@ -34,7 +34,8 @@ final class ExposureDetectionCoordinator {
 				appConfigurationProvider: appConfigurationProvider,
 				onSurveyTap: { [weak self] urlString in
 					self?.showSurveyConsent(for: urlString)
-				}, onInactiveButtonTap: { [weak self] completion in
+				}, 
+				onInactiveButtonTap: { [weak self] completion in
 					self?.setExposureManagerEnabled(true, then: completion)
 				}
 			),

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -97,6 +97,7 @@ final class ExposureDetectionViewController: DynamicTableViewController, Require
 
 		viewModel.$isButtonEnabled.assign(to: \.isEnabled, on: checkButton).store(in: &subscriptions)
 		viewModel.$buttonTitle.assign(to: \.accessibilityLabel, on: checkButton).store(in: &subscriptions)
+		viewModel.updateAppConfiguration()
 	}
 
 	override func viewDidLayoutSubviews() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -97,7 +97,6 @@ final class ExposureDetectionViewController: DynamicTableViewController, Require
 
 		viewModel.$isButtonEnabled.assign(to: \.isEnabled, on: checkButton).store(in: &subscriptions)
 		viewModel.$buttonTitle.assign(to: \.accessibilityLabel, on: checkButton).store(in: &subscriptions)
-		viewModel.updateAppConfiguration()
 	}
 
 	override func viewDidLayoutSubviews() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -272,7 +272,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 		case .high:
 			appConfigurationProvider.appConfiguration()
 				.sink { [weak self] in
-					let survayParameters = $0.eventDrivenUserSurveyParameters.common
+					let surveyParameters = $0.eventDrivenUserSurveyParameters.common
 					let isSurvayEnabled = survayParameters.surveyOnHighRiskEnabled && !survayParameters.surveyOnHighRiskURL.isEmpty
 					self?.surveyOnHighRiskURL = survayParameters.surveyOnHighRiskURL
 					if let dynamicViewModel = self?.highRiskModel(risk: risk, isSurvayEnabled: isSurvayEnabled) {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -272,16 +272,17 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 		case .high:
 			appConfigurationProvider.appConfiguration()
 				.sink { [weak self] in
-					let surveyParameters = $0.eventDrivenUserSurveyParameters.common
-					let isSurvayEnabled = survayParameters.surveyOnHighRiskEnabled && !survayParameters.surveyOnHighRiskURL.isEmpty
-					self?.surveyOnHighRiskURL = survayParameters.surveyOnHighRiskURL
-					if let dynamicViewModel = self?.highRiskModel(risk: risk, isSurvayEnabled: isSurvayEnabled) {
-						self?.dynamicTableViewModel = dynamicViewModel
+					guard let self = self else {
+						Log.debug("failed to get strong self")
+						return
 					}
+					let surveyParameters = $0.eventDrivenUserSurveyParameters.common
+					let isSurveyEnabled = surveyParameters.surveyOnHighRiskEnabled && !surveyParameters.surveyOnHighRiskURL.isEmpty
+					self.surveyOnHighRiskURL = surveyParameters.surveyOnHighRiskURL
+					self.dynamicTableViewModel = self.highRiskModel(risk: risk, isSurveyEnabled: isSurveyEnabled)
 				}
 				.store(in: &subscriptions)
 		}
-
 		titleText = risk.level.text
 		titleTextAccessibilityColor = risk.level.accessibilityRiskColor
 
@@ -405,7 +406,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 		])
 	}
 
-	private func highRiskModel(risk: Risk, isSurvayEnabled: Bool) -> DynamicTableViewModel {
+	private func highRiskModel(risk: Risk, isSurveyEnabled: Bool) -> DynamicTableViewModel {
 		let activeTracing = risk.details.activeTracing
 		let numberOfExposures = risk.details.numberOfDaysWithRiskLevel
 		var sections: [DynamicSection] = [
@@ -448,7 +449,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 				accessibilityIdentifier: AccessibilityIdentifiers.ExposureDetection.explanationTextHigh
 			)
 		]
-		if isSurvayEnabled {
+		if isSurveyEnabled {
 			sections.insert(surveySection(), at: 3)
 		}
 		return DynamicTableViewModel(sections)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -93,6 +93,8 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 
 	// MARK: - Internal
 
+	let appConfigurationProvider: AppConfigurationProviding
+
 	enum CloseButtonStyle {
 		case normal
 		case contrast
@@ -174,7 +176,6 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	// MARK: - Private
 
 	private let homeState: HomeState
-	let appConfigurationProvider: AppConfigurationProviding
 
 	private let onInactiveButtonTap: (@escaping (ExposureNotificationError?) -> Void) -> Void
 	private let onSurveyTap: (String?) -> Void

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
@@ -92,4 +92,10 @@ final class SurveyConsentViewModel {
 			]
 		)
 	])
+	
+	let urlString: String?
+	
+	init(urlString: String?) {
+		self.urlString = urlString
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewControllerTests.swift
@@ -35,8 +35,9 @@ class ExposureDetectionViewControllerTests: XCTestCase {
 		return ExposureDetectionViewController(
 			viewModel: ExposureDetectionViewModel(
 				homeState: homeState,
-				onInactiveButtonTap: { _ in },
-				onSurveyTap: { }
+				appConfigurationProvider: CachedAppConfigurationMock(),
+				onSurveyTap: { _ in },
+				onInactiveButtonTap: { _ in }
 			),
 			store: store
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
@@ -248,15 +248,15 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			}
 			.store(in: &subscriptions)
 
-		waitForExpectations(timeout: 5, handler: { (erro) in
+		waitForExpectations(timeout: 5, handler: { [weak self] _ in
 			if survayEnabled {
-				self.checkHighRiskConfigurationWithSurvayEnabled(
+				self?.checkHighRiskConfigurationWithSurvayEnabled(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: false
 				)
 			} else {
-				self.checkHighRiskConfiguration(
+				self?.checkHighRiskConfiguration(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: false

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
@@ -180,18 +180,18 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.isButtonHidden)
 	}
 
-	func testHighRiskStateWithDisabledSurvay() {
-		highRiskTesting(survayEnabled: false)
-		highRiskHomeStatesTesting(survayEnabled: false)
+	func testHighRiskStateWithDisabledSurvey() {
+		highRiskTesting(surveyEnabled: false)
+		highRiskHomeStatesTesting(surveyEnabled: false)
 
 	}
 	
-	func testHighRiskStateWithEnabledSurvay() {
-		highRiskTesting(survayEnabled: true)
-		highRiskHomeStatesTesting(survayEnabled: true)
+	func testHighRiskStateWithEnabledSurvey() {
+		highRiskTesting(surveyEnabled: true)
+		highRiskHomeStatesTesting(surveyEnabled: true)
 	}
 
-	func testEventSurvayDisabled_cellShouldBeHidden() {
+	func testEventSurveyDisabled_cellShouldBeHidden() {
 		var subscriptions = Set<AnyCancellable>()
 		
 		let store = MockTestStore()
@@ -223,7 +223,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		)
 		homeState.updateDetectionMode(.automatic)
 		
-		let configuration = CachedAppConfigurationMock(isEventSurvayEnabled: false, isEventSurvayUrlAvailable: false)
+		let configuration = CachedAppConfigurationMock(isEventSurveyEnabled: false, isEventSurveyUrlAvailable: false)
 		
 		let viewModel = ExposureDetectionViewModel(
 			homeState: homeState,
@@ -251,7 +251,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		})
 	}
 
-	private func highRiskTesting(survayEnabled: Bool) {
+	private func highRiskTesting(surveyEnabled: Bool) {
 		var subscriptions = Set<AnyCancellable>()
 		
 		let store = MockTestStore()
@@ -284,8 +284,8 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		homeState.updateDetectionMode(.automatic)
 		
 		let configuration: AppConfigurationProviding
-		if survayEnabled {
-			configuration = CachedAppConfigurationMock(isEventSurvayEnabled: survayEnabled, isEventSurvayUrlAvailable: true)
+		if surveyEnabled {
+			configuration = CachedAppConfigurationMock(isEventSurveyEnabled: surveyEnabled, isEventSurveyUrlAvailable: true)
 		} else {
 			configuration = CachedAppConfigurationMock()
 		}
@@ -308,8 +308,8 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			.store(in: &subscriptions)
 
 		waitForExpectations(timeout: 5, handler: { [weak self] _ in
-			if survayEnabled {
-				self?.checkHighRiskConfigurationWithSurvayEnabled(
+			if surveyEnabled {
+				self?.checkHighRiskConfigurationWithSurveyEnabled(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: false
@@ -357,7 +357,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.isButtonHidden)
 	}
 	
-	private func highRiskHomeStatesTesting(survayEnabled: Bool) {
+	private func highRiskHomeStatesTesting(surveyEnabled: Bool) {
 		var subscriptions = Set<AnyCancellable>()
 
 		let store = MockTestStore()
@@ -390,8 +390,8 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		homeState.updateDetectionMode(.automatic)
 		
 		let configuration: AppConfigurationProviding
-		if survayEnabled {
-			configuration = CachedAppConfigurationMock(isEventSurvayEnabled: survayEnabled, isEventSurvayUrlAvailable: true)
+		if surveyEnabled {
+			configuration = CachedAppConfigurationMock(isEventSurveyEnabled: surveyEnabled, isEventSurveyUrlAvailable: true)
 		} else {
 			configuration = CachedAppConfigurationMock()
 		}
@@ -414,13 +414,13 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			.store(in: &subscriptions)
 
 		waitForExpectations(timeout: 5, handler: { [weak self] _ in
-			if survayEnabled {
+			if surveyEnabled {
 				
 				// Check downloading state
 				
 				homeState.riskProviderActivityState = .downloading
 				
-				self?.checkHighRiskConfigurationWithSurvayEnabled(
+				self?.checkHighRiskConfigurationWithSurveyEnabled(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: true
@@ -430,7 +430,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 				
 				homeState.riskProviderActivityState = .detecting
 				
-				self?.checkHighRiskConfigurationWithSurvayEnabled(
+				self?.checkHighRiskConfigurationWithSurveyEnabled(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: true
@@ -440,7 +440,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 				
 				homeState.riskProviderActivityState = .idle
 				
-				self?.checkHighRiskConfigurationWithSurvayEnabled(
+				self?.checkHighRiskConfigurationWithSurveyEnabled(
 					of: viewModel.dynamicTableViewModel,
 					viewController: viewController,
 					isLoading: false
@@ -969,7 +969,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertEqual(section.cells[1].cellReuseIdentifier.rawValue, "labelCell")
 	}
 
-	private func checkHighRiskConfigurationWithSurvayEnabled(
+	private func checkHighRiskConfigurationWithSurveyEnabled(
 		of dynamicTableViewModel: DynamicTableViewModel,
 		viewController: ExposureDetectionViewController,
 		isLoading: Bool

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
@@ -8,7 +8,8 @@ import XCTest
 class SurveyConsentViewModelTests: XCTestCase {
 
 	func testDynamicTableViewModel() {
-		let viewModel = SurveyConsentViewModel()
+		let placeHolderString = "https://www.test.de"
+		let viewModel = SurveyConsentViewModel(urlString: placeHolderString)
 
 		let dynamicTableViewModel = viewModel.dynamicTableViewModel
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfigurationMock.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfigurationMock.swift
@@ -42,13 +42,13 @@ final class CachedAppConfigurationMock: AppConfigurationProviding {
 	
 	init(
 		with config: SAP_Internal_V2_ApplicationConfigurationIOS = CachedAppConfigurationMock.defaultAppConfiguration,
-		isEventSurvayEnabled: Bool,
-		isEventSurvayUrlAvailable: Bool
+		isEventSurveyEnabled: Bool,
+		isEventSurveyUrlAvailable: Bool
 	) {
 		self.config = config
 		self.config.eventDrivenUserSurveyParameters = eventDrivenUserSurveyParametersEnabled(
-			isEnabled: isEventSurvayEnabled,
-			isCorrectURL: isEventSurvayUrlAvailable)
+			isEnabled: isEventSurveyEnabled,
+			isCorrectURL: isEventSurveyUrlAvailable)
 	}
 	
 	func appConfiguration(forceFetch: Bool) -> AnyPublisher<SAP_Internal_V2_ApplicationConfigurationIOS, Never> {
@@ -68,10 +68,10 @@ final class CachedAppConfigurationMock: AppConfigurationProviding {
 		}).eraseToAnyPublisher()
 	}
 	private func eventDrivenUserSurveyParametersEnabled(isEnabled: Bool, isCorrectURL: Bool) -> SAP_Internal_V2_PPDDEventDrivenUserSurveyParametersIOS {
-		var survayParameters = SAP_Internal_V2_PPDDEventDrivenUserSurveyParametersIOS()
-		survayParameters.common.surveyOnHighRiskURL = isCorrectURL ? "https://www.test.de" : "https://w.test.de"
-		survayParameters.common.surveyOnHighRiskEnabled = isEnabled ? true : false
-		return survayParameters
+		var surveyParameters = SAP_Internal_V2_PPDDEventDrivenUserSurveyParametersIOS()
+		surveyParameters.common.surveyOnHighRiskURL = isCorrectURL ? "https://www.test.de" : "https://w.test.de"
+		surveyParameters.common.surveyOnHighRiskEnabled = isEnabled ? true : false
+		return surveyParameters
 	}
 }
 #endif

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfigurationMock.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfigurationMock.swift
@@ -40,12 +40,15 @@ final class CachedAppConfigurationMock: AppConfigurationProviding {
 		self.config = config
 	}
 	
-	init(with config: SAP_Internal_V2_ApplicationConfigurationIOS = CachedAppConfigurationMock.defaultAppConfiguration,
-		 isEventSurvayEnabled: Bool,
-		 isEventSurvayUrlAvailable: Bool) {
+	init(
+		with config: SAP_Internal_V2_ApplicationConfigurationIOS = CachedAppConfigurationMock.defaultAppConfiguration,
+		isEventSurvayEnabled: Bool,
+		isEventSurvayUrlAvailable: Bool
+	) {
 		self.config = config
-		self.config.eventDrivenUserSurveyParameters = eventDrivenUserSurveyParametersEnabled(isEnabled: isEventSurvayEnabled,
-																							 isCorrectURL: isEventSurvayUrlAvailable)
+		self.config.eventDrivenUserSurveyParameters = eventDrivenUserSurveyParametersEnabled(
+			isEnabled: isEventSurvayEnabled,
+			isCorrectURL: isEventSurvayUrlAvailable)
 	}
 	
 	func appConfiguration(forceFetch: Bool) -> AnyPublisher<SAP_Internal_V2_ApplicationConfigurationIOS, Never> {


### PR DESCRIPTION
## Description

- Add business logic to inject the "Event based Survay" parameters: "the survey link, isSurvayEnabledFlag" to the ExposureDetectionViewController.

- update the unit tests to reflect the new cell and testing that if the survey feature is enabled or not the screen should reflect this correclty.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4833

