### PR TITLE
Fix/5242-Fixed issue with not closed HTML tag

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -530,7 +530,7 @@
 			Wenn Sie andere über eine mögliche Risiko-Begegnung gewarnt haben:
 		</p>
 		<br><ul>
-			<li>Angaben dazu, ob Sie die Schritte zur Warnung anderer abgebrochen haben./li>
+			<li>Angaben dazu, ob Sie die Schritte zur Warnung anderer abgebrochen haben.</li>
 			<li>Angaben dazu, ob Sie Angaben zum Symptombeginn gemacht haben.</li>
 			<li>Angaben dazu, wann Sie Ihr Einverständnis in die Warnung anderer erteilt haben.</li>
 			<li>Angaben dazu, bis zu welcher Meldung im Rahmen der Warnung anderer Sie gekommen sind.</li>


### PR DESCRIPTION
This PR corrects the issue with the closing HTML tag in the data privacy description so that it is rendered correctly and not shown as text.
[Bug Ticket 5242](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5242).

![image](https://user-images.githubusercontent.com/70148649/108829716-cdb48180-75c8-11eb-953b-7faf1187a34e.png)
