### PR TITLE
Different Selection Buttons in the Popup, when scanning invalid QR-Code

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/UIViewController+Alert.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UIViewController+Alert.swift
@@ -43,7 +43,6 @@ extension UIAlertController {
 	///   - message: The description of the alert.
 	///   - okTitle: The text of the ok action.
 	///   - secondaryActionTitle: The text of the secondary action, if there is one.
-	///   - hasSecondaryAction: Indicates whether an alert has a secondary action or not.
 	///   - completion: The completion handler for the "ok" action.
 	///   - secondaryActionCompletion: The completion handler for the secondary action.
 	/// - Returns: An alert with either one or two actions, with the specified completion handlers
@@ -70,7 +69,7 @@ extension UIAlertController {
 		)
 
 		alert.addAction(ok)
-		if secondaryActionTitle != nil {
+		if let secondaryActionTitle = secondaryActionTitle {
 			let retryAction = UIAlertAction(
 				title: secondaryActionTitle,
 				style: .default,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -712,12 +712,18 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 						title: AppStrings.ExposureSubmissionError.qrNotExistTitle,
 						message: error.localizedDescription
 					)
-
-					self?.navigationController?.present(alert, animated: true, completion: nil)
 				case .qrAlreadyUsed:
 					alert = UIAlertController.errorAlert(
 						title: AppStrings.ExposureSubmissionError.qrAlreadyUsedTitle,
-						message: error.localizedDescription
+						message: error.localizedDescription,
+						okTitle: AppStrings.Common.alertActionCancel,
+						secondaryActionTitle: AppStrings.Common.alertActionRetry,
+						completion: { [weak self] in
+							self?.navigationController?.dismiss(animated: true)
+						},
+						secondaryActionCompletion: { [weak self] in
+							self?.showQRScreen(isLoading: isLoading)
+						}
 					)
 				case .qrExpired:
 					alert = UIAlertController.errorAlert(


### PR DESCRIPTION
## Description

Add retry option to error popup when qr code has already been used

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5025

## Screenshots

![IMG_2546](https://user-images.githubusercontent.com/3601228/107338209-94095400-6abb-11eb-9517-0b4badbe0e70.PNG)
