### PR TITLE
Reload table view completely on statistics update

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -458,7 +458,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 				self?.tableView.scrollToRow(at: indexPath, at: .top, animated: false)
 			},
 			onUpdate: { [weak self] in
-				self?.tableView.reloadSections([HomeTableViewModel.Section.statistics.rawValue], with: .none)
+				self?.reload()
 			}
 		)
 


### PR DESCRIPTION
## Description
Reloads table view completely on statistics update because number of rows in riskAndTest section can change in the meantime.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5231
