### PR TITLE
Fix/5174 icons on infoscreen are not adapted to light dark mode

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewIconCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewIconCell.swift
@@ -73,14 +73,8 @@ class DynamicTableViewIconCell: UITableViewCell {
 	) {
 		stackView.alignment = alignment
 
-		if let customTintColor = customTintColor {
-			iconImageView.tintColor = customTintColor
-			iconImageView.image = image?.withRenderingMode(.alwaysTemplate)
-		} else {
-			iconImageView.tintColor = tintColor
-			iconImageView.image = image?.withRenderingMode(.alwaysOriginal)
-		}
-
+		iconImageView.tintColor = customTintColor ?? tintColor
+		iconImageView.image = image
 		iconImageView.isHidden = image == nil
 
 		imageViewWidthConstraint?.constant = iconWidth


### PR DESCRIPTION
## Description
Icon images used wrong asset if the UI mode was changed

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5174

## Screenshots
https://user-images.githubusercontent.com/2675578/108208567-7bd3ad80-7129-11eb-84be-2f349011d3f1.mov


