### PR TITLE
Risk Card "Risiko-Ermittlung gestoppt" behave different on Home vs. Detailscreen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionCoordinator.swift
@@ -57,8 +57,20 @@ final class ExposureDetectionCoordinator {
 						self.showSurveyConsent()
 					}
 				},
-				onInactiveButtonTap: { [weak self] completion in
-					self?.setExposureManagerEnabled(true, then: completion)
+				onInactiveButtonTap: { [weak self] in
+					guard let self = self else {
+						return
+					}
+
+					let vc = ExposureNotificationSettingViewController(
+						initialEnState: self.homeState.enState,
+						store: self.store,
+						appConfigurationProvider: self.appConfigurationProvider,
+						setExposureManagerEnabled: { [weak self] newState, completion in
+							self?.setExposureManagerEnabled(newState, then: completion)
+						}
+					)
+					self.navigationController?.pushViewController(vc, animated: true)
 				}
 			),
 			store: store

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewController.swift
@@ -60,16 +60,6 @@ final class ExposureDetectionViewController: DynamicTableViewController, Require
 			}
 			.store(in: &subscriptions)
 
-		viewModel.$exposureNotificationError
-			.sink { [weak self] error in
-				guard let self = self, let error = error else { return }
-
-				self.viewModel.exposureNotificationError = nil
-
-				self.alertError(message: error.localizedDescription, title: AppStrings.Common.alertTitleGeneral)
-			}
-			.store(in: &subscriptions)
-
 		viewModel.$riskBackgroundColor.assign(to: \.backgroundColor, on: headerView).store(in: &subscriptions)
 
 		viewModel.$titleText.assign(to: \.text, on: titleLabel).store(in: &subscriptions)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/ExposureDetectionViewModel.swift
@@ -17,7 +17,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 		homeState: HomeState,
 		appConfigurationProvider: AppConfigurationProviding,
 		onSurveyTap: @escaping () -> Void,
-		onInactiveButtonTap: @escaping (@escaping (ExposureNotificationError?) -> Void) -> Void
+		onInactiveButtonTap: @escaping () -> Void
 	) {
 		self.homeState = homeState
 		self.appConfigurationProvider = appConfigurationProvider
@@ -104,8 +104,6 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	@OpenCombine.Published var isButtonEnabled: Bool = false
 	@OpenCombine.Published var isButtonHidden: Bool = true
 
-	@OpenCombine.Published var exposureNotificationError: ExposureNotificationError?
-
 	var previousRiskTitle: String {
 		switch homeState.lastRiskCalculationResult?.riskLevel {
 		case .low:
@@ -155,9 +153,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	func onButtonTap() {
 		switch homeState.riskState {
 		case .inactive:
-			onInactiveButtonTap { [weak self] error in
-				self?.exposureNotificationError = error
-			}
+			onInactiveButtonTap()
 		case .risk, .detectionFailed:
 			homeState.requestRisk(userInitiated: true)
 		}
@@ -167,7 +163,7 @@ class ExposureDetectionViewModel: CountdownTimerDelegate {
 	
 	private let homeState: HomeState
 
-	private let onInactiveButtonTap: (@escaping (ExposureNotificationError?) -> Void) -> Void
+	private let onInactiveButtonTap: () -> Void
 	private let onSurveyTap: () -> Void
 
 	private var countdownTimer: CountdownTimer?

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewControllerTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewControllerTests.swift
@@ -37,7 +37,7 @@ class ExposureDetectionViewControllerTests: XCTestCase {
 				homeState: homeState,
 				appConfigurationProvider: CachedAppConfigurationMock(),
 				onSurveyTap: { },
-				onInactiveButtonTap: { _ in }
+				onInactiveButtonTap: { }
 			),
 			store: store
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureDetection/__tests__/ExposureDetectionViewModelTests.swift
@@ -44,7 +44,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 
 		// Needed to check the isHidden state of sections
@@ -112,7 +112,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 
 		// Needed to check the isHidden state of sections
@@ -239,7 +239,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: configuration,
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 		
 		// Needed to check the isHidden state of sections
@@ -298,7 +298,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: configuration,
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 		
 		// Needed to check the isHidden state of sections
@@ -397,7 +397,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: configuration,
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 		
 		// Needed to check the isHidden state of sections
@@ -496,7 +496,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 
 		// Needed to check the isHidden state of sections
@@ -573,7 +573,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in }
+			onInactiveButtonTap: { }
 		)
 
 		// Needed to check the isHidden state of sections
@@ -681,7 +681,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in onInactiveButtonTapExpectation.fulfill() }
+			onInactiveButtonTap: { onInactiveButtonTapExpectation.fulfill() }
 		)
 
 		viewModel.onButtonTap()
@@ -741,7 +741,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in onInactiveButtonTapExpectation.fulfill() }
+			onInactiveButtonTap: { onInactiveButtonTapExpectation.fulfill() }
 		)
 
 		viewModel.onButtonTap()
@@ -787,7 +787,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in onInactiveButtonTapExpectation.fulfill() }
+			onInactiveButtonTap: { onInactiveButtonTapExpectation.fulfill() }
 		)
 
 		viewModel.onButtonTap()
@@ -834,7 +834,7 @@ class ExposureDetectionViewModelTests: XCTestCase {
 			homeState: homeState,
 			appConfigurationProvider: CachedAppConfigurationMock(),
 			onSurveyTap: { },
-			onInactiveButtonTap: { _ in onInactiveButtonTapExpectation.fulfill() }
+			onInactiveButtonTap: { onInactiveButtonTapExpectation.fulfill() }
 		)
 
 		viewModel.onButtonTap()


### PR DESCRIPTION
## Description

Open exposure notification settings view controller when tapping button instead of enabling exposure notification

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4954
