### PR TITLE
Chore/fix infinite loop in tests

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
@@ -533,7 +533,6 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 	func testOverviewWithRiskLevelHighOnToday() throws {
 		app.launchArguments.append(contentsOf: ["-diaryInfoScreenShown", "YES"])
 		app.launchArguments.append(contentsOf: ["-riskLevel", "high"])
-		app.launchArguments.append(contentsOf: ["-diaryInfoScreenShown", "YES"])
 
 		navigateToJournalOverview()
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -69,6 +69,13 @@ final class RiskProvider: RiskProviding {
 
 	/// Called by consumers to request the risk level. This method triggers the risk level process.
 	func requestRisk(userInitiated: Bool, timeoutInterval: TimeInterval) {
+		#if DEBUG
+		if isUITesting {
+			self._requestRiskLevel_Mock(userInitiated: userInitiated)
+			return
+		}
+		#endif
+
 		Log.info("RiskProvider: Request risk was called. UserInitiated: \(userInitiated)", log: .riskDetection)
 
 		guard activityState == .idle else {
@@ -97,14 +104,6 @@ final class RiskProvider: RiskProviding {
 
 		queue.async {
 			self.updateActivityState(.riskRequested)
-
-			#if DEBUG
-			if isUITesting {
-				self._requestRiskLevel_Mock(userInitiated: userInitiated)
-				return
-			}
-			#endif
-
 			self._requestRiskLevel(userInitiated: userInitiated, timeoutInterval: timeoutInterval)
 		}
 	}

--- a/src/xcode/ENA/ENAUITests/AppInformation/ENAUITestsAppInformation.swift
+++ b/src/xcode/ENA/ENAUITests/AppInformation/ENAUITestsAppInformation.swift
@@ -24,18 +24,18 @@ class ENAUITests_02_AppInformation: XCTestCase {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.aboutNavigation"].waitForExistence(timeout: 5.0))
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.faqNavigation"].waitForExistence(timeout: 5.0))
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.contactNavigation"].waitForExistence(timeout: 5.0))
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.privacyNavigation"].waitForExistence(timeout: 5.0))
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.termsNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.aboutNavigation"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.faqNavigation"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.contactNavigation"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.privacyNavigation"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.termsNavigation"].waitForExistence(timeout: .medium))
 
 	}
 
@@ -43,84 +43,84 @@ class ENAUITests_02_AppInformation: XCTestCase {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.aboutNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.aboutNavigation"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.AppInformation.aboutNavigation"].tap()
 
-		XCTAssertTrue(app.staticTexts["AppStrings.AppInformation.aboutTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.staticTexts["AppStrings.AppInformation.aboutTitle"].waitForExistence(timeout: .medium))
 	}
 
 	func test_0022_AppInformationFlow_faq() throws {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.faqNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.faqNavigation"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.AppInformation.faqNavigation"].tap()
 
-		XCTAssertTrue(app.webViews.firstMatch.waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.webViews.firstMatch.waitForExistence(timeout: .long)) // web is slow :p
 	}
 
 	func test_0023_AppInformationFlow_contact() throws {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.contactNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.contactNavigation"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.AppInformation.contactNavigation"].tap()
 
-		XCTAssertTrue(app.staticTexts["AppStrings.AppInformation.contactTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.staticTexts["AppStrings.AppInformation.contactTitle"].waitForExistence(timeout: .medium))
 	}
 
 	func test_0024_AppInformationFlow_privacy() throws {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.privacyNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.privacyNavigation"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.AppInformation.privacyNavigation"].tap()
 
-		XCTAssertTrue(app.images["AppStrings.AppInformation.privacyImageDescription"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.images["AppStrings.AppInformation.privacyImageDescription"].waitForExistence(timeout: .medium))
 	}
 
 	func test_0025_AppInformationFlow_terms() throws {
 		app.launch()
 
 		// only run if onboarding screen is present
-		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.rightBarButtonDescription].waitForExistence(timeout: .medium))
 
 		app.swipeUp()
 		// assert cells
-		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.Home.appInformationCardTitle"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.Home.appInformationCardTitle"].tap()
 
-		XCTAssertTrue(app.cells["AppStrings.AppInformation.termsNavigation"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.cells["AppStrings.AppInformation.termsNavigation"].waitForExistence(timeout: .medium))
 		app.cells["AppStrings.AppInformation.termsNavigation"].tap()
 
-		XCTAssertTrue(app.images["AppStrings.AppInformation.termsImageDescription"].waitForExistence(timeout: 5.0))
+		XCTAssertTrue(app.images["AppStrings.AppInformation.termsImageDescription"].waitForExistence(timeout: .medium))
 	}
 }

--- a/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
@@ -28,12 +28,6 @@ extension XCUIElement {
 		return staticTexts.matching(predicate).firstMatch.exists
 	}
 
-	func scrollToElement(element: XCUIElement) {
-		while !element.visible() {
-			swipeUp()
-		}
-	}
-
 	func visible() -> Bool {
 		guard exists, !frame.isEmpty else { return false }
 		return XCUIApplication().windows.element(boundBy: 0).frame.contains(frame)

--- a/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
@@ -40,7 +40,6 @@ extension XCUIElementQuery {
 
 extension XCUIApplication {
 	func setDefaults() {
-		// launchEnvironment["CW_MODE"] = "mock"
 		launchEnvironment["XCUI"] = "YES"
 	}
 
@@ -74,13 +73,5 @@ extension XCUIApplication {
 			localeCode = "\(langCode)-\(regionCode)"
 		}
 		return (langCode, localeCode)
-	}
-}
-
-extension XCTestCase {
-	func wait(for seconds: TimeInterval = 0.2) {
-		let expectation = XCTestExpectation(description: "Pause test")
-		DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { expectation.fulfill() }
-		wait(for: [expectation], timeout: seconds + 1)
 	}
 }

--- a/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
@@ -18,7 +18,7 @@ enum SizeCategoryAccessibility: String {
 	case accessibility = "Accessibility"
 	case normal = ""
 	func description() -> String {
-		self == .normal ? "" : "Accessibility"
+		return self.rawValue
 	}
 }
 

--- a/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests-Extensions.swift
@@ -50,9 +50,9 @@ extension XCUIApplication {
 		launchEnvironment["XCUI"] = "YES"
 	}
 
-	func setPreferredContentSizeCategory(accessibililty: SizeCategoryAccessibility, size: SizeCategory) {
+	func setPreferredContentSizeCategory(accessibility: SizeCategoryAccessibility, size: SizeCategory) {
 		// based on https://stackoverflow.com/questions/38316591/how-to-test-dynamic-type-larger-font-sizes-in-ios-simulator
-		launchArguments += ["-UIPreferredContentSizeCategoryName", "UICTContentSizeCategory\(accessibililty.description())\(size)"]
+		launchArguments += ["-UIPreferredContentSizeCategoryName", "UICTContentSizeCategory\(accessibility.description())\(size)"]
 	}
 
 	func localized(_ key: String) -> String {

--- a/src/xcode/ENA/ENAUITests/ENAUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests.swift
@@ -40,7 +40,7 @@ class ENAUITests: XCTestCase {
 
 		let snapshotsActive = true
 
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .M)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "NO"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
@@ -105,7 +105,7 @@ class ENAUITests: XCTestCase {
 	
 	func test_0003_Generate_Screenshot_For_AppStore_Statistics() throws {
 
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .M)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "YES"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launchArguments.append(contentsOf: ["-useMockDataForStatistics", "YES"]) // prevent failing tests for 1.11; use "NO" for 1.12
@@ -121,7 +121,7 @@ class ENAUITests: XCTestCase {
 
 		let snapshotsActive = true
 
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .M)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "NO"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launchArguments.append(contentsOf: ["-testResult", TestResult.negative.stringValue])

--- a/src/xcode/ENA/ENAUITests/ExposureDetection/ENAUITestsExposureDetection.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureDetection/ENAUITestsExposureDetection.swift
@@ -27,7 +27,6 @@ class ENAUITestsExposureDetection: XCTestCase {
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.AccessibilityLabel.close].waitForExistence(timeout: .long))
 
 		// Scroll to and tap survey card.
-		app.scrollToElement(element: app.cells[AccessibilityIdentifiers.ExposureDetection.surveyCardCell])
 		XCTAssertTrue(app.cells[AccessibilityIdentifiers.ExposureDetection.surveyCardCell].waitForExistence(timeout: .long))
 		app.cells[AccessibilityIdentifiers.ExposureDetection.surveyCardCell].tap()
 

--- a/src/xcode/ENA/ENAUITests/ExposureLogging/ENAUITests_05_ExposureLogging.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureLogging/ENAUITests_05_ExposureLogging.swift
@@ -24,7 +24,7 @@ class ENAUITests_05_ExposureLogging: XCTestCase {
 
 	func test_screenshot_exposureLogging() throws {
 		var screenshotCounter = 0
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "YES"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
@@ -41,7 +41,7 @@ class ENAUITests_05_ExposureLogging: XCTestCase {
 
 	func test_screenshot_exposureLoggingOff() throws {
 		var screenshotCounter = 0
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "YES"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.unknown.stringValue])
 		app.launch()

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITests-Statistics.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITests-Statistics.swift
@@ -27,7 +27,7 @@ class ENAUITests_Statistics: XCTestCase {
 		let layoutDirection = UIView.userInterfaceLayoutDirection(for: UIView().semanticContentAttribute)
 
 		// WHEN
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .S)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .S)
 		app.launch()
 		app.swipeUp(velocity: .slow)
 		
@@ -63,7 +63,7 @@ class ENAUITests_Statistics: XCTestCase {
 		let layoutDirection = UIView.userInterfaceLayoutDirection(for: UIView().semanticContentAttribute)
 		
 		// WHEN
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .S)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .S)
 		app.launch()
 		app.swipeUp(velocity: .slow)
 		
@@ -107,7 +107,7 @@ class ENAUITests_Statistics: XCTestCase {
 		var screenshotCounter = 0
 
 		// WHEN
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .S)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .S)
 		app.launch()
 		app.swipeUp(velocity: .slow)
 

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
@@ -23,7 +23,7 @@ class ENAUITests_01_Home: XCTestCase {
 	}
 
 	func test_0010_HomeFlow_medium() throws {
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .M)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.launch()
 
 		// only run if home screen is present
@@ -39,7 +39,7 @@ class ENAUITests_01_Home: XCTestCase {
 	}
 
 	func test_0011_HomeFlow_extrasmall() throws {
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .XS)
 		app.launch()
 
 		// only run if home screen is present
@@ -55,7 +55,7 @@ class ENAUITests_01_Home: XCTestCase {
 	}
 
 	func test_0013_HomeFlow_extralarge() throws {
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XL)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XL)
 		app.launch()
 
 		// only run if home screen is present
@@ -76,7 +76,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "high"
 		let numberOfDaysWithHighRisk = 1
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launch()
 		
@@ -101,7 +101,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "high"
 		let numberOfDaysWithHighRisk = "4"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithHighRisk])
 		app.launch()
@@ -127,7 +127,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "low"
 		let numberOfDaysWithLowRisk = 0
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launch()
 		
@@ -152,7 +152,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "low"
 		let numberOfDaysWithLowRisk = "1"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launch()
@@ -178,7 +178,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "low"
 		let numberOfDaysWithLowRisk = "4"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launch()
@@ -204,7 +204,7 @@ class ENAUITests_01_Home: XCTestCase {
 		var screenshotCounter = 0
 		let riskLevel = "low"
 		let activeTracingDays = "14"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
 		app.launch()
@@ -217,7 +217,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let riskLevel = "low"
 		// change the value based on N
 		let activeTracingDays = "12"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
 		app.launch()
@@ -229,7 +229,7 @@ class ENAUITests_01_Home: XCTestCase {
 		try XCTSkipIf(Locale.current.identifier == "bg_BG") // temporary hack!
 		var screenshotCounter = 0
 		let riskLevel = "inactive"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launch()
 
@@ -250,7 +250,7 @@ class ENAUITests_01_Home: XCTestCase {
 	func test_screenshot_homescreen_riskCardHigh_activeExposureLogging() throws {
 		var screenshotCounter = 0
 		let riskLevel = "high"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "YES"])
 		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
@@ -286,7 +286,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let riskLevel = "high"
 		// change the value based on N
 		let activeTracingDays = "5"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
 		app.launch()
@@ -303,7 +303,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let riskLevel = "low"
 		// change the value based on N
 		let activeTracingDays = "5"
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", "1"])
@@ -318,7 +318,7 @@ class ENAUITests_01_Home: XCTestCase {
 
 	func test_screenshot_homescreen_thankyou_screen() throws {
 		var screenshotCounter = 0
-		app.setPreferredContentSizeCategory(accessibililty: .accessibility, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-showThankYouScreen", "YES"])
 		app.launch()
 		

--- a/src/xcode/ENA/ENAUITests/Onboarding/ENAUITestsOnboarding.swift
+++ b/src/xcode/ENA/ENAUITests/Onboarding/ENAUITestsOnboarding.swift
@@ -24,7 +24,7 @@ class ENAUITests_00_Onboarding: XCTestCase {
 	}
 
 	func test_0000_OnboardingFlow_DisablePermissions_normal_XXXL() throws {
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .XXXL)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .XXXL)
 		app.launch()
 
 		// only run if onboarding screen is present
@@ -91,7 +91,7 @@ class ENAUITests_00_Onboarding: XCTestCase {
 	}
 
 	func test_0001_OnboardingFlow_EnablePermissions_normal_XS() throws {
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .XS)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .XS)
 		app.launch()
 
 		// only run if onboarding screen is present
@@ -162,7 +162,7 @@ class ENAUITests_00_Onboarding: XCTestCase {
 	func test_0002_Screenshots_OnboardingFlow_EnablePermissions_normal_S() throws {
 		var screenshotCounter = 0
 		app.launchArguments.append(contentsOf: ["-userNeedsToBeInformedAboutHowRiskDetectionWorks", "YES"])
-		app.setPreferredContentSizeCategory(accessibililty: .normal, size: .S)
+		app.setPreferredContentSizeCategory(accessibility: .normal, size: .S)
 		app.launch()
 		
 		let prefix = "OnboardingFlow_EnablePermission_"


### PR DESCRIPTION
## Description
I had one test `test_NavigationToSurvey` that failed constantly because of an infinite loop. This happens locally (started via `fastlane`) but not on the CI. [Enabling test timeouts](https://github.com/corona-warn-app/cwa-app-ios/commit/bc9bd970a02e073e619a00c383e25632c1d68ee7) helped here to identify the failing test.

* This PR fixes an issue where a given launch argument for the desired risk state is not provided under certain conditions.
* It also does some cleanups for looking up cells in table views during UITests. Remember: you can simply address the cell you are looking for by using code like
```Swift
let cell = app.cells[my.identifier].waitForExistence(<#timeout#>) // this takes time on long tables!
cell.tap()
```
* Also one typo was fixed that encountered during debugging. Thanks @nickguendling for hinting the spell checking :)

**Remember: Please don't write loops without abort conditions.** 

## Link to Jira
n/a

## Screenshots

https://user-images.githubusercontent.com/149976/109650499-97917780-7b5d-11eb-92ca-9a55f6c42e0f.mov


