### PR TITLE
Leave downloading activity state in EOL state when download is finished

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -425,6 +425,9 @@ final class RiskProvider: RiskProviding {
 			switch downloadStatus {
 			case .downloading:
 				self.updateActivityState(.downloading)
+			/// In end-of-life state we only download the keys, therefore the activity state needs to be reset to idle when the download is finished
+			case .idle where self.store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil || WarnOthersReminder(store: self.store).positiveTestResultWasShown:
+				self.updateActivityState(.idle)
 			default:
 				break
 			}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -298,8 +298,8 @@ final class RiskProviderTests: XCTestCase {
 		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
 		didFailCalculateRiskExpectation.isInverted = true
 
-		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
-		didChangeActivityStateExpectation.isInverted = true
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called")
+		didChangeActivityStateExpectation.expectedFulfillmentCount = 2
 
 		consumer.didCalculateRisk = { _ in
 			didCalculateRiskExpectation.fulfill()
@@ -349,8 +349,8 @@ final class RiskProviderTests: XCTestCase {
 		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
 		didFailCalculateRiskExpectation.isInverted = true
 
-		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
-		didChangeActivityStateExpectation.isInverted = true
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called")
+		didChangeActivityStateExpectation.expectedFulfillmentCount = 2
 
 		consumer.didCalculateRisk = { _ in
 			didCalculateRiskExpectation.fulfill()


### PR DESCRIPTION
## Description
Leave downloading activity state in EOL state when download is finished.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5169
