### PR TITLE
OnboardingInfoViewController pushed twice on second next tap

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockExposureManager.swift
@@ -91,9 +91,6 @@ extension MockExposureManager: ExposureManager {
 	}
 
 	func alertForBluetoothOff(completion: @escaping () -> Void) -> UIAlertController? {
-		DispatchQueue.main.async {
-			completion()
-		}
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Remove faulty completion when not returning any view controller

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5771
