### PR TITLE
5784 - risk metadata missing after first submission

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -272,6 +272,10 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 	}
 
 	private func executeAnalyticsSubmission(completion: @escaping () -> Void) {
+		// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
+		if let riskCalculationResult = store.riskCalculationResult {
+			Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
+		}
 		Analytics.triggerAnalyticsSubmission(completion: { result in
 			switch result {
 			case .success:

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMPPAnalytics/DMPPAnalyticsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMPPAnalytics/DMPPAnalyticsViewModel.swift
@@ -53,6 +53,10 @@ final class DMPPAnalyticsViewModel {
 				textColor: .white,
 				backgroundColor: .enaColor(for: .buttonPrimary),
 				action: { [weak self] in
+					// it's added for the testers in case of force submission
+					if let riskCalculationResult = self?.store.riskCalculationResult {
+						Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
+					}
 					Analytics.forcedAnalyticsSubmission(completion: { [weak self] result in
 						switch result {
 						case .success:

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -75,6 +75,10 @@ enum PPAnalyticsCollector {
 
 	/// Triggers the submission of all collected analytics data. Only if all checks success, the submission is done. Otherwise, the submission is aborted. Optionally, you can specify a completion handler to get the success or failure handlers.
 	static func triggerAnalyticsSubmission(completion: ((Result<Void, PPASError>) -> Void)? = nil) {
+		// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
+		if let riskCalculationResult = store?.riskCalculationResult {
+			updateRiskExposureMetadata(riskCalculationResult)
+		}
 		guard let submitter = submitter else {
 			Log.warning("I cannot submit analytics data. Perhaps i am a mock or setup was not called correctly?", log: .ppa)
 			return

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -75,10 +75,6 @@ enum PPAnalyticsCollector {
 
 	/// Triggers the submission of all collected analytics data. Only if all checks success, the submission is done. Otherwise, the submission is aborted. Optionally, you can specify a completion handler to get the success or failure handlers.
 	static func triggerAnalyticsSubmission(completion: ((Result<Void, PPASError>) -> Void)? = nil) {
-		// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
-		if let riskCalculationResult = store?.riskCalculationResult {
-			updateRiskExposureMetadata(riskCalculationResult)
-		}
 		guard let submitter = submitter else {
 			Log.warning("I cannot submit analytics data. Perhaps i am a mock or setup was not called correctly?", log: .ppa)
 			return

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -227,6 +227,12 @@ final class RiskProvider: RiskProviding {
 		// 2. There is a previous risk that is still valid and should not be recalculated
 		if let risk = previousRiskIfExistingAndNotExpired(userInitiated: userInitiated) {
 			Log.info("RiskProvider: Using risk from previous detection", log: .riskDetection)
+			
+			
+			// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
+			if let riskCalculationResult = store.riskCalculationResult {
+				Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
+			}
 			completion(.success(risk))
 			return
 		}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -227,6 +227,11 @@ final class RiskProvider: RiskProviding {
 		// 2. There is a previous risk that is still valid and should not be recalculated
 		if let risk = previousRiskIfExistingAndNotExpired(userInitiated: userInitiated) {
 			Log.info("RiskProvider: Using risk from previous detection", log: .riskDetection)
+
+			// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
+			if let riskCalculationResult = store.riskCalculationResult {
+				Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
+			}
 			completion(.success(risk))
 			return
 		}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -228,7 +228,6 @@ final class RiskProvider: RiskProviding {
 		if let risk = previousRiskIfExistingAndNotExpired(userInitiated: userInitiated) {
 			Log.info("RiskProvider: Using risk from previous detection", log: .riskDetection)
 			
-			
 			// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
 			if let riskCalculationResult = store.riskCalculationResult {
 				Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -227,11 +227,6 @@ final class RiskProvider: RiskProviding {
 		// 2. There is a previous risk that is still valid and should not be recalculated
 		if let risk = previousRiskIfExistingAndNotExpired(userInitiated: userInitiated) {
 			Log.info("RiskProvider: Using risk from previous detection", log: .riskDetection)
-
-			// fill in the risk exposure metadata if new risk calculation is not done in the meanwhile
-			if let riskCalculationResult = store.riskCalculationResult {
-				Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
-			}
 			completion(.success(risk))
 			return
 		}


### PR DESCRIPTION
## Description
Risk metadata was missing after first submission and also in the case of force submission because risk calculation was not done in the meanwhile.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5784

## Screenshots
NA
