### PR TITLE
Tweak Linter for tests

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -189,7 +189,7 @@ opt_in_rules:
   #  - vertical_whitespace_opening_braces             # Don't include vertical whitespace (empty line) after opening braces.
   - void_return                                       # Prefer `-> Void` over `-> ()`.
   - weak_delegate                                     # Delegates should be weak to avoid reference cycles.
-  #  - xct_specific_matcher                           # Prefer specific XCTest matchers over `XCTAssertEqual` and `XCTAssertNotEqual`
+  - xct_specific_matcher                           # Prefer specific XCTest matchers over `XCTAssertEqual` and `XCTAssertNotEqual`
   - xctfail_message                                   # An XCTFail call should include a description of the assertion.
   #  - yoda_condition                                 # The variable should be placed on the left, the constant on the right of a comparison operator.
 

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/WifiHTTPClientTests.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/WifiHTTPClientTests.swift
@@ -16,7 +16,7 @@ class WifiHTTPClientTest: XCTestCase {
 		let wifiClient = WifiOnlyHTTPClient(serverEnvironmentProvider: mockStore)
 
 		// THEN
-		XCTAssertEqual(wifiClient.isWifiOnlyActive, true)
+		XCTAssertTrue(wifiClient.isWifiOnlyActive)
 	}
 
 	func testGIVEN_WifiOnlyClient_WHEN_updateSessionWifiFalse_THEN_WifiOnlyIsDisabled() {
@@ -28,7 +28,7 @@ class WifiHTTPClientTest: XCTestCase {
 		wifiClient.updateSession(wifiOnly: false)
 
 		// THEN
-		XCTAssertEqual(wifiClient.isWifiOnlyActive, false)
+		XCTAssertFalse(wifiClient.isWifiOnlyActive)
 	}
 
 	func testGIVEN_WifiOnlyClient_WHEN_updateSessionWifiTrue_THEN_WifiOnlyIsDisabled() {
@@ -40,7 +40,7 @@ class WifiHTTPClientTest: XCTestCase {
 		wifiClient.updateSession(wifiOnly: true)
 
 		// THEN
-		XCTAssertEqual(wifiClient.isWifiOnlyActive, true)
+		XCTAssertTrue(wifiClient.isWifiOnlyActive)
 	}
 
 	func testWHEN_WifiOnlyClient_THEN_disableHourlyDownloadIsFalse() {
@@ -49,7 +49,7 @@ class WifiHTTPClientTest: XCTestCase {
 		let wifiClient = WifiOnlyHTTPClient(serverEnvironmentProvider: mockStore)
 
 		// THEN
-		XCTAssertEqual(wifiClient.disableHourlyDownload, false)
+		XCTAssertFalse(wifiClient.disableHourlyDownload)
 	}
 
 	func testGIVEN_WifiOnlyClient_WHEN_DisableHourlyDownloadIsTrue_THEN_NoRequestIsSent() throws {

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewControllerRowsTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewControllerRowsTests.swift
@@ -96,8 +96,8 @@ extension DynamicTableViewControllerRowsTests {
 			return XCTFail("cell should not be nil")
 		}
 		let topSeparator = unwrappedCell.viewWithTag(100_001)
-		let topSeparatorIsSubview = topSeparator?.isDescendant(of: unwrappedCell)
-		XCTAssertEqual(topSeparatorIsSubview, true)
+		let topSeparatorIsSubview = topSeparator?.isDescendant(of: unwrappedCell) ?? false
+		XCTAssertTrue(topSeparatorIsSubview)
 	}
 	
 	func testCellForRowAt_whenSectionHasSeparators_NotAddsTopSeparatorToSecondCell() {
@@ -138,8 +138,8 @@ extension DynamicTableViewControllerRowsTests {
 			return XCTFail("cell should not be nil")
 		}
 		let bottomSeparator = unwrappedCell.viewWithTag(100_002)
-		let isSubview = bottomSeparator?.isDescendant(of: unwrappedCell)
-		XCTAssertEqual(isSubview, true)
+		let isSubview = bottomSeparator?.isDescendant(of: unwrappedCell) ?? false
+		XCTAssertTrue(isSubview)
 	}
 	
 	func testCellForRowAt_whenSectionHasSeparators_notAddsBottomSeparatorToFirstCell() {
@@ -180,8 +180,8 @@ extension DynamicTableViewControllerRowsTests {
 			return XCTFail("cell should not be nil")
 		}
 		let insetSeparator = unwrappedCell.viewWithTag(100_003)
-		let isSubview = insetSeparator?.isDescendant(of: unwrappedCell)
-		XCTAssertEqual(isSubview, true)
+		let isSubview = insetSeparator?.isDescendant(of: unwrappedCell) ?? false
+		XCTAssertTrue(isSubview)
 	}
 	
 	func testCellForRowAt_whenSectionHasSeparators_addsInsetSeparatorToIntermediateCells() {
@@ -203,8 +203,8 @@ extension DynamicTableViewControllerRowsTests {
 			return XCTFail("cell should not be nil")
 		}
 		let insetSeparator = unwrappedCell.viewWithTag(100_003)
-		let isSubview = insetSeparator?.isDescendant(of: unwrappedCell)
-		XCTAssertEqual(isSubview, true)
+		let isSubview = insetSeparator?.isDescendant(of: unwrappedCell) ?? false
+		XCTAssertTrue(isSubview)
 	}
 	
 	func testCellForRowAt_whenSectionHasSeparators_notAddsInsetSeparatorToLastCell() {

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewTextViewCellTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/__tests__/DynamicTableViewTextViewCellTests.swift
@@ -34,8 +34,8 @@ class DynamicTableViewTextViewCellTests: XCTestCase {
 	func testSetup_UITextView_LikeLabel() throws {
 		// `setup` should be called when using the below constructor
 		let sut = try DynamicTableViewTextViewCell(style: .default, reuseIdentifier: "Foo").getTextView()
-		XCTAssertEqual(sut.isScrollEnabled, false)
-		XCTAssertEqual(sut.isEditable, false)
+		XCTAssertFalse(sut.isScrollEnabled)
+		XCTAssertFalse(sut.isEditable)
 		XCTAssertEqual(sut.textContainerInset, .zero)
 		XCTAssertEqual(sut.textContainer.lineFragmentPadding, .zero)
 	}
@@ -151,7 +151,7 @@ class DynamicTableViewTextViewCellTests: XCTestCase {
 private extension DynamicTableViewTextViewCell {
 	func testMargins() {
 		XCTAssertEqual(contentView.layoutMargins, UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
-		XCTAssertEqual(contentView.insetsLayoutMarginsFromSafeArea, false)
+		XCTAssertFalse(contentView.insetsLayoutMarginsFromSafeArea)
 	}
 
 	func testDefaultConfiguration() throws {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
@@ -47,7 +47,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.titleTextColor, .enaColor(for: .textContrast))
 		XCTAssertEqual(viewModel.closeButtonStyle, .contrast)
 
-		XCTAssertEqual(viewModel.isButtonHidden, true)
+		XCTAssertTrue(viewModel.isButtonHidden)
 
 		XCTAssertEqual(viewModel.riskTintColor, .enaColor(for: .riskLow))
 		XCTAssertEqual(viewModel.riskContrastTintColor, .enaColor(for: .textContrast))
@@ -321,8 +321,8 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.closeButtonStyle, .normal)
 
 		XCTAssertEqual(viewModel.buttonTitle, AppStrings.Home.riskCardInactiveNoCalculationPossibleButton)
-		XCTAssertEqual(viewModel.isButtonEnabled, true)
-		XCTAssertEqual(viewModel.isButtonHidden, false)
+		XCTAssertTrue(viewModel.isButtonEnabled)
+		XCTAssertFalse(viewModel.isButtonHidden)
 
 		XCTAssertEqual(viewModel.riskTintColor, .enaColor(for: .riskNeutral))
 		XCTAssertEqual(viewModel.riskContrastTintColor, .enaColor(for: .riskNeutral))
@@ -398,8 +398,8 @@ class ExposureDetectionViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.closeButtonStyle, .normal)
 
 		XCTAssertEqual(viewModel.buttonTitle, AppStrings.Home.riskCardFailedCalculationRestartButtonTitle)
-		XCTAssertEqual(viewModel.isButtonEnabled, true)
-		XCTAssertEqual(viewModel.isButtonHidden, false)
+		XCTAssertTrue(viewModel.isButtonEnabled)
+		XCTAssertFalse(viewModel.isButtonHidden)
 
 		XCTAssertEqual(viewModel.riskTintColor, .enaColor(for: .riskNeutral))
 		XCTAssertEqual(viewModel.riskContrastTintColor, .enaColor(for: .riskNeutral))

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
@@ -100,7 +100,7 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		viewModel.didScan(metadataObjects: [metaDataObject])
 
 		waitForExpectations(timeout: .short)
-		XCTAssertEqual(viewModel.isScanningActivated, false)
+		XCTAssertFalse(viewModel.isScanningActivated)
 	}
 
 	func testScanningIsDeactivatedInitially() {
@@ -126,7 +126,7 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		viewModel.didScan(metadataObjects: [metaDataObject])
 
 		waitForExpectations(timeout: .short)
-		XCTAssertEqual(viewModel.isScanningActivated, false)
+		XCTAssertFalse(viewModel.isScanningActivated)
 	}
 
 	func testInitalUnsuccessfulScanWithSuccessfulRetry() {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Info/__tests__/HomeInfoCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Info/__tests__/HomeInfoCellModelTests.swift
@@ -35,7 +35,7 @@ class HomeInfoCellModelTests: XCTestCase {
 
 		// THEN
 		XCTAssertEqual(homeInfoCellModel.title, AppStrings.Home.appInformationCardTitle)
-		XCTAssertEqual(homeInfoCellModel.description, nil)
+		XCTAssertNil(homeInfoCellModel.description)
 		XCTAssertEqual(homeInfoCellModel.position, .first)
 		XCTAssertEqual(homeInfoCellModel.accessibilityIdentifier, AccessibilityIdentifiers.Home.appInformationCardTitle)
 	}
@@ -46,7 +46,7 @@ class HomeInfoCellModelTests: XCTestCase {
 
 		// THEN
 		XCTAssertEqual(homeInfoCellModel.title, AppStrings.Home.settingsCardTitle)
-		XCTAssertEqual(homeInfoCellModel.description, nil)
+		XCTAssertNil(homeInfoCellModel.description)
 		XCTAssertEqual(homeInfoCellModel.position, .last)
 		XCTAssertEqual(homeInfoCellModel.accessibilityIdentifier, AccessibilityIdentifiers.Home.settingsCardTitle)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/__test__/RiskLegendeTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/__test__/RiskLegendeTest.swift
@@ -51,6 +51,6 @@ class RiskLegendeTest: XCTestCase {
 		let cell = RiskLegendDotBodyCell()
 		XCTAssertNotNil(cell)
 		XCTAssertEqual(cell.dotView.backgroundColor, .enaColor(for: .riskHigh))
-		XCTAssertEqual(cell.label.text, nil)
+		XCTAssertNil(cell.label.text)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -38,11 +38,11 @@ final class StoreTests: XCTestCase {
 	}
 
 	func testInitialSubmitCompleted_Success() {
-		XCTAssertEqual(store.initialSubmitCompleted, false)
+		XCTAssertFalse(store.initialSubmitCompleted)
 		store.initialSubmitCompleted = true
-		XCTAssertEqual(store.initialSubmitCompleted, true)
+		XCTAssertTrue(store.initialSubmitCompleted)
 		store.initialSubmitCompleted = false
-		XCTAssertEqual(store.initialSubmitCompleted, false)
+		XCTAssertFalse(store.initialSubmitCompleted)
 	}
 
 	func testRegistrationToken_Success() {
@@ -64,9 +64,9 @@ final class StoreTests: XCTestCase {
 		store.tracingStatusHistory.append(entry2)
 
 		XCTAssertEqual(store.tracingStatusHistory.count, 2)
-		XCTAssertEqual(store.tracingStatusHistory[0].on, true)
+		XCTAssertTrue(store.tracingStatusHistory[0].on)
 		XCTAssertEqual(store.tracingStatusHistory[0].date.description, date1.description)
-		XCTAssertEqual(store.tracingStatusHistory[1].on, false)
+		XCTAssertFalse(store.tracingStatusHistory[1].on)
 		XCTAssertEqual(store.tracingStatusHistory[1].date.description, date2.description)
 
 		store.flush()
@@ -123,9 +123,9 @@ final class StoreTests: XCTestCase {
 		XCTAssertTrue(tmpStore.exposureActivationConsentAccept)
 
 		XCTAssertEqual(tmpStore.tracingStatusHistory.count, 2)
-		XCTAssertEqual(tmpStore.tracingStatusHistory[0].on, true)
+		XCTAssertTrue(tmpStore.tracingStatusHistory[0].on)
 		XCTAssertEqual(tmpStore.tracingStatusHistory[0].date.description, testDate1.description)
-		XCTAssertEqual(tmpStore.tracingStatusHistory[1].on, false)
+		XCTAssertFalse(tmpStore.tracingStatusHistory[1].on)
 		XCTAssertEqual(tmpStore.tracingStatusHistory[1].date.description, testDate2.description)
 
 		
@@ -133,13 +133,13 @@ final class StoreTests: XCTestCase {
 	
 	func testDeviceTimeSettings_initalAfterInitialization() {
 		XCTAssertEqual(store.deviceTimeCheckResult, .correct)
-		XCTAssertEqual(store.wasDeviceTimeErrorShown, false)
+		XCTAssertFalse(store.wasDeviceTimeErrorShown)
 		
 		store.deviceTimeCheckResult = .incorrect
 		store.wasDeviceTimeErrorShown = true
 		
 		XCTAssertEqual(store.deviceTimeCheckResult, .incorrect)
-		XCTAssertEqual(store.wasDeviceTimeErrorShown, true)
+		XCTAssertTrue(store.wasDeviceTimeErrorShown)
 	}
 
 	func testValueToggles() throws {


### PR DESCRIPTION
## Description
This PR enables xct_specific_matcher as a Linter rule, to avoid:
`		XCTAssertEqual(viewModel.isButtonHidden, false)
`
and "force"

`		XCTAssertFalse(viewModel.isButtonHidden)
`
## Link to Jira
<!-- Please add the link to the related Jira issue -->

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
