### PR TITLE
Check if the OTP is authorized then navigate accordingly.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Coordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Coordinator.swift
@@ -243,7 +243,8 @@ class Coordinator: RequiresAppDependencies {
 			store: store,
 			homeState: homeState,
 			exposureManager: exposureManager,
-			appConfigurationProvider: appConfigurationProvider
+			appConfigurationProvider: appConfigurationProvider,
+			client: client
 		)
 		exposureDetectionCoordinator?.start()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
@@ -62,7 +62,7 @@ final class ExposureDetectionCoordinator {
 	private func showSurveyConsent(for surveyURL: URL) {
 		setNavigationBarHidden(false)
 		
-		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel(urlString: surveyURL)) { [weak self] url in
+		let surveyConsentViewController = SurveyConsentViewController(viewModel: SurveyConsentViewModel(url: surveyURL)) { [weak self] url in
 			self?.showSurveyWebpage(url: url)
 		}
 		navigationController?.pushViewController(surveyConsentViewController, animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -16,7 +16,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	init(
 		homeState: HomeState,
 		appConfigurationProvider: AppConfigurationProviding,
-		onSurveyTap: @escaping (String?) -> Void,
+		onSurveyTap: @escaping (URL?) -> Void,
 		onInactiveButtonTap: @escaping (@escaping (ExposureNotificationError?) -> Void) -> Void
 	) {
 		self.homeState = homeState
@@ -168,13 +168,13 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	private let homeState: HomeState
 
 	private let onInactiveButtonTap: (@escaping (ExposureNotificationError?) -> Void) -> Void
-	private let onSurveyTap: (String?) -> Void
+	private let onSurveyTap: (URL?) -> Void
 
 	private var countdownTimer: CountdownTimer?
 	private var timeUntilUpdate: String?
 
 	private var riskProviderActivityState: RiskProviderActivityState = .idle
-	private var surveyOnHighRiskURL: String?
+	private var surveyOnHighRiskURL: String = ""
 	private var subscriptions = Set<AnyCancellable>()
 
 	private var lastUpdateDateString: String {
@@ -524,18 +524,19 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	}
 
 	private func surveySection() -> DynamicSection {
+		let url = URL(string: surveyOnHighRiskURL)
 		return .section(
 			cells: [
 				.custom(
 					withIdentifier: ExposureDetectionViewController.ReusableCellIdentifier.survey,
 					action: .execute(block: { [weak self] _, _ in
-						self?.onSurveyTap(self?.surveyOnHighRiskURL)
+						self?.onSurveyTap(url)
 					}),
 					accessoryAction: .none,
 					configure: { _, cell, _ in
 						if let surveyCell = cell as? ExposureDetectionSurveyTableViewCell {
 							surveyCell.configure(with: ExposureDetectionSurveyCellModel()) { [weak self] in
-								self?.onSurveyTap(self?.surveyOnHighRiskURL)
+								self?.onSurveyTap(url)
 							}
 						}
 					})

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
@@ -93,9 +93,9 @@ final class SurveyConsentViewModel {
 		)
 	])
 	
-	let urlString: URL
+	let url: URL
 	
-	init(urlString: URL) {
-		self.urlString = urlString
+	init(url: URL) {
+		self.url = url
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/Survey/SurveyConsentViewModel.swift
@@ -93,9 +93,9 @@ final class SurveyConsentViewModel {
 		)
 	])
 	
-	let urlString: String?
+	let urlString: URL
 	
-	init(urlString: String?) {
+	init(urlString: URL) {
 		self.urlString = urlString
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class SurveyConsentViewModelTests: XCTestCase {
 
 	func testDynamicTableViewModel() {
-		if let url = URL(string: "https://www.test.de") {
+		if let url = URL(string: "https://www.example.com") {
 			let viewModel = SurveyConsentViewModel(url: url)
 
 			let dynamicTableViewModel = viewModel.dynamicTableViewModel

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/Survey/SurveyConsentViewModelTests.swift
@@ -8,14 +8,17 @@ import XCTest
 class SurveyConsentViewModelTests: XCTestCase {
 
 	func testDynamicTableViewModel() {
-		let placeHolderString = "https://www.test.de"
-		let viewModel = SurveyConsentViewModel(urlString: placeHolderString)
+		if let url = URL(string: "https://www.test.de") {
+			let viewModel = SurveyConsentViewModel(url: url)
 
-		let dynamicTableViewModel = viewModel.dynamicTableViewModel
+			let dynamicTableViewModel = viewModel.dynamicTableViewModel
 
-		XCTAssertEqual(dynamicTableViewModel.numberOfSection, 3)
-		XCTAssertEqual(dynamicTableViewModel.section(0).cells.count, 4)
-		XCTAssertEqual(dynamicTableViewModel.section(1).cells.count, 1)
-		XCTAssertEqual(dynamicTableViewModel.section(2).cells.count, 1)
+			XCTAssertEqual(dynamicTableViewModel.numberOfSection, 3)
+			XCTAssertEqual(dynamicTableViewModel.section(0).cells.count, 4)
+			XCTAssertEqual(dynamicTableViewModel.section(1).cells.count, 1)
+			XCTAssertEqual(dynamicTableViewModel.section(2).cells.count, 1)
+		} else {
+			XCTFail("survay URL should not be nil")
+		}
 	}
 }


### PR DESCRIPTION
## Description
Check if the OTP is authorized then navigate directly to the browser, if not then navigate to the consent screen.

_Small note_: the  **surveyOnHighRiskURL** was changed from an optional to a non-optional because the protobuf parameter **surveyOnHighRiskURL** is not an optional.
`	private var surveyOnHighRiskURL: String = ""
`
So we either have an empty string or a string.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4989

## Screenshots
No UI involved
