### PR TITLE
Fix/5640 Clean Up Screenshots

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
@@ -207,13 +207,13 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
 		addPersonToDayEntry("Max Mustermann")
-		addPersonToDayEntry("Erika Mustermann")
+		addPersonToDayEntry("Erika Musterfrau")
 
 		// check count for day entries: 1 add entry cell + 1 person added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 3)
 
-		// deselect Erika Mustermann - 1 because new persons get entered on top
-		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 1).staticTexts["Erika Mustermann"].tap()
+		// deselect Erika Musterfrau - 1 because new persons get entered on top
+		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 1).staticTexts["Erika Musterfrau"].tap()
 
 		XCTAssertTrue(app.segmentedControls.firstMatch.waitForExistence(timeout: .medium))
 		app.segmentedControls.firstMatch.buttons[app.localized("ContactDiary_Day_LocationsSegment")].tap()
@@ -238,7 +238,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 
 		XCTAssertTrue(dayCell.staticTexts["Max Mustermann"].exists)
 		XCTAssertTrue(dayCell.staticTexts["Bäckerei"].exists)
-		XCTAssertFalse(dayCell.staticTexts["Erika Mustermann"].exists)
+		XCTAssertFalse(dayCell.staticTexts["Erika Musterfrau"].exists)
 	}
 
 	func testScreenshotContactJournalInformation() throws {
@@ -275,7 +275,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		app.cells.element(boundBy: 1).tap()
 
 		// add persons
-		addPersonToDayEntry("Erika Mustermann")
+		addPersonToDayEntry("Erika Musterfrau")
 		addPersonToDayEntry("Max Mustermann")
 		// take screenshot
 		snapshot("contact_journal_listing_add_persons")
@@ -328,12 +328,12 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		// check count for day entries: 1 add entry cell
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
-		addPersonToDayEntry("Max Mustermann", phoneNumber: "12345678", eMail: "marcus@mustermann.de")
+		addPersonToDayEntry("Max Mustermann", phoneNumber: "12345678", eMail: "max@mustermann.de")
 
 		// check count for day entries: 1 add entry cell + 1 person added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 2)
 
-		addPersonToDayEntry("Maria Musterfrau", phoneNumber: "12345678", eMail: "maria@musterfrau.de")
+		addPersonToDayEntry("Erika Musterfrau", phoneNumber: "12345678", eMail: "erika@musterfrau.de")
 
 		// check count for day entries: 1 add entry cell + 2 persons added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 3)
@@ -607,7 +607,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).tap()
 
 		addPersonToDayEntry("Max Mustermann")
-		addPersonToDayEntry("Erika Mustermann")
+		addPersonToDayEntry("Erika Musterfrau")
 		app.segmentedControls.firstMatch.buttons[app.localized("ContactDiary_Day_LocationsSegment")].tap()
 		addLocationToDayEntry("Bäckerei")
 		addLocationToDayEntry("Supermarkt")

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/__tests__/ENAUITests_07_ContactJournalUITests.swift
@@ -133,18 +133,18 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		XCTAssertEqual(app.navigationBars.element(boundBy: 1).identifier, app.localized("ContactDiary_AddEditEntry_LocationTitle"))
 		let textField = app.tables.firstMatch.cells.textFields.firstMatch
 		textField.tap()
-		textField.typeText("-RotWeiss")
+		textField.typeText(" Innenstadt")
 
 		XCTAssertTrue(textField.buttons.firstMatch.waitForExistence(timeout: .medium))
 		// tap the clear button inside textfield to clear input
 		textField.buttons.firstMatch.tap()
-		textField.typeText("PommesBude-RotWeiss")
+		textField.typeText("Supermarkt Innenstadt")
 
 		XCTAssertTrue(app.buttons[app.localized("ContactDiary_AddEditEntry_PrimaryButton_Title")].waitForExistence(timeout: .medium))
 		app.buttons[app.localized("ContactDiary_AddEditEntry_PrimaryButton_Title")].tap()
 
 		XCTAssertNotEqual(originalLocation, locationsTableView.cells.firstMatch.staticTexts.firstMatch.label)
-		XCTAssertEqual("PommesBude-RotWeiss", locationsTableView.cells.firstMatch.staticTexts.firstMatch.label)
+		XCTAssertEqual("Supermarkt Innenstadt", locationsTableView.cells.firstMatch.staticTexts.firstMatch.label)
 	}
 
 	func testScreenshotTwoPersonsOneLocationAndMessages() throws {
@@ -206,14 +206,14 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		// check count for day entries: 1 add entry cell
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
-		addPersonToDayEntry("Marcus Mustermann")
-		addPersonToDayEntry("Manu Mustermann")
+		addPersonToDayEntry("Max Mustermann")
+		addPersonToDayEntry("Erika Mustermann")
 
 		// check count for day entries: 1 add entry cell + 1 person added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 3)
 
-		// deselect Manu Mustermann - 1 because new persons get entered on top
-		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 1).staticTexts["Manu Mustermann"].tap()
+		// deselect Erika Mustermann - 1 because new persons get entered on top
+		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 1).staticTexts["Erika Mustermann"].tap()
 
 		XCTAssertTrue(app.segmentedControls.firstMatch.waitForExistence(timeout: .medium))
 		app.segmentedControls.firstMatch.buttons[app.localized("ContactDiary_Day_LocationsSegment")].tap()
