### PR TITLE
Feature/5004 reset consent on test deletion

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -229,6 +229,8 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 		store.devicePairingConsentAccept = false
 		store.devicePairingSuccessfulTimestamp = nil
 		store.devicePairingConsentAcceptTimestamp = nil
+
+		isSubmissionConsentGiven = false
 	}
 
 	var exposureManagerState: ExposureManagerState {


### PR DESCRIPTION
## Description
Resets the submission consent on test deletion.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5004
