### PR TITLE
Add missing server error code for error message handling

### DIFF
--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -254,7 +254,7 @@ final class HTTPClient: Client {
 				switch response.statusCode {
 				case 200:
 					self?.otpAuthorizationSuccessHandler(for: response, completion: completion)
-				case 400, 401, 403:
+				case 400, 401, 403, 429:
 					self?.otpAuthorizationFailureHandler(for: response, completion: completion)
 				case 500:
 					Log.error("Failed to get authorized OTP - 500 status code", log: .api)


### PR DESCRIPTION
This PR fixes an issue that the server error code 429 was not processed as an individual error message for PPAC Survey. Now it shows the correct error message.

[JIRA Bug Ticket 5304](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5304)