### PR TITLE
fix/5640 Disabled override_status_bar

### DIFF
--- a/src/xcode/fastlane/Snapfile
+++ b/src/xcode/fastlane/Snapfile
@@ -38,7 +38,7 @@ headless(false)
 erase_simulator(true)
 
 # Remove the '#' to set the status bar to 9:41 AM, and show full battery and reception.
-override_status_bar(true)
+# override_status_bar(true)
 
 localize_simulator(true)
 


### PR DESCRIPTION
## Description
Use actual time as device time instead of 9:41. Disable override_status_bar(true)

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5640

