### PR TITLE
Fixed typo in 'New Functions' UI

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1368,7 +1368,7 @@ sein.";
 
 "NewVersionFeature_114_screenshots_title" = "Screenshots zur Corona-Warn-App";
 
-"NewVersionFeature_114_screenshots_description" = "Auf https://www.coronawarn.app stehen nun alle Screenshots der App zu Verfügung. So können sich nun auch über geplante Funktionen der App informieren.";
+"NewVersionFeature_114_screenshots_description" = "Auf https://www.coronawarn.app stehen nun alle Screenshots der App zu Verfügung. So können Sie sich nun auch über geplante Funktionen der App informieren.";
 
 /* Delta Onboarding */
 "DeltaOnboarding_AccessibilityImageLabel" = "Länderübergreifende Risiko-Ermittlung";


### PR DESCRIPTION
## Description
There was a 'Sie' missing in the description of the availability of screenshots for the app.