### PR TITLE
Feature/task 5080 fix migration

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Store/ContactDiaryStore.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Store/ContactDiaryStore.swift
@@ -848,7 +848,6 @@ class ContactDiaryStore: DiaryStoring, DiaryProviding {
 		
 		databaseQueue.inDatabase { database in
 			Log.info("[ContactDiaryStore] Open and setup database.", log: .localData)
-			userVersion = database.userVersion
 			let dbHandle = OpaquePointer(database.sqliteHandle)
 			guard CWASQLite.sqlite3_key(dbHandle, key, Int32(key.count)) == SQLITE_OK else {
 				Log.error("[ContactDiaryStore] Unable to set Key for encryption.", log: .localData)
@@ -861,7 +860,9 @@ class ContactDiaryStore: DiaryStoring, DiaryProviding {
 				errorResult = .failure(dbError(from: database))
 				return
 			}
-			
+
+			userVersion = database.userVersion
+
 			let sql = """
 				PRAGMA locking_mode=EXCLUSIVE;
 				PRAGMA auto_vacuum=2;


### PR DESCRIPTION
## Description
Small change to fix the migration.
Read the user version after the database is open.
Reading it before always results in userVersion 0.