### PR TITLE
Bugfix/5785 no submission for 48h

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -315,6 +315,7 @@
 		500DB4CC25CDDECF0038DFED /* PPASResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DB4CB25CDDECF0038DFED /* PPASResponse.swift */; };
 		500DB4D425CDE5C20038DFED /* PPASError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DB4D325CDE5C20038DFED /* PPASError.swift */; };
 		5017F64D25FFAD11003A812E /* PPASubmissionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5017F64C25FFAD11003A812E /* PPASubmissionState.swift */; };
+		5017F65F25FFC1E8003A812E /* ClientMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5017F65E25FFC1E8003A812E /* ClientMetadataTests.swift */; };
 		5021532925C988D80006842D /* OTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5021532825C988D80006842D /* OTPResponse.swift */; };
 		50352C8B25C94961007193D2 /* OTPServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50352C8A25C94961007193D2 /* OTPServiceTests.swift */; };
 		50352C9F25C96687007193D2 /* HTTPClient+AuthorizationOTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50352C9725C9665A007193D2 /* HTTPClient+AuthorizationOTPTests.swift */; };
@@ -1171,6 +1172,7 @@
 		500DB4CB25CDDECF0038DFED /* PPASResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPASResponse.swift; sourceTree = "<group>"; };
 		500DB4D325CDE5C20038DFED /* PPASError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPASError.swift; sourceTree = "<group>"; };
 		5017F64C25FFAD11003A812E /* PPASubmissionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPASubmissionState.swift; sourceTree = "<group>"; };
+		5017F65E25FFC1E8003A812E /* ClientMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMetadataTests.swift; sourceTree = "<group>"; };
 		5021532825C988D80006842D /* OTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPResponse.swift; sourceTree = "<group>"; };
 		50352C8A25C94961007193D2 /* OTPServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPServiceTests.swift; sourceTree = "<group>"; };
 		50352C9725C9665A007193D2 /* HTTPClient+AuthorizationOTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPClient+AuthorizationOTPTests.swift"; sourceTree = "<group>"; };
@@ -2545,6 +2547,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		5017F65D25FFC1CF003A812E /* __tests__ */ = {
+			isa = PBXGroup;
+			children = (
+				5017F65E25FFC1E8003A812E /* ClientMetadataTests.swift */,
+			);
+			path = __tests__;
+			sourceTree = "<group>";
+		};
 		504C9CC725C44BE60005875B /* OTP */ = {
 			isa = PBXGroup;
 			children = (
@@ -2690,6 +2700,7 @@
 		50C0296E25E4067400460FA4 /* Client Metadata */ = {
 			isa = PBXGroup;
 			children = (
+				5017F65D25FFC1CF003A812E /* __tests__ */,
 				50C0296F25E4067400460FA4 /* ClientMetadata.swift */,
 			);
 			path = "Client Metadata";
@@ -5721,6 +5732,7 @@
 				01A1B452252DFDC400841B63 /* FakeMetadataMachineReadableObject.swift in Sources */,
 				3598D99A24FE280700483F1F /* CountryTests.swift in Sources */,
 				B163D1102499068D001A322C /* SettingsViewModelTests.swift in Sources */,
+				5017F65F25FFC1E8003A812E /* ClientMetadataTests.swift in Sources */,
 				AB2F094F25D169DC00C16309 /* SurveyURLServiceTests.swift in Sources */,
 				0185DDDE25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift in Sources */,
 				A1654F0224B43E8500C0E115 /* DynamicTableViewTextViewCellTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		5008F60325DC0237008B516F /* PPAnalyticsCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5008F60225DC0237008B516F /* PPAnalyticsCollector.swift */; };
 		500DB4CC25CDDECF0038DFED /* PPASResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DB4CB25CDDECF0038DFED /* PPASResponse.swift */; };
 		500DB4D425CDE5C20038DFED /* PPASError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DB4D325CDE5C20038DFED /* PPASError.swift */; };
