### PR TITLE
Chore/hint to plain logging

### DIFF
--- a/src/xcode/ENA/.swiftlint.yml
+++ b/src/xcode/ENA/.swiftlint.yml
@@ -257,3 +257,20 @@ custom_rules:
       - identifier
     message: "Please specify your assertion: XCTAssertTrue, XCTAssertEqual, ..."
     severity: error
+  no_plain_print:
+    excluded: ".*Test[s]?\\.swift" # Allowed in tests!
+    name: "No plain print statements"
+    regex: "([debug]*[pP]rint)\\("
+    capture_group: 0
+    match_kinds:
+      - identifier
+    message: "Please use `Log` for printing messages to the console"
+    severity: warning # allowed during development, in production it will fail due to the 'no warnings rule'
+  no_direct_oslog:
+    name: "No plain `os_log` statements"
+    regex: "os_log"
+    capture_group: 0
+    match_kinds:
+      - identifier
+    message: "Please use `Log` for printing messages to the console"
+    severity: error

--- a/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
@@ -68,6 +68,9 @@ enum Log {
 		#if !RELEASE
 		// Console logging
 		let meta: String = "[\(file):\(line)] [\(function)]"
+
+		// obviously we have to disable swiftline here:
+		// swiftlint:disable:next no_direct_oslog
 		os_log("%{private}@ %{private}@", log: log, type: type, meta, message)
 
 		// Save logs to File. This is used for viewing and exporting logs from debug menu.

--- a/src/xcode/ENA/ENATests/Helper/iOS13TestCase.swift
+++ b/src/xcode/ENA/ENATests/Helper/iOS13TestCase.swift
@@ -11,7 +11,8 @@ class iOS13TestCase: XCTestCase {
 		if #available(iOS 13, *) {
 			return super.invokeTest()
 		} else {
-			print("Skipping test because it's iOS13+ only.")
+			// swiftlint:disable:next no_plain_print
+			print("Skipping test \(self) because it's iOS13+ only.")
 			return
 		}
 	}

--- a/src/xcode/ENA/ENAUITests/Helper/AccessibilityLabels.swift
+++ b/src/xcode/ENA/ENAUITests/Helper/AccessibilityLabels.swift
@@ -13,27 +13,6 @@ enum AccessibilityLabels {
 		let uiTestBundle = Bundle(for: ENAUITests_01_Home.self)
 		return NSLocalizedString(key, bundle: uiTestBundle, comment: "")
 	}
-	
-	// print labels to console
-	static func printLabels(_ query: XCUIElementQuery) {
-		for (index, value) in labelsOfElement(query).enumerated() {
-			print("Label \(index + 1): \(value)")
-		}
-	}
-	
-	// print accessibility identifiers to console
-	static func printAccIdentifiers(_ query: XCUIElementQuery) {
-		for (index, value) in accIdentifiersOfElement(query).enumerated() {
-			print("Acc.Id \(index + 1): \(value)")
-		}
-	}
-
-	// print accessibility labels to console
-	static func printAccLabels(_ query: XCUIElementQuery) {
-		for (index, value) in accLabelsOfElement(query).enumerated() {
-			print("Acc.Label \(index + 1): \(value)")
-		}
-	}
 
 	// label attributes
 	static func labelsOfElement(_ query: XCUIElementQuery) -> [String] {


### PR DESCRIPTION
## Description
For data privacy reasons we need to prevent 'leakage' of information through log statements that are not monitored by us. This PR prevents the usage of `print`, `debugPrint` and `os_log` (with one exception) in production builds. Please use out `Log` handler for all kinds of logging.

The usage of these keywords is allowed in tests and during development. However, for non-test code it will produce a warning which the CI frowns upon.

## Link to Jira
n/a

## Screenshots
n/a
