### PR TITLE
Bugfix/5785 no submission for 48h

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -252,8 +252,13 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 	}
 
 	private func executeAnalyticsSubmission(completion: @escaping () -> Void) {
-		Analytics.triggerAnalyticsSubmission(completion: { _ in
-			// Ignore the result of the call, so we just complete after the call is finished.
+		Analytics.triggerAnalyticsSubmission(completion: { result in
+			switch result {
+			case .success:
+				Log.info("[ENATaskExecutionDelegate] Analytics submission was triggered succesfully from background", log: .ppa)
+			case let .failure(error):
+				Log.error("[ENATaskExecutionDelegate] Analytics submission was triggered not succesfully from background", log: .ppa, error: error)
+			}
 			completion()
 		})
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -16,7 +16,6 @@ struct DataDonationModel {
 		self.isConsentGiven = store.isPrivacyPreservingAnalyticsConsentGiven
 
 		let userMetadata = store.userData
-		Analytics.collect(.userData(.create(userMetadata)))
 		self.federalStateName = userMetadata?.federalState?.rawValue
 		self.age = userMetadata?.ageGroup?.text
 

--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -57,7 +57,9 @@ struct DataDonationModel {
 		store.isPrivacyPreservingAnalyticsConsentGiven = isConsentGiven
 
 		// If user has not given or revoked his consent, delete all analytics data. If he gives not the consent, delete all analytics data to have a clean state.
-		Analytics.deleteAnalyticsData()
+		if isConsentGiven == false {
+			Analytics.deleteAnalyticsData()
+		}
 
 		guard isConsentGiven else {
 			region = nil

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -249,9 +249,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	}
 
 	private func obtainUsageData(disableExposureWindowsProbability: Bool = false) -> SAP_Internal_Ppdd_PPADataIOS {
-
-		Log.info("Obtaining now all usage data for analytics submission.", log: .ppa)
-
+		Log.info("Obtaining now all usage data for analytics submission...", log: .ppa)
 		let exposureRiskMetadata = gatherExposureRiskMetadata()
 		let userMetadata = gatherUserMetadata()
 		let clientMetadata = gatherClientMetadata()

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -327,7 +327,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 					self?.store.lastSubmissionAnalytics = Date()
 					completion?(result)
 				case let .failure(error):
-					Log.error("Analytics data were not submitted", log: .ppa, error: error)
+					Log.error("Analytics data were not submitted. Error: \(error)", log: .ppa, error: error)
 					completion?(result)
 				}
 			}


### PR DESCRIPTION
## Description
It seems to me that this `sink` on the appConfiguration in the `Submitter` made trouble when it was in the submission-call itself concatenated with the `cancelable`. I could reproduce that in some cases a submission was not triggered because the `cancelable` was nil.
So I moved the `sink` to the initializer and now the logs look fine. I also added a bunch of more logs and made some more precise.

If this really solved the bug, that there is no submission > 48h, i cannot say but has to be determined by the testers.

I also fixed the collection of the client and user metadata, because according to the tech spec, they should be graped right before the submission.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5785
