### PR TITLE
Reset timeUntilUpdate on timer end

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -62,6 +62,8 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	// MARK: - Protocol CountdownTimerDelegate
 
 	func countdownTimer(_ timer: CountdownTimer, didEnd done: Bool) {
+		timeUntilUpdate = nil
+		
 		if case .risk = homeState.riskState, homeState.manualExposureDetectionState == .possible {
 			buttonTitle = AppStrings.Home.riskCardUpdateButton
 			isButtonEnabled = true

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Risk/HomeRiskCellModel.swift
@@ -77,6 +77,8 @@ class HomeRiskCellModel: CountdownTimerDelegate {
 	// MARK: - Protocol CountdownTimerDelegate
 
 	func countdownTimer(_ timer: CountdownTimer, didEnd done: Bool) {
+		timeUntilUpdate = nil
+
 		if case .risk = homeState.riskState, homeState.manualExposureDetectionState == .possible {
 			buttonTitle = AppStrings.Home.riskCardUpdateButton
 			isButtonEnabled = true


### PR DESCRIPTION
## Description
Resets timeUntilUpdate on timer end so the initial time is correct if timer already ended, e.g. after the update of the required time between risk calculation from default 24 hours to 4 hours.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4972