@@ -221,7 +221,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		// check count for day entries: 1 add entry cell
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
-		addLocationToDayEntry("Pommesbude")
+		addLocationToDayEntry("Bäckerei")
 
 		// check count for day entries: 1 add entry cell + 1 location added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 2)
@@ -236,9 +236,9 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		XCTAssertTrue(app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).waitForExistence(timeout: .medium))
 		let dayCell = app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3)
 
-		XCTAssertTrue(dayCell.staticTexts["Marcus Mustermann"].exists)
-		XCTAssertTrue(dayCell.staticTexts["Pommesbude"].exists)
-		XCTAssertFalse(dayCell.staticTexts["Manu Mustermann"].exists)
+		XCTAssertTrue(dayCell.staticTexts["Max Mustermann"].exists)
+		XCTAssertTrue(dayCell.staticTexts["Bäckerei"].exists)
+		XCTAssertFalse(dayCell.staticTexts["Erika Mustermann"].exists)
 	}
 
 	func testScreenshotContactJournalInformation() throws {
@@ -328,7 +328,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		// check count for day entries: 1 add entry cell
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
-		addPersonToDayEntry("Marcus Mustermann", phoneNumber: "12345678", eMail: "marcus@mustermann.de")
+		addPersonToDayEntry("Max Mustermann", phoneNumber: "12345678", eMail: "marcus@mustermann.de")
 
 		// check count for day entries: 1 add entry cell + 1 person added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 2)
@@ -357,7 +357,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		// check count for day entries: 1 add entry cell
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 1)
 
-		addLocationToDayEntry("Pommesbude", phoneNumber: "12345678", eMail: "pommes@bude.de")
+		addLocationToDayEntry("Bäckerei", phoneNumber: "12345678", eMail: "bäcker@meinestadt.de")
 
 		// check count for day entries: 1 add entry cell + 1 location added
 		XCTAssertEqual(app.descendants(matching: .table).firstMatch.cells.count, 2)
@@ -380,7 +380,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 
 		// Add person.
 
-		addPersonToDayEntry("Marcus Mustermann")
+		addPersonToDayEntry("Max Mustermann")
 
 		// Select details of encounter.
 
@@ -468,7 +468,7 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		XCTAssertTrue(app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).waitForExistence(timeout: .medium))
 		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).tap()
 
-		addPersonToDayEntry("Marcus Mustermann")
+		addPersonToDayEntry("Max Mustermann")
 
 		// Tap info button.
 		app.buttons[AccessibilityIdentifiers.ContactDiaryInformation.Day.notesInfoButton].tap()
@@ -606,11 +606,11 @@ class ENAUITests_07_ContactJournalUITests: XCTestCase {
 		XCTAssertTrue(app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).waitForExistence(timeout: .medium))
 		app.descendants(matching: .table).firstMatch.cells.element(boundBy: 3).tap()
 
-		addPersonToDayEntry("Marcus Mustermann")
-		addPersonToDayEntry("Manu Mustermann")
+		addPersonToDayEntry("Max Mustermann")
+		addPersonToDayEntry("Erika Mustermann")
 		app.segmentedControls.firstMatch.buttons[app.localized("ContactDiary_Day_LocationsSegment")].tap()
-		addLocationToDayEntry("Pommesbude")
-		addLocationToDayEntry("Dönerstand")
+		addLocationToDayEntry("Bäckerei")
+		addLocationToDayEntry("Supermarkt")
 
 		XCTAssertTrue(app.navigationBars.firstMatch.buttons.element(boundBy: 0).waitForExistence(timeout: .medium))
 		app.navigationBars.firstMatch.buttons.element(boundBy: 0).tap()

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -435,7 +435,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			)
 		} else {
 			cellModel = HomeThankYouCellModel(
-				testResultTimestamp: 1615766400 // 15.03.2021, 18701 days since 01.01.1970
+				testResultTimestamp: 1604793600 // 08.11.2020, 18574 days since 01.01.1970
 			)
 		}
 		cell.configure(

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -428,9 +428,16 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			fatalError("Could not dequeue HomeThankYouTableViewCell")
 		}
 
