### PR TITLE
Fix/5544 crash when system time wrong

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -691,8 +691,10 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	
 	@objc
 	private func refreshUI() {
-		viewModel.state.updateTestResult()
-		viewModel.state.updateStatistics()
+		DispatchQueue.main.async { [weak self] in
+			self?.viewModel.state.updateTestResult()
+			self?.viewModel.state.updateStatistics()
+		}
 	}
 
 	// swiftlint:disable:next file_length


### PR DESCRIPTION
## Description
Fixes crash after setting wrong date on device.

NOTE: This fix only works with the other fix PR: https://github.com/corona-warn-app/cwa-app-ios/pull/2134

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5544
