### PR TITLE
Not all EN-Errors link to the FAQ page correctly

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/Error+FAQUrl.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/Error+FAQUrl.swift
@@ -32,7 +32,8 @@ extension ENError {
 			return URL(string: AppStrings.Links.appFaqENError11)
 		case .rateLimited:
 			return URL(string: AppStrings.Links.appFaqENError13)
-		default: return nil
+		default:
+			return URL(string: AppStrings.Links.appFaq)
 		}
 	}
 }


### PR DESCRIPTION
## Description

Open general FAQ link instead of none when selecting "Find out more" in the EN error popup.

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5223
