### PR TITLE
Fix/infinite loop

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -16,6 +16,7 @@ struct DataDonationModel {
 		self.isConsentGiven = store.isPrivacyPreservingAnalyticsConsentGiven
 
 		let userMetadata = store.userData
+		Analytics.collect(.userData(.create(userMetadata)))
 		self.federalStateName = userMetadata?.federalState?.rawValue
 		self.age = userMetadata?.ageGroup?.text
 

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/Model/PPAnalyticsData.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/Model/PPAnalyticsData.swift
@@ -59,8 +59,8 @@ extension SecureStore: PPAnalyticsData {
 	}
 
 	var userMetadata: UserMetadata? {
-		get { kvStore["userMetadata"] as UserMetadata? ?? nil }
-		set { kvStore["userMetadata"] = newValue }
+		get { kvStore["userMetadataAnalytics"] as UserMetadata? ?? nil }
+		set { kvStore["userMetadataAnalytics"] = newValue }
 	}
 
 	var testResultMetadata: TestResultMetadata? {

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -373,8 +373,8 @@ extension SecureStore: PrivacyPreservingProviding {
 	}
 
 	var userData: UserMetadata? {
-		get { kvStore["userdata"] as UserMetadata? ?? nil }
-		set { kvStore["userdata"] = newValue
+		get { kvStore["userMetadata"] as UserMetadata? ?? nil }
+		set { kvStore["userMetadata"] = newValue
 			Analytics.collect(.userData(.create(newValue)))
 		}
 	}


### PR DESCRIPTION
## Description
This fixes three problems after the analytics refactoring:
1. An infinite loop can occur when submitting the PPA, which triggers a new fetch of the app config, which triggers again a submission and so on. For this, the sink on the app config call has a proof to be called only once.
2. In the submission we call Analytics.collect, which triggers again a submission. To avoid this, we write directly into the store (what the Submitter is allowed to do)
3. UserDataMetadata was Splitter to differ between the UI-Data and the PPA-Data. Now we let the originally stored data and copy the data to the PPA-Data instead to recreate new ones (that would lead that the user looses his entered user data on the data donation screen). 


Jira Ticket (with error log):
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5458