### PR TITLE
Fix/5496a link to coronawarn.app screenshots does not work in english

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
@@ -22,4 +22,4 @@
 
 "ExposureDetection_high_faq_URL" = "https://www.coronawarn.app/en/faq/#red_card_how_to_test";
 
-"NewVersion_Feature_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";
+"NewVersion_Feature_114_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
@@ -22,4 +22,4 @@
 
 "ExposureDetection_high_faq_URL" = "https://www.coronawarn.app/en/faq/#red_card_how_to_test";
 
-"NewVersion_Feature_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";
+"NewVersion_Feature_114_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
@@ -22,4 +22,4 @@
 
 "ExposureDetection_high_faq_URL" = "https://www.coronawarn.app/en/faq/#red_card_how_to_test";
 
-"NewVersion_Feature_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";
+"NewVersion_Feature_114_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
@@ -22,4 +22,4 @@
 
 "ExposureDetection_high_faq_URL" = "https://www.coronawarn.app/en/faq/#red_card_how_to_test";
 
-"NewVersion_Feature_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";
+"NewVersion_Feature_114_Screenshot_URL" = "https://www.coronawarn.app/en/screenshots";

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
@@ -102,6 +102,7 @@ struct DeltaOnboardingNewVersionFeaturesViewModel {
 				featureBulletPoint.append(NSAttributedString(string: feature.description, attributes: normalTextAttribute))
 				cells.append(.bulletPoint(attributedText: featureBulletPoint))
 				cells.append(.link(placeholder: "\t\(AppStrings.NewVersionFeatures.feature114ScreenshotWebSiteURLDisplayText)", link: AppStrings.NewVersionFeatures.feature114ScreenshotWebSiteURL, font: .body, style: .body, accessibilityIdentifier: ""))
+				Log.debug("The screenshot URL is the following: \(AppStrings.NewVersionFeatures.feature114ScreenshotWebSiteURL)")
 			} else {
 				let featureBulletPoint = NSMutableAttributedString(string: feature.title + "\n\t", attributes: boldTextAttribute)
 				featureBulletPoint.append(NSAttributedString(string: feature.description, attributes: normalTextAttribute))


### PR DESCRIPTION
Small PR which fixes an issue with the coronawarn.app screenshot link in the new version 1.14 features when not German language.

[JIRA Bug Ticket 5496](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5496)