### PR TITLE
Fix/5017 Correct term in reset view (closes #1934)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1161,9 +1161,9 @@ sein.";
 
 "Reset_Discard" = "Abbrechen";
 
-"Reset_InfoTitle" = "Begegnungs-Aufzeichnung löschen";
+"Reset_InfoTitle" = "Begegnungsaufzeichnung löschen";
 
-"Reset_InfoDescription" = "Die Begegnungs-Aufzeichnung muss separat in den Geräte-Einstellungen gelöscht werden.";
+"Reset_InfoDescription" = "Die Begegnungsaufzeichnung muss separat in den Geräte-Einstellungen gelöscht werden.";
 
 "Reset_Subtitle" = "Anwendung zurücksetzen";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1213,13 +1213,13 @@ sein.";
 
 "RiskLegend_Definitions_Title" = "Wichtige Begriffe";
 
-"RiskLegend_Store_Title" = "Begegnungs-Aufzeichnung";
+"RiskLegend_Store_Title" = "Begegnungsaufzeichnung";
 
 "RiskLegend_Store_Text" = "Liste der empfangenen und vorübergehend im Betriebssystemspeicher abgelegten kurzlebigen Zufalls-IDs. Diese Liste wird bei der Risiko-Überprüfung gelesen. Alle Zufalls-IDs werden nach 14 Tagen automatisch gelöscht.";
 
 "RiskLegend_Check_Title" = "Risiko-Überprüfung";
 
-"RiskLegend_Check_Text" = "Abfrage der Begegnungs-Aufzeichnung und Abgleich mit den Risiko-Mitteilungen anderer Personen. Ihr Risiko wird mehrmals täglich automatisch überprüft.";
+"RiskLegend_Check_Text" = "Abfrage der Begegnungsaufzeichnung und Abgleich mit den Risiko-Mitteilungen anderer Personen. Ihr Risiko wird mehrmals täglich automatisch überprüft.";
 
 "RiskLegend_Contact_Title" = "Risiko-Begegnung";
 


### PR DESCRIPTION
## Description
This PR changes line 1164 and 1166 in `src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings`.
"Begegnungs-Aufzeichnungen", which is at the moment used in the reset view, is not the term used by Apple in the iOS settings. They call it "Begegnungsaufzeichnungen" (without a hyphen). 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5017

## Screenshots

![IMG_1BE55BD42D62-1](https://user-images.githubusercontent.com/7896005/107197234-ec751e80-69f3-11eb-86e0-fbe5fe1e33ce.jpeg)

#### Closes #1934