+		5017F64D25FFAD11003A812E /* PPASubmissionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5017F64C25FFAD11003A812E /* PPASubmissionState.swift */; };
 		5021532925C988D80006842D /* OTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5021532825C988D80006842D /* OTPResponse.swift */; };
 		50352C8B25C94961007193D2 /* OTPServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50352C8A25C94961007193D2 /* OTPServiceTests.swift */; };
 		50352C9F25C96687007193D2 /* HTTPClient+AuthorizationOTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50352C9725C9665A007193D2 /* HTTPClient+AuthorizationOTPTests.swift */; };
@@ -1169,6 +1170,7 @@
 		5008F60225DC0237008B516F /* PPAnalyticsCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPAnalyticsCollector.swift; sourceTree = "<group>"; };
 		500DB4CB25CDDECF0038DFED /* PPASResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPASResponse.swift; sourceTree = "<group>"; };
 		500DB4D325CDE5C20038DFED /* PPASError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPASError.swift; sourceTree = "<group>"; };
+		5017F64C25FFAD11003A812E /* PPASubmissionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPASubmissionState.swift; sourceTree = "<group>"; };
 		5021532825C988D80006842D /* OTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPResponse.swift; sourceTree = "<group>"; };
 		50352C8A25C94961007193D2 /* OTPServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPServiceTests.swift; sourceTree = "<group>"; };
 		50352C9725C9665A007193D2 /* HTTPClient+AuthorizationOTPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPClient+AuthorizationOTPTests.swift"; sourceTree = "<group>"; };
@@ -2538,6 +2540,7 @@
 			children = (
 				500DB4CB25CDDECF0038DFED /* PPASResponse.swift */,
 				500DB4D325CDE5C20038DFED /* PPASError.swift */,
+				5017F64C25FFAD11003A812E /* PPASubmissionState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -5327,6 +5330,7 @@
 				94427A5025502B8900C36BE6 /* WarnOthersNotificationsTimeInterval.swift in Sources */,
 				713EA25D24798A7000AB7EE8 /* ExposureDetectionRoundedView.swift in Sources */,
 				AB5F84B224F8F7E3000400D4 /* Migration0To1.swift in Sources */,
+				5017F64D25FFAD11003A812E /* PPASubmissionState.swift in Sources */,
 				01A4DC7025922EB4007D5794 /* HomeItemView.swift in Sources */,
 				01F2A58125803AA500DA96A6 /* DiaryOverviewDescriptionTableViewCell.swift in Sources */,
 				A3EE6E5D249BB9B900C64B61 /* UITestingParameters.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -252,8 +252,13 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 	}
 
 	private func executeAnalyticsSubmission(completion: @escaping () -> Void) {
-		Analytics.triggerAnalyticsSubmission(completion: { _ in
-			// Ignore the result of the call, so we just complete after the call is finished.
+		Analytics.triggerAnalyticsSubmission(completion: { result in
+			switch result {
+			case .success:
+				Log.info("[ENATaskExecutionDelegate] Analytics submission was triggered succesfully from background", log: .ppa)
+			case let .failure(error):
+				Log.error("[ENATaskExecutionDelegate] Analytics submission was triggered not succesfully from background", log: .ppa, error: error)
+			}
 			completion()
 		})
 	}

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -257,7 +257,7 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 			case .success:
 				Log.info("[ENATaskExecutionDelegate] Analytics submission was triggered succesfully from background", log: .ppa)
 			case let .failure(error):
-				Log.error("[ENATaskExecutionDelegate] Analytics submission was triggered not succesfully from background", log: .ppa, error: error)
+				Log.error("[ENATaskExecutionDelegate] Analytics submission was triggered not succesfully from background with error: \(error)", log: .ppa, error: error)
 			}
 			completion()
 		})

--- a/src/xcode/ENA/ENA/Source/Models/Metadata/Client Metadata/__tests__/ClientMetadataTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Metadata/Client Metadata/__tests__/ClientMetadataTests.swift
@@ -1,0 +1,43 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+@testable import ENA
+import XCTest
+
+class ClientMetadataTests: XCTestCase {
+
+	func testGIVEN_ClientMetadat_WHEN_AnalyticsCollectIsCalled_THEN_ClientMetadataAreLoggedCorrect() {
+		// GIVEN
+		let mockStore = MockTestStore()
+		Analytics.setupMock(store: mockStore)
+		mockStore.isPrivacyPreservingAnalyticsConsentGiven = true
+
+		XCTAssertNil(mockStore.clientMetadata, "Client metadata should be initially nil")
+		let appVersionParts = Bundle.main.appVersion.split(separator: ".")
+		guard appVersionParts.count == 3,
+			  let majorAppVersion = Int(appVersionParts[0]),
+			  let minorAppVersion = Int(appVersionParts[1]),
+			  let patchAppVersion = Int((appVersionParts[2])) else {
+			return
+		}
+		let expectedAppVersion = Version(major: majorAppVersion, minor: minorAppVersion, patch: patchAppVersion)
+		// iOSVersion
+		let expectediosVersion = Version(
+			major: ProcessInfo().operatingSystemVersion.majorVersion,
+			minor: ProcessInfo().operatingSystemVersion.minorVersion,
+			patch: ProcessInfo().operatingSystemVersion.patchVersion
+		)
+		// eTag
+		let expectedETag = "fake"
+		
+		// WHEN
+		Analytics.collect(.clientMetadata(.create(ClientMetadata(etag: expectedETag))))
+	
+		// THEN
+		XCTAssertNotNil(mockStore.clientMetadata, "Client metadata should be not nil")
+		XCTAssertEqual(expectedAppVersion, mockStore.clientMetadata?.cwaVersion, "appVersion not equal clientMetaData appVersion")
+		XCTAssertEqual(expectediosVersion, mockStore.clientMetadata?.iosVersion, "iosVersion not equal clientMetaData iosVersion")
+		XCTAssertEqual(expectedETag, mockStore.clientMetadata?.eTag, "eTag not equal clientMetaData eTag")
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -16,7 +16,6 @@ struct DataDonationModel {
 		self.isConsentGiven = store.isPrivacyPreservingAnalyticsConsentGiven
 
 		let userMetadata = store.userData
-		Analytics.collect(.userData(.create(userMetadata)))
 		self.federalStateName = userMetadata?.federalState?.rawValue
 		self.age = userMetadata?.ageGroup?.text
 

--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -55,15 +55,12 @@ struct DataDonationModel {
 	mutating func save() {
 		store.isPrivacyPreservingAnalyticsConsentGiven = isConsentGiven
 
-		// If user has not given or revoked his consent, delete all analytics data. If he gives not the consent, delete all analytics data to have a clean state.
-		if isConsentGiven == false {
-			Analytics.deleteAnalyticsData()
-		}
-
+		// If user has not given or revoked his consent, delete all analytics data and the userData.
 		guard isConsentGiven else {
 			region = nil
 			federalStateName = nil
 			age = nil
+			Analytics.deleteAnalyticsData()
 			return
 		}
 		let ageGroup = AgeGroup(from: self.age)

--- a/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DataDonation/Model/DataDonationModel.swift
@@ -57,7 +57,9 @@ struct DataDonationModel {
 		store.isPrivacyPreservingAnalyticsConsentGiven = isConsentGiven
 
 		// If user has not given or revoked his consent, delete all analytics data. If he gives not the consent, delete all analytics data to have a clean state.
-		Analytics.deleteAnalyticsData()
+		if isConsentGiven == false {
+			Analytics.deleteAnalyticsData()
+		}
 
 		guard isConsentGiven else {
 			region = nil

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
@@ -6,6 +6,7 @@ import Foundation
 
 enum PPASError: Error {
 
+	case submissionInProgress
 	case generalError
 	case urlCreationError
 	case responseError(Int)

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASubmissionState.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASubmissionState.swift
@@ -1,0 +1,10 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+
+enum PPASubmissionState {
+	case submissionInProgress
+	case readyForSubmission
+}

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -249,9 +249,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	}
 
 	private func obtainUsageData(disableExposureWindowsProbability: Bool = false) -> SAP_Internal_Ppdd_PPADataIOS {
-
-		Log.info("Obtaining now all usage data for analytics submission.", log: .ppa)
-
+		Log.info("Obtaining now all usage data for analytics submission...", log: .ppa)
 		let exposureRiskMetadata = gatherExposureRiskMetadata()
 		let userMetadata = gatherUserMetadata()
 		let clientMetadata = gatherClientMetadata()

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -21,7 +21,6 @@ protocol PPAnalyticsSubmitting {
 	#endif
 }
 
-// swiftlint:disable:next type_body_length
 final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	
 	// MARK: - Init

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -65,8 +65,10 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			return
 		}
 		
+		Log.debug("PPAnayticsSubmitter requesting AppConfig…", log: .ppa)
 		// Sink on the app configuration if something has changed. But do this in background.
-		self.configurationProvider.appConfiguration().receive(on: DispatchQueue.global(qos: .utility).ocombine).sink { [ weak self] configuration in
+		self.configurationProvider.appConfiguration().sink { [ weak self] configuration in
+			Log.debug("PPAnayticsSubmitter recieved AppConfig", log: .ppa)
 			let ppaConfigData = configuration.privacyPreservingAnalyticsParameters.common
 			self?.probabilityToSubmitPPAUsageData = ppaConfigData.probabilityToSubmit
 			self?.hoursSinceTestResultToSubmitKeySubmissionMetadata = ppaConfigData.hoursSinceTestResultToSubmitKeySubmissionMetadata

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -39,7 +39,6 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		self.client = client
 		self.submissionState = .readyForSubmission
 		self.configurationProvider = appConfig
-		self.dispatchGroupSubmission = DispatchGroup()
 	}
 	
 	// MARK: - Protocol PPAnalyticsSubmitting
@@ -67,19 +66,14 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			return
 		}
 		
-		// Sink on the app configuration if something has changed. But do this in background and wait for the result before continue.
-		dispatchGroupSubmission.enter()
+		// Sink on the app configuration if something has changed. But do this in background.
 		self.configurationProvider.appConfiguration().receive(on: DispatchQueue.global(qos: .background).ocombine).sink { [ weak self] configuration in
 			let ppaConfigData = configuration.privacyPreservingAnalyticsParameters.common
 			self?.probabilityToSubmitPPAUsageData = ppaConfigData.probabilityToSubmit
 			self?.hoursSinceTestResultToSubmitKeySubmissionMetadata = ppaConfigData.hoursSinceTestResultToSubmitKeySubmissionMetadata
 			self?.hoursSinceTestRegistrationToSubmitTestResultMetadata = ppaConfigData.hoursSinceTestRegistrationToSubmitTestResultMetadata
 			self?.probabilityToSubmitExposureWindows = ppaConfigData.probabilityToSubmitExposureWindows
-			self?.dispatchGroupSubmission.leave()
-		}.store(in: &subscriptions)
-		
-		// If we have the app config, we continue...
-		dispatchGroupSubmission.notify(queue: .global(qos: .background)) { [weak self] in
+			
 			guard let strongSelf = self else {
 				Log.warning("Analytics submission abord due fail at creating strong self", log: .ppa)
 				self?.submissionState = .readyForSubmission
@@ -127,7 +121,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 				Log.info("Analytics submission needs to generate new ppac token.", log: .ppa)
 				strongSelf.generatePPACAndSubmitData(completion: completion)
 			}
-		}
+		}.store(in: &subscriptions)
 	}
 	
 	#if !RELEASE
@@ -154,7 +148,6 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	private let store: (Store & PPAnalyticsData)
 	private let client: Client
 	private let configurationProvider: AppConfigurationProviding
-	private let dispatchGroupSubmission: DispatchGroup
 	
 	private var submissionState: PPASubmissionState
 	private var subscriptions: Set<AnyCancellable> = []

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -66,7 +66,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		}
 		
 		// Sink on the app configuration if something has changed. But do this in background.
-		self.configurationProvider.appConfiguration().receive(on: DispatchQueue.global(qos: .background).ocombine).sink { [ weak self] configuration in
+		self.configurationProvider.appConfiguration().receive(on: DispatchQueue.global(qos: .utility).ocombine).sink { [ weak self] configuration in
 			let ppaConfigData = configuration.privacyPreservingAnalyticsParameters.common
 			self?.probabilityToSubmitPPAUsageData = ppaConfigData.probabilityToSubmit
 			self?.hoursSinceTestResultToSubmitKeySubmissionMetadata = ppaConfigData.hoursSinceTestResultToSubmitKeySubmissionMetadata

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -327,7 +327,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 					self?.store.lastSubmissionAnalytics = Date()
 					completion?(result)
 				case let .failure(error):
-					Log.error("Analytics data were not submitted", log: .ppa, error: error)
+					Log.error("Analytics data were not submitted. Error: \(error)", log: .ppa, error: error)
 					completion?(result)
 				}
 			}

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -57,6 +57,8 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			return
 		}
 		
+		submissionState = .submissionInProgress
+		
 		// Check if user has given his consent to collect data
 		if userDeclinedAnalyticsCollectionConsent {
 			Log.warning("Analytics submission abord due to missing users consent", log: .ppa)
@@ -64,8 +66,6 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			completion?(.failure(.userConsentError))
 			return
 		}
-		
-		submissionState = .submissionInProgress
 		
 		// Sink on the app configuration if something has changed. But do this in background and wait for the result before continue.
 		dispatchQueueSubmission.enter()

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -50,9 +50,18 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	) {
 		Log.info("Analytics submission was triggered. Checking now if we can submit...", log: .ppa)
 		
+		// Check if a submission is already in progress
 		guard submissionState == .readyForSubmission else {
 			Log.warning("Analytics submission abord due to submission is already in progress", log: .ppa)
 			completion?(.failure(.submissionInProgress))
+			return
+		}
+		
+		// Check if user has given his consent to collect data
+		if userDeclinedAnalyticsCollectionConsent {
+			Log.warning("Analytics submission abord due to missing users consent", log: .ppa)
+			submissionState = .readyForSubmission
+			completion?(.failure(.userConsentError))
 			return
 		}
 		
@@ -75,14 +84,6 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 				Log.warning("Analytics submission abord due fail at creating strong self", log: .ppa)
 				self?.submissionState = .readyForSubmission
 				completion?(.failure(.generalError))
-				return
-			}
-			
-			// Check if user has given his consent to collect data
-			if strongSelf.userDeclinedAnalyticsCollectionConsent {
-				Log.warning("Analytics submission abord due to missing users consent", log: .ppa)
-				strongSelf.submissionState = .readyForSubmission
-				completion?(.failure(.userConsentError))
 				return
 			}
 			

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -21,6 +21,7 @@ protocol PPAnalyticsSubmitting {
 	#endif
 }
 
+// swiftlint:disable:next type_body_length
 final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	
 	// MARK: - Init

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -307,7 +307,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .ppacError(.generationFailed))
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -56,9 +56,9 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		XCTAssertNil(store.exposureWindowsMetadata?.newExposureWindowsQueue)
 		
 		/// Since the Date is super precise we have to be fuzzy here, and since we know our CI lets me a lot fuzzy here.
-		let tenSecondsAgo = Calendar.current.date(byAdding: .second, value: -20, to: Date())
-		let lastTenSeconds = try XCTUnwrap(tenSecondsAgo)...Date()
-		XCTAssertTrue(lastTenSeconds.contains(try XCTUnwrap(store.lastSubmissionAnalytics)))
+		let someTimeAgo = Calendar.current.date(byAdding: .second, value: -20, to: Date())
+		let someTimeAgoTimeRange = try XCTUnwrap(someTimeAgo)...Date()
+		XCTAssertTrue(someTimeAgoTimeRange.contains(try XCTUnwrap(store.lastSubmissionAnalytics)))
 		
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -39,14 +39,13 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 			switch result {
 			case .success:
 				expectation.fulfill()
-			case .failure:
-				XCTFail("Test should not fail")
+			case let .failure(error):
+				XCTFail("Test should not fail. Received error: \(error)")
 			}
 		})
 
 		// THEN
 		waitForExpectations(timeout: .medium)
-		
 		
 		/// Check that store is setup correctly after successful submission
 		XCTAssertEqual(store.previousRiskExposureMetadata, currentRiskExposureMetadata)

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -314,6 +314,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_SeveralTimes_THEN_SubmissionInProgressErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		Analytics.setupMock(store: store)
 		let client = ClientMock()
 		let appConfigurationProvider = CachedAppConfigurationMock()

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -45,7 +45,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		
 		
 		/// Check that store is setup correctly after successful submission
@@ -94,7 +94,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .userConsentError)
 	}
 
@@ -127,7 +127,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .probibilityError)
 	}
 
@@ -162,7 +162,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .probibilityError)
 	}
 
@@ -197,7 +197,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .submission23hoursError)
 	}
 
@@ -233,7 +233,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .onboardingError)
 	}
 
@@ -270,7 +270,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		})
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .medium)
 		XCTAssertEqual(ppasError, .appResetError)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -56,7 +56,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		XCTAssertNil(store.exposureWindowsMetadata?.newExposureWindowsQueue)
 		
 		/// Since the Date is super precise we have to be fuzzy here, and since we know our CI lets me a lot fuzzy here.
-		let tenSecondsAgo = Calendar.current.date(byAdding: .second, value: -10, to: Date())
+		let tenSecondsAgo = Calendar.current.date(byAdding: .second, value: -20, to: Date())
 		let lastTenSeconds = try XCTUnwrap(tenSecondsAgo)...Date()
 		XCTAssertTrue(lastTenSeconds.contains(try XCTUnwrap(store.lastSubmissionAnalytics)))
 		

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -12,7 +12,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_EverythingIsGiven_THEN_Success() throws {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -67,7 +66,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_UserConsentIsMissing_THEN_UserConsentErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		let client = ClientMock()
 		let config = SAP_Internal_V2_ApplicationConfigurationIOS()
 		let appConfigurationProvider = CachedAppConfigurationMock(with: config)
@@ -101,7 +99,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_AppConfigIsMissing_THEN_ProbibilityErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		let config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -134,7 +131,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_ProbabilityIsLow_THEN_ProbibilityErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -169,7 +165,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas2HoursAgo_THEN_Submission23hoursErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -204,7 +199,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_OnboardingWas2HoursAgo_THEN_OnboardingErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -240,7 +234,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_AppResetWas2HoursAgo_THEN_AppResetErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -277,7 +270,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 	func testGIVEN_SubmissionIsTriggered_WHEN_PpacCouldNotAuthorize_THEN_PpacErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
-		Analytics.setupMock(store: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
 		let client = ClientMock()
 		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
@@ -315,7 +307,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		// GIVEN
 		let store = MockTestStore()
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
-		Analytics.setupMock(store: store)
 		let client = ClientMock()
 		let appConfigurationProvider = CachedAppConfigurationMock()
 		let analyticsSubmitter = PPAnalyticsSubmitter(

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -328,12 +328,13 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		expectation.expectedFulfillmentCount = 2
 
 		// WHEN
-		var ppasError: PPASError?
+		var ppasErrors: [PPASError] = []
 		analyticsSubmitter.triggerSubmitData(ppacToken: nil, completion: { result in
 			switch result {
 			case .success:
 				XCTFail("Test should not success")
-			case .failure:
+			case let .failure(error):
+				ppasErrors.append(error)
 				expectation.fulfill()
 			}
 		})
@@ -343,14 +344,15 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 			case .success:
 				XCTFail("Test should not success")
 			case let .failure(error):
-				ppasError = error
+				ppasErrors.append(error)
 				expectation.fulfill()
 			}
 		})
-
+		
 		// THEN
-		waitForExpectations(timeout: .short)
-		XCTAssertEqual(ppasError, .submissionInProgress)
+		waitForExpectations(timeout: .medium)
+		XCTAssertEqual(ppasErrors.count, 2)
+		XCTAssertTrue(ppasErrors.contains(.submissionInProgress))
 	}
 
 	// MARK: - Conversion to protobuf

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/CachedAppConfiguration.swift
@@ -93,7 +93,6 @@ final class CachedAppConfiguration {
 							lastAppConfigFetch: Date(),
 							appConfig: response.config
 						)
-						Analytics.collect(.clientMetadata(.create(ClientMetadata(etag: response.eTag))))
 						// update revokation list
 						let revokationList = self.store.appConfigMetadata?.appConfig.revokationEtags ?? []
 						self.packageStore?.revokationList = revokationList // for future package-operations

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/CachedAppConfigurationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Helper/__tests__/CachedAppConfigurationTests.swift
@@ -84,43 +84,6 @@ final class CachedAppConfigurationTests: XCTestCase {
 
 		subscription.cancel()
 	}
-	
-	func testClientMetadata_isUpdated_everytime_appconfiguration_isFetched() {
-		let mockStore = MockTestStore()
-		Analytics.setupMock(store: mockStore)
-		mockStore.isPrivacyPreservingAnalyticsConsentGiven = true
-		XCTAssertNil(mockStore.clientMetadata, "Client metadata should be initially nil")
-		let client = CachingHTTPClientMock(store: mockStore)
-		let cache = CachedAppConfiguration(client: client, store: mockStore)
-		let expectationClientMetadata = expectation(description: "ClientMetadata")
-		// AppVersion
-		let appVersionParts = Bundle.main.appVersion.split(separator: ".")
-		guard appVersionParts.count == 3,
-			  let majorAppVersion = Int(appVersionParts[0]),
-			  let minorAppVersion = Int(appVersionParts[1]),
-			  let patchAppVersion = Int((appVersionParts[2])) else {
-			return
-		}
-		let expectedAppVersion = Version(major: majorAppVersion, minor: minorAppVersion, patch: patchAppVersion)
-		// iOSVersion
-		let expectediosVersion = Version(
-			major: ProcessInfo().operatingSystemVersion.majorVersion,
-			minor: ProcessInfo().operatingSystemVersion.minorVersion,
-			patch: ProcessInfo().operatingSystemVersion.patchVersion
-		)
-		// eTag
-		let expectedETag = "fake"
-		let configuration = cache.appConfiguration(forceFetch: true).sink { _ in
-			expectationClientMetadata.fulfill()
-		}
-		waitForExpectations(timeout: .medium) { _ in
-			XCTAssertNotNil(configuration, "configuration is not nil")
-			XCTAssertNotNil(mockStore.clientMetadata, "Client metadata should be filled after fetching")
-			XCTAssertEqual(expectedAppVersion, mockStore.clientMetadata?.cwaVersion, "appVersion not equal clientMetaData appVersion")
-			XCTAssertEqual(expectediosVersion, mockStore.clientMetadata?.iosVersion, "iosVersion not equal clientMetaData iosVersion")
-			XCTAssertEqual(expectedETag, mockStore.clientMetadata?.eTag, "eTag not equal clientMetaData eTag")
-		}
-	}
 
 	func testCacheEmptySupportedCountries() throws {
 		let fetchedFromClientExpectation = expectation(description: "configuration fetched from client")

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -361,7 +361,9 @@ extension SecureStore: PrivacyPreservingProviding {
 	var isPrivacyPreservingAnalyticsConsentGiven: Bool {
 		get { kvStore["isPrivacyPreservingAnalyticsConsentGiven"] as Bool? ?? false }
 		set { kvStore["isPrivacyPreservingAnalyticsConsentGiven"] = newValue
-			userData = nil
+			if newValue == false {
+				userData = nil
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Removed that cancellable flag and put the sink on the app config in a dispatch group. And first if we leave the completion handler from the sink, we continue with the submission. That all is done in the background to not block something.
Also I added several logs.
And least, I added a submission state to avoid triggering more then one submission at the same time. The submission state is reset at every completion call.

If this really solved the bug, that there is no submission > 48h, i cannot say but has to be determined by the testers.

I also fixed the collection of the client and user metadata, because according to the tech spec they should be graped right before the submission. And also to solve multiple collect calls at the same time.

i removed the collection of the client metadata in the app config completion handler to avoid infinite loops.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5785
