### PR TITLE
Add Days since Install to New Functions Display

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1394,6 +1394,10 @@ sein.";
 
 "NewVersionFeature_115_cross_border_switzerland_description" = "Die Corona-Warn-App nutzende Personen können nun auch verschlüsselte Zufalls-IDs mit Personen austauschen, die die offizielle Warn-App der Schweiz nutzen. Somit können Warnungen an App nutzende Personen in der Schweiz geschickt sowie von ihnen empfangen werden.";
 
+"NewVersionFeature_115_days_since_install_title" = "Änderung der Risikokarten";
+
+"NewVersionFeature_115_days_since_install_description" = "Auf den Risikokarten entfällt die Anzeige der Anzahl aktiver Tage bzw. dass die App dauerhaft aktiv ist.";
+
 "NewVersionFeature_115_error_analytic_logs_title" = "Erstellung von Fehlerberichten";
 
 "NewVersionFeature_115_error_analytic_logs_description" = "Sie können nun nach Aufforderung des technischen Supports einen Fehlerbericht erstellen und die Schritte aufzeichnen, die Sie in der App ausführen. Mögliche technische Fehler können so besser analysiert und schneller behoben werden.";

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
@@ -19,6 +19,10 @@ struct DeltaOnboardingNewVersionFeaturesViewModel {
 		self.newVersionFeatures.append(
 			NewVersionFeature(title: AppStrings.NewVersionFeatures.feature115SwitzerlandTitle, description: AppStrings.NewVersionFeatures.feature115SwitzerlandDescription)
 		)
+		// Days since Install
+		self.newVersionFeatures.append(
+			NewVersionFeature(title: AppStrings.NewVersionFeatures.feature115DaysSinceInstallTitle, description: AppStrings.NewVersionFeatures.feature115DaysSinceInstallDescription)
+		)
 	}
 
 	// MARK: - Internal

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -917,6 +917,10 @@ enum AppStrings {
 		
 		static let feature115SwitzerlandDescription = NSLocalizedString("NewVersionFeature_115_cross_border_switzerland_description", comment: "")
 		
+		static let feature115DaysSinceInstallTitle = NSLocalizedString("NewVersionFeature_115_days_since_install_title", comment: "")
+		
+		static let feature115DaysSinceInstallDescription = NSLocalizedString("NewVersionFeature_115_days_since_install_description", comment: "")
+		
 		static let feature115ErrorAnalyticsLogTitle = NSLocalizedString("NewVersionFeature_115_error_analytic_logs_title", comment: "")
 		
 		static let feature115ErrorAnalyticsLogDescription = NSLocalizedString("NewVersionFeature_115_error_analytic_logs_description", comment: "")


### PR DESCRIPTION
## Description
This PR adds Info about the update Riskcard (Days since install) to the New Features display 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5889

## Screenshots
![Simulator Screen Shot - iPhone 12 - 2021-03-18 at 14 37 14](https://user-images.githubusercontent.com/10122052/111635375-b8adc580-87f7-11eb-88fa-d9a024546762.png)
![Simulator Screen Shot - iPhone 12 - 2021-03-18 at 14 37 11](https://user-images.githubusercontent.com/10122052/111635399-bba8b600-87f7-11eb-90c1-d51259b612ed.png)