-		let cellModel = HomeThankYouCellModel(
-			testResultTimestamp: viewModel.store.devicePairingSuccessfulTimestamp
-		)
+		var cellModel: HomeThankYouCellModel
+		if !isUITesting {
+			cellModel = HomeThankYouCellModel(
+				testResultTimestamp: viewModel.store.devicePairingSuccessfulTimestamp
+			)
+		} else {
+			cellModel = HomeThankYouCellModel(
+				testResultTimestamp: 1615766400 // 15.03.2021, 18701 days since 01.01.1970
+			)
+		}
 		cell.configure(
 			with: cellModel,
 			onPrimaryAction: { [weak self] in

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
@@ -18,10 +18,6 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-userNeedsToBeInformedAboutHowRiskDetectionWorks", "NO"])
 	}
 
-	override func tearDownWithError() throws {
-		// Put teardown code here. This method is called after the invocation of each test method in the class.
-	}
-
 	func test_0010_HomeFlow_medium() throws {
 		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.launch()

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
@@ -131,6 +131,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let numberOfDaysWithLowRisk = 0
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITestsHome.swift
@@ -78,6 +78,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let numberOfDaysWithHighRisk = 1
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))
@@ -104,6 +105,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithHighRisk])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))
@@ -155,6 +157,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))
@@ -181,6 +184,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))
@@ -207,6 +211,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-appInstallationDays", installationDays])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		snapshot("homescreenrisk_level_\(riskLevel)_installation_14days_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -220,6 +225,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-appInstallationDays", installationDays])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		snapshot("homescreenrisk_level_\(riskLevel)_installation_\(installationDays)days_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -231,6 +237,7 @@ class ENAUITests_01_Home: XCTestCase {
 		let riskLevel = "inactive"
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.submitCardButton].waitForExistence(timeout: .short))
@@ -247,13 +254,13 @@ class ENAUITests_01_Home: XCTestCase {
 
 	// MARK: - Risk states with active Exposure Logging
 
-	func test_screenshot_homescreen_riskCardHigh_activeExposureLogging() throws {
+	func test_screenshot_homescreen_riskCardHigh_disabledExposureLogging() throws {
 		var screenshotCounter = 0
 		let riskLevel = "high"
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-isOnboarded", "YES"])
-		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.disabled.stringValue])
 		app.launch()
 
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.RiskTableViewCell.topContainer].waitForExistence(timeout: .medium))
@@ -289,6 +296,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		let riskCell = app.cells.element(boundBy: 1)
@@ -307,6 +315,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-activeTracingDays", activeTracingDays])
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", "1"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		let riskCell = app.cells.element(boundBy: 1)
@@ -325,6 +334,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		app.launchArguments.append(contentsOf: ["-riskLevel", riskLevel])
 		app.launchArguments.append(contentsOf: ["-appInstallationDays", installationDays])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 		
 		let riskCell = app.cells.element(boundBy: 1)
@@ -356,6 +366,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launchArguments.append(contentsOf: ["-showTestResultScreen", "YES"])
 		app.launchArguments.append(contentsOf: ["-showInvalidTestResult", "YES"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		snapshot("homescreenrisk_show_invalid_test_result_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -372,6 +383,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launchArguments.append(contentsOf: ["-showTestResultScreen", "YES"])
 		app.launchArguments.append(contentsOf: ["-showLoadingTestResult", "YES"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		snapshot("homescreenrisk_show_loading_test_result_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -388,6 +400,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launchArguments.append(contentsOf: ["-showTestResultScreen", "YES"])
 		app.launchArguments.append(contentsOf: ["-showPendingTestResult", "YES"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		snapshot("homescreenrisk_show_pending_test_result_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -404,6 +417,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.launchArguments.append(contentsOf: ["-numberOfDaysWithRiskLevel", numberOfDaysWithLowRisk])
 		app.launchArguments.append(contentsOf: ["-showTestResultScreen", "YES"])
 		app.launchArguments.append(contentsOf: ["-showNegativeTestResult", "YES"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		snapshot("homescreenrisk_show_negative_test_result_\(String(format: "%04d", (screenshotCounter.inc() )))")
@@ -416,6 +430,7 @@ class ENAUITests_01_Home: XCTestCase {
 		app.setPreferredContentSizeCategory(accessibility: .accessibility, size: .XS)
 		// we just need one launch argument because it is handled separately
 		app.launchArguments.append(contentsOf: ["-showPositiveTestResult", "YES"])
+		app.launchArguments.append(contentsOf: ["-ENStatus", ENStatus.active.stringValue])
 		app.launch()
 
 		snapshot("homescreenrisk_show_positive_test_result_\(String(format: "%04d", (screenshotCounter.inc() )))")


### PR DESCRIPTION
## Description
- Replaced names of persons and locations
- home screen shows active exposure logging
- fixed: date of test is now 08.11.200 instead of 01.01.1970 (as on the statistics cards)
- device time (9:41) is configured by fastlane and shall be changed in src/xcode/fastlane/Snapfile

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5640

## Screenshots
<img width="414" alt="iPhone 11-homescreenrisk_show_thankyou_screen_0003" src="https://user-images.githubusercontent.com/7896005/112015622-45c08980-8b2c-11eb-9edd-3805a13d4891.png">

