### PR TITLE
Fix/5899 ppa hours since test registration are mainly 0

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Metadata/Client Metadata/__tests__/ClientMetadataTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Metadata/Client Metadata/__tests__/ClientMetadataTests.swift
@@ -32,7 +32,7 @@ class ClientMetadataTests: XCTestCase {
 		let expectedETag = "fake"
 		
 		// WHEN
-		Analytics.collect(.clientMetadata(.create(ClientMetadata(etag: expectedETag))))
+		mockStore.clientMetadata = ClientMetadata(etag: expectedETag)
 	
 		// THEN
 		XCTAssertNotNil(mockStore.clientMetadata, "Client metadata should be not nil")

--- a/src/xcode/ENA/ENA/Source/Models/Metadata/Exposure Windows Metadata/ExposureWindowsMetadata.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Metadata/Exposure Windows Metadata/ExposureWindowsMetadata.swift
@@ -39,7 +39,7 @@ struct ExposureWindowsMetadata: Codable {
 	var reportedExposureWindowsQueue: [SubmissionExposureWindow]
 }
 
-struct SubmissionExposureWindow: Codable {
+struct SubmissionExposureWindow: Codable, Equatable {
 
 	// MARK: - Init
 
@@ -51,6 +51,16 @@ struct SubmissionExposureWindow: Codable {
 		self.date = date
 	}
 	
+	// MARK: - Protocol Equatable
+
+	static func == (lhs: SubmissionExposureWindow, rhs: SubmissionExposureWindow) -> Bool {
+		return  lhs.exposureWindow == rhs.exposureWindow &&
+			lhs.transmissionRiskLevel == rhs.transmissionRiskLevel &&
+			lhs.normalizedTime == rhs.normalizedTime &&
+			lhs.hash == rhs.hash &&
+			lhs.date == rhs.date
+	}
+
 	// MARK: - Internal
 
 	var exposureWindow: ExposureWindow

--- a/src/xcode/ENA/ENA/Source/Models/Metadata/Key Submission Metadata/__tests__/KeySubmissionMetadataTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Metadata/Key Submission Metadata/__tests__/KeySubmissionMetadataTests.swift
@@ -27,7 +27,8 @@ class KeySubmissionMetadataTests: XCTestCase {
 			hoursSinceTestResult: 0,
 			hoursSinceTestRegistration: 0,
 			daysSinceMostRecentDateAtRiskLevelAtTestRegistration: -1,
-			hoursSinceHighRiskWarningAtTestRegistration: -1)
+			hoursSinceHighRiskWarningAtTestRegistration: -1
+		)
 		Analytics.collect(.keySubmissionMetadata(.create(keySubmissionMetadata)))
 		Analytics.collect(.keySubmissionMetadata(.setDaysSinceMostRecentDateAtRiskLevelAtTestRegistration))
 		Analytics.collect(.keySubmissionMetadata(.setHoursSinceHighRiskWarningAtTestRegistration))

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/Model/PPADataType.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/Model/PPADataType.swift
@@ -9,7 +9,6 @@ import Foundation
 enum PPADataType {
 	case userData(PPAUserMetadata)
 	case riskExposureMetadata(PPARiskExposureMetadata)
-	case clientMetadata(PPAClientMetadata)
 	case testResultMetadata(PPATestResultMetadata)
 	case keySubmissionMetadata(PPAKeySubmissionMetadata)
 	case exposureWindowsMetadata(PPAExposureWindowsMetadata)
@@ -23,11 +22,6 @@ enum PPAUserMetadata {
 enum PPARiskExposureMetadata {
 	case create(RiskExposureMetadata)
 	case updateRiskExposureMetadata(RiskCalculationResult)
-}
-
-enum PPAClientMetadata {
-	case create(ClientMetadata)
-	case setClientMetaData
 }
 
 enum PPATestResultMetadata {

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -41,8 +41,6 @@ enum PPAnalyticsCollector {
 			Analytics.logUserMetadata(userMetadata)
 		case let .riskExposureMetadata(riskExposureMetadata):
 			Analytics.logRiskExposureMetadata(riskExposureMetadata)
-		case let .clientMetadata(clientMetadata):
-			Analytics.logClientMetadata(clientMetadata)
 		case let .testResultMetadata(TestResultMetadata):
 			Analytics.logTestResultMetadata(TestResultMetadata)
 		case let .keySubmissionMetadata(keySubmissionMetadata):
@@ -176,23 +174,6 @@ enum PPAnalyticsCollector {
 		Analytics.collect(.riskExposureMetadata(.create(newRiskExposureMetadata)))
 	}
 
-
-	// MARK: - ClientMetadata
-
-	private static func logClientMetadata(_ clientMetadata: PPAClientMetadata) {
-		switch clientMetadata {
-		case let .create(metaData):
-			store?.clientMetadata = metaData
-		case .setClientMetaData:
-			Analytics.setClientMetaData()
-		}
-	}
-
-	private static func setClientMetaData() {
-		let eTag = store?.appConfigMetadata?.lastAppConfigETag
-		Analytics.collect(.clientMetadata(.create(ClientMetadata(etag: eTag))))
-	}
-
 	// MARK: - TestResultMetadata
 
 	private static func logTestResultMetadata(_ TestResultMetadata: PPATestResultMetadata) {
@@ -234,7 +215,6 @@ enum PPAnalyticsCollector {
 			store?.testResultMetadata?.hoursSinceHighRiskWarningAtTestRegistration = -1
 		}
 	}
-	
 	private static func updateTestResult(_ testResult: TestResult, _ token: String) {
 		// we only save metadata for tests submitted on QR code,and there is the only place in the app where we set the registration date
 		guard store?.testResultMetadata?.testRegistrationToken == token,

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -359,7 +359,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		)
 	}
 	
-	private func gatherExposureRiskMetadata() -> [SAP_Internal_Ppdd_ExposureRiskMetadata] {
+	func gatherExposureRiskMetadata() -> [SAP_Internal_Ppdd_ExposureRiskMetadata] {
 		guard let storedUsageData = store.currentRiskExposureMetadata else {
 			return []
 		}
@@ -371,7 +371,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		}]
 	}
 	
-	private func gatherNewExposureWindows() -> [SAP_Internal_Ppdd_PPANewExposureWindow] {
+	func gatherNewExposureWindows() -> [SAP_Internal_Ppdd_PPANewExposureWindow] {
 		guard let exposureWindowsMetadata = store.exposureWindowsMetadata else {
 			return []
 		}
@@ -403,7 +403,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		return exposureWindowsMetadataProto
 	}
 	
-	private func gatherUserMetadata() -> SAP_Internal_Ppdd_PPAUserMetadata {
+	func gatherUserMetadata() -> SAP_Internal_Ppdd_PPAUserMetadata {
 		// According to the tech spec, grap the user metadata right before the submission. We do not use "Analytics.collect()" here because we are probably already inside this call. So if we would use the call here, we could produce a infinite loop.
 		store.userMetadata = store.userData
 		guard let storedUserData = store.userMetadata else {
@@ -423,7 +423,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		}
 	}
 	
-	private func gatherClientMetadata() -> SAP_Internal_Ppdd_PPAClientMetadataIOS {
+	func gatherClientMetadata() -> SAP_Internal_Ppdd_PPAClientMetadataIOS {
 		// According to the tech spec, grap the client metadata right before the submission. We do not use "Analytics.collect()" here because we are probably already inside this call. So if we would use the call here, we could produce a infinite loop.
 		let eTag = store.appConfigMetadata?.lastAppConfigETag
 		store.clientMetadata = ClientMetadata(etag: eTag)
@@ -444,7 +444,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 	}
 	
 	// swiftlint:disable:next cyclomatic_complexity
-	private func gatherKeySubmissionMetadata() -> [SAP_Internal_Ppdd_PPAKeySubmissionMetadata] {
+	func gatherKeySubmissionMetadata() -> [SAP_Internal_Ppdd_PPAKeySubmissionMetadata] {
 		guard let storedUsageData = store.keySubmissionMetadata else {
 			return []
 		}

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -483,7 +483,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		}]
 	}
 	
-	private func gatherTestResultMetadata() -> [SAP_Internal_Ppdd_PPATestResultMetadata] {
+	func gatherTestResultMetadata() -> [SAP_Internal_Ppdd_PPATestResultMetadata] {
 		let metadata = store.testResultMetadata
 		
 		let resultProtobuf = SAP_Internal_Ppdd_PPATestResultMetadata.with {

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -491,7 +491,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			if let testResult = metadata?.testResult?.protobuf {
 				$0.testResult = testResult
 			}
-			if let hoursSinceTestRegistration = metadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration {
+			if let hoursSinceTestRegistration = metadata?.hoursSinceTestRegistration {
 				$0.hoursSinceTestRegistration = Int32(hoursSinceTestRegistration)
 			}
 			if let riskLevel = metadata?.riskLevelAtTestRegistration?.protobuf {

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -381,22 +381,64 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		// THEN
 		XCTAssertEqual(expectation, SAP_Internal_Ppdd_PPARiskLevel.riskLevelHigh)
 	}
-	
-	func testGatherTestResultMetadata() {
-		// setup Submitter
+		
+	// MARK: - ProtoBuf Mapping
+
+	func testGatherUserMetadata() {
 		let store = MockTestStore()
+		let analyticsSubmitter = createMockSubmitter(with: store)
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
-		let client = ClientMock()
-		var config = SAP_Internal_V2_ApplicationConfigurationIOS()
-		let appConfigurationProvider = CachedAppConfigurationMock(with: config)
-		let analyticsSubmitter = PPAnalyticsSubmitter(
-			store: store,
-			client: client,
-			appConfig: appConfigurationProvider
-		)
 		
 		// Setup Collector
-		Analytics.setupMock(store: store,submitter: analyticsSubmitter)
+		Analytics.setupMock(store: store, submitter: analyticsSubmitter)
+
+		// collect userMetadata
+		let state: FederalStateName = .badenWürttemberg
+		let ageGroup: AgeGroup = .ageBelow29
+		let administrativeUnit = 4
+		
+		store.userData = UserMetadata(
+			federalState: state,
+			administrativeUnit: administrativeUnit,
+			ageGroup: ageGroup)
+		
+		let protobuf = analyticsSubmitter.gatherUserMetadata()
+		XCTAssertNotNil(store.userMetadata, "userMetadata should be allocated")
+
+		XCTAssertEqual(protobuf.federalState, state.protobuf, "Wrong Registration date")
+		XCTAssertEqual(protobuf.ageGroup, ageGroup.protobuf, "Wrong Registration date")
+		XCTAssertEqual(protobuf.administrativeUnit, Int32(administrativeUnit), "Wrong Registration date")
+	}
+	
+	func testGatherClientMetadata() {
+		
+		let eTag = "123"
+		let store = MockTestStore()
+		store.appConfigMetadata = AppConfigMetadata(
+			lastAppConfigETag: eTag,
+			lastAppConfigFetch: Date(),
+			appConfig: SAP_Internal_V2_ApplicationConfigurationIOS()
+		)
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
+		
+		let analyticsSubmitter = createMockSubmitter(with: store)
+		let clientMetadata = ClientMetadata(etag: eTag)
+		let protobuf = analyticsSubmitter.gatherClientMetadata()
+		
+		XCTAssertNotNil(store.clientMetadata, "clientMetadata should be allocated")
+		XCTAssertEqual(protobuf.appConfigEtag, eTag, "eTag not equal clientMetaData eTag")
+		XCTAssertEqual(protobuf.cwaVersion, clientMetadata.cwaVersion?.protobuf, "cwaVersion not equal clientMetaData cwaVersion")
+		XCTAssertEqual(protobuf.iosVersion, clientMetadata.iosVersion.protobuf, "iosVersion not equal clientMetaData iosVersion")
+	}
+	
+	func testGatherTestResultMetadata() {
+		let store = MockTestStore()
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
+		let analyticsSubmitter = createMockSubmitter(with: store)
+
+		// Setup Collector
+		
+		Analytics.setupMock(store: store, submitter: analyticsSubmitter)
 		
 		// collect testResultMetadata
 		
@@ -404,7 +446,6 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		let registrationDate = Calendar.current.date(byAdding: .day, value: -10, to: today) ?? Date()
 		let mostRecentDayWithRisk = Calendar.current.date(byAdding: .day, value: -5, to: today)
 		let dateOfRiskChangeToHigh = Calendar.current.date(byAdding: .day, value: -12, to: today)
-		
 		let registrationToken = "123"
 		let testResult: TestResult = .negative
 		let numberOfDaysWithHightRisk = 25
@@ -427,48 +468,194 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		store.riskCalculationResult = riskCalculationResult
 		store.dateOfConversionToHighRisk = dateOfRiskChangeToHigh
 		
-		
-		// Test Saving Value To Store Correctly
+		let metadata = store.testResultMetadata
 		Analytics.collect(.testResultMetadata(.registerNewTestMetadata(registrationDate, registrationToken)))
-		
-		XCTAssertEqual(store.testResultMetadata?.testRegistrationDate, registrationDate, "Wrong Registration date")
-		XCTAssertEqual(store.testResultMetadata?.riskLevelAtTestRegistration, riskLevel, "Wrong Risk Level")
-		XCTAssertEqual(store.testResultMetadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, numberOfDaysWithHightRisk, "Wrong number of days with this risk level")
-		XCTAssertEqual(store.testResultMetadata?.hoursSinceHighRiskWarningAtTestRegistration, differenceInHoursBetweenChangeToHighRiskAndRegistrationDate, "Wrong difference hoursSinceHighRiskWarningAtTestRegistration")
+		XCTAssertEqual(metadata?.testRegistrationDate, registrationDate, "Wrong Registration date")
+		XCTAssertEqual(metadata?.riskLevelAtTestRegistration, riskLevel, "Wrong Risk Level")
+		XCTAssertEqual(metadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, numberOfDaysWithHightRisk, "Wrong number of days with this risk level")
+		XCTAssertEqual(metadata?.hoursSinceHighRiskWarningAtTestRegistration, differenceInHoursBetweenChangeToHighRiskAndRegistrationDate, "Wrong difference hoursSinceHighRiskWarningAtTestRegistration")
 
 		Analytics.collect(.testResultMetadata(.updateTestResult(testResult, registrationToken)))
-		
-		XCTAssertEqual(store.testResultMetadata?.testResult, testResult, "Wrong TestResult")
-		XCTAssertEqual(store.testResultMetadata?.hoursSinceTestRegistration, differenceInHoursBetweenRegistrationDateAndTestResult, "Wrong difference hoursSinceTestRegistration")
+		XCTAssertEqual(metadata?.testResult, testResult, "Wrong TestResult")
+		XCTAssertEqual(metadata?.hoursSinceTestRegistration, differenceInHoursBetweenRegistrationDateAndTestResult, "Wrong difference hoursSinceTestRegistration")
 
-		// Test mapping to protobuf
-
-		let protobuf = analyticsSubmitter.gatherTestResultMetadata()
+		// Mapping to protobuf
+		let protobuf = analyticsSubmitter.gatherTestResultMetadata().first
 		XCTAssertEqual(
 			store.testResultMetadata?.testResult?.protobuf,
-			protobuf.first?.testResult,
+			protobuf?.testResult,
 			"Wrong testResult protobuf mapping"
 		)
 		XCTAssertEqual(
 			store.testResultMetadata?.hoursSinceTestRegistration,
-			Int(protobuf.first?.hoursSinceTestRegistration ?? -1),
+			Int(protobuf?.hoursSinceTestRegistration ?? -1),
 			"Wrong hoursSinceTestRegistration protobuf mapping"
 		)
 		XCTAssertEqual(
 			store.testResultMetadata?.riskLevelAtTestRegistration?.protobuf,
-			protobuf.first?.riskLevelAtTestRegistration,
+			protobuf?.riskLevelAtTestRegistration,
 			"Wrong riskLevelAtTestRegistration protobuf mapping"
 		)
 		XCTAssertEqual(
 			store.testResultMetadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration,
-			Int(protobuf.first?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration ?? -1),
+			Int(protobuf?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration ?? -1),
 			"Wrong daysSinceMostRecentDateAtRiskLevelAtTestRegistration protobuf mapping"
 		)
 		XCTAssertEqual(
 			store.testResultMetadata?.hoursSinceHighRiskWarningAtTestRegistration,
-			Int(protobuf.first?.hoursSinceHighRiskWarningAtTestRegistration ?? -1),
+			Int(protobuf?.hoursSinceHighRiskWarningAtTestRegistration ?? -1),
 			"Wrong hoursSinceHighRiskWarningAtTestRegistration protobuf mapping"
 		)
+	}
+	
+	func testGatherRiskExposureMetadata() {
+		let store = MockTestStore()
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
+		let analyticsSubmitter = createMockSubmitter(with: store)
+
+		// Setup Collector
+		Analytics.setupMock(store: store, submitter: analyticsSubmitter)
+		
+		// Collect RiskExposureMetadata
+		let numberOfDaysWithHightRisk = 25
+		let riskLevel: RiskLevel = .high
+		let mostRecentDayWithRisk = Calendar.current.date(byAdding: .day, value: -5, to: Date())
+
+		let riskCalculationResult = RiskCalculationResult(
+			riskLevel: riskLevel,
+			minimumDistinctEncountersWithLowRisk: 6,
+			minimumDistinctEncountersWithHighRisk: 2,
+			mostRecentDateWithLowRisk: nil,
+			mostRecentDateWithHighRisk: mostRecentDayWithRisk,
+			numberOfDaysWithLowRisk: 0,
+			numberOfDaysWithHighRisk: numberOfDaysWithHightRisk,
+			calculationDate: Date(),
+			riskLevelPerDate: [:],
+			minimumDistinctEncountersWithHighRiskPerDate: [:]
+		)
+
+		let metadata = store.currentRiskExposureMetadata
+		Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
+		XCTAssertNotNil(store.currentRiskExposureMetadata, "riskMetadata should be allocated")
+		XCTAssertEqual(metadata?.riskLevel, riskLevel, "Wrong riskLevel")
+		XCTAssertEqual(metadata?.riskLevelChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
+		XCTAssertEqual(metadata?.dateChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
+		
+		// Mapping to protobuf
+		let protobuf = analyticsSubmitter.gatherExposureRiskMetadata()
+		XCTAssertFalse(protobuf.isEmpty, "There should be at least one item in the array")
+		XCTAssertEqual(protobuf.first?.riskLevel, riskLevel.protobuf, "Wrong riskLevel mapped")
+		XCTAssertEqual(protobuf.first?.riskLevelChangedComparedToPreviousSubmission, metadata?.riskLevelChangedComparedToPreviousSubmission, "Wrong riskLevelChangedComparedToPreviousSubmission")
+		XCTAssertEqual(protobuf.first?.mostRecentDateAtRiskLevel, formatToUnixTimestamp(for: metadata?.mostRecentDateAtRiskLevel), "Wrong mostRecentDateAtRiskLevel")
+		XCTAssertEqual(protobuf.first?.dateChangedComparedToPreviousSubmission, metadata?.dateChangedComparedToPreviousSubmission, "Wrong dateChangedComparedToPreviousSubmission")
+	}
+	
+	func testGatherExposureWindowsMetadata() {
+		let store = MockTestStore()
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
+		let analyticsSubmitter = createMockSubmitter(with: store)
+
+		// Setup Collector
+		Analytics.setupMock(store: store, submitter: analyticsSubmitter)
+		
+		// collect exposureWindowsMetadata
+		Analytics.collect(.exposureWindowsMetadata(.collectExposureWindows(mappedExposureWindows)))
+		let mappedSubmissionExposureWindows: [SubmissionExposureWindow] = mappedExposureWindows.map {
+			SubmissionExposureWindow(
+				exposureWindow: $0.exposureWindow,
+				transmissionRiskLevel: $0.transmissionRiskLevel,
+				normalizedTime: $0.normalizedTime,
+				hash: generateSHA256($0.exposureWindow),
+				date: $0.date
+			)
+		}
+		
+		let metadata = store.exposureWindowsMetadata
+		XCTAssertEqual(metadata?.newExposureWindowsQueue, mappedSubmissionExposureWindows, "Wrong newExposureWindowsQueue")
+		XCTAssertEqual(metadata?.reportedExposureWindowsQueue, mappedSubmissionExposureWindows, "Wrong reportedExposureWindowsQueue")
+
+		// Mapping to protobuf
+		let protobuf = analyticsSubmitter.gatherNewExposureWindows()
+		
+		for index in protobuf.indices {
+			XCTAssertEqual(protobuf[index].normalizedTime, mappedSubmissionExposureWindows[index].normalizedTime, "Wrong normalizedTime")
+			XCTAssertEqual(protobuf[index].transmissionRiskLevel, Int32(mappedSubmissionExposureWindows[index].transmissionRiskLevel), "Wrong transmissionRiskLevel")
+			XCTAssertEqual(protobuf[index].exposureWindow.calibrationConfidence, Int32(mappedSubmissionExposureWindows[index].exposureWindow.calibrationConfidence.rawValue), "Wrong calibrationConfidence")
+			XCTAssertEqual(protobuf[index].exposureWindow.infectiousness, mappedSubmissionExposureWindows[index].exposureWindow.infectiousness.protobuf, "Wrong infectiousness")
+			XCTAssertEqual(protobuf[index].exposureWindow.reportType, mappedSubmissionExposureWindows[index].exposureWindow.reportType.protobuf, "Wrong reportType")
+			XCTAssertEqual(protobuf[index].exposureWindow.date, Int64(mappedSubmissionExposureWindows[index].exposureWindow.date.timeIntervalSince1970), "Wrong date")
+			XCTAssertEqual(protobuf[index].exposureWindow.scanInstances.count, mappedSubmissionExposureWindows[index].exposureWindow.scanInstances.count, "Wrong scanInstances.count")
+
+			for (scanInstancesIndex, scanInstance)  in protobuf[index].exposureWindow.scanInstances.enumerated() {
+				XCTAssertEqual(scanInstance.minAttenuation, Int32(mappedSubmissionExposureWindows[index].exposureWindow.scanInstances[scanInstancesIndex].minAttenuation), "Wrong minAttenuation")
+				XCTAssertEqual(scanInstance.secondsSinceLastScan, Int32(mappedSubmissionExposureWindows[index].exposureWindow.scanInstances[scanInstancesIndex].secondsSinceLastScan), "Wrong secondsSinceLastScan")
+				XCTAssertEqual(scanInstance.typicalAttenuation, Int32(mappedSubmissionExposureWindows[index].exposureWindow.scanInstances[scanInstancesIndex].typicalAttenuation), "Wrong typicalAttenuation")
+			}
+		}
+	}
+	
+	func testGatherKeySubmissionMetadata() {
+		let store = MockTestStore()
+		store.isPrivacyPreservingAnalyticsConsentGiven = true
+		let analyticsSubmitter = createMockSubmitter(with: store)
+
+		// Setup Collector
+		Analytics.setupMock(store: store, submitter: analyticsSubmitter)
+		
+		// collect keySubmissionMetadata
+		let keySubmissionMetadata = KeySubmissionMetadata(
+			submitted: false,
+			submittedInBackground: false,
+			submittedAfterCancel: false,
+			submittedAfterSymptomFlow: false,
+			lastSubmissionFlowScreen: .submissionFlowScreenUnknown,
+			advancedConsentGiven: true,
+			hoursSinceTestResult: 0,
+			hoursSinceTestRegistration: 0,
+			daysSinceMostRecentDateAtRiskLevelAtTestRegistration: -1,
+			hoursSinceHighRiskWarningAtTestRegistration: -1
+		)
+		
+		let lastScreen: LastSubmissionFlowScreen = .submissionFlowScreenOther
+		Analytics.collect(.keySubmissionMetadata(.create(keySubmissionMetadata)))
+		Analytics.collect(.keySubmissionMetadata(.submitted(true)))
+		Analytics.collect(.keySubmissionMetadata(.submittedInBackground(true)))
+		Analytics.collect(.keySubmissionMetadata(.submittedAfterCancel(true)))
+		Analytics.collect(.keySubmissionMetadata(.submittedAfterSymptomFlow(true)))
+		Analytics.collect(.keySubmissionMetadata(.submittedWithTeletan(false)))
+		Analytics.collect(.keySubmissionMetadata(.lastSubmissionFlowScreen(lastScreen)))
+		Analytics.collect(.keySubmissionMetadata(.advancedConsentGiven(true)))
+		Analytics.collect(.keySubmissionMetadata(.hoursSinceTestResult(5)))
+		Analytics.collect(.keySubmissionMetadata(.keySubmissionHoursSinceTestRegistration(9)))
+		Analytics.collect(.keySubmissionMetadata(.daysSinceMostRecentDateAtRiskLevelAtTestRegistration(74)))
+		Analytics.collect(.keySubmissionMetadata(.hoursSinceHighRiskWarningAtTestRegistration(53)))
+
+		let metadata = store.keySubmissionMetadata
+		XCTAssertNotNil(metadata, "keySubmissionMetadata should be allocated")
+		XCTAssertEqual(metadata?.submitted, true, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.submittedInBackground, true, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.submittedAfterCancel, true, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.submittedAfterSymptomFlow, true, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.lastSubmissionFlowScreen, lastScreen, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.advancedConsentGiven, true, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.hoursSinceTestResult, 5, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.hoursSinceTestRegistration, 9, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, 74, "Wrong keySubmissionMetadata")
+		XCTAssertEqual(metadata?.hoursSinceHighRiskWarningAtTestRegistration, 53, "Wrong keySubmissionMetadata")
+		
+		// Mapping to protobuf
+		let protobuf = analyticsSubmitter.gatherKeySubmissionMetadata().first
+		XCTAssertEqual(protobuf?.submitted, metadata?.submitted, "Wrong submitted")
+		XCTAssertEqual(protobuf?.submittedInBackground, metadata?.submittedInBackground, "Wrong submittedInBackground")
+		XCTAssertEqual(protobuf?.submittedAfterCancel, metadata?.submittedAfterCancel, "Wrong submittedAfterCancel")
+		XCTAssertEqual(protobuf?.submittedAfterSymptomFlow, metadata?.submittedAfterSymptomFlow, "Wrong submittedAfterSymptomFlow")
+		XCTAssertEqual(protobuf?.advancedConsentGiven, metadata?.advancedConsentGiven, "Wrong advancedConsentGiven")
+		XCTAssertEqual(protobuf?.lastSubmissionFlowScreen, metadata?.lastSubmissionFlowScreen?.protobuf, "Wrong lastSubmissionFlowScreen")
+		XCTAssertEqual(protobuf?.hoursSinceTestResult, metadata?.hoursSinceTestResult, "Wrong hoursSinceTestResult")
+		XCTAssertEqual(protobuf?.hoursSinceTestRegistration, metadata?.hoursSinceTestRegistration, "Wrong hoursSinceTestRegistration")
+		XCTAssertEqual(protobuf?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, metadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, "Wrong daysSinceMostRecentDateAtRiskLevelAtTestRegistration")
+		XCTAssertEqual(protobuf?.hoursSinceHighRiskWarningAtTestRegistration, metadata?.hoursSinceHighRiskWarningAtTestRegistration, "Wrong hoursSinceHighRiskWarningAtTestRegistration")
+		XCTAssertNotEqual(protobuf?.submittedWithTeleTan, store.submittedWithQR, "Wrong submittedWithTeleTan")
 	}
 	
 	// MARK: - Helpers
@@ -502,4 +689,40 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		}
 		return Int64(date.timeIntervalSince1970)
 	}
+	
+	private var mappedExposureWindows: [RiskCalculationExposureWindow] = [
+		RiskCalculationExposureWindow(
+			exposureWindow: ExposureWindow(
+				calibrationConfidence: .high,
+				date: Date(),
+				reportType: .confirmedClinicalDiagnosis,
+				infectiousness: .high,
+				scanInstances: []
+			),
+			configuration: RiskCalculationConfiguration(
+				from: SAP_Internal_V2_ApplicationConfigurationIOS().riskCalculationParameters)
+		),
+		RiskCalculationExposureWindow(
+			exposureWindow: ExposureWindow(
+				calibrationConfidence: .low,
+				date: Date(),
+				reportType: .confirmedClinicalDiagnosis,
+				infectiousness: .high,
+				scanInstances: []
+			),
+			configuration: RiskCalculationConfiguration(
+				from: SAP_Internal_V2_ApplicationConfigurationIOS().riskCalculationParameters)
+		),
+		RiskCalculationExposureWindow(
+			exposureWindow: ExposureWindow(
+				calibrationConfidence: .medium,
+				date: Date(),
+				reportType: .confirmedClinicalDiagnosis,
+				infectiousness: .high,
+				scanInstances: []
+			),
+			configuration: RiskCalculationConfiguration(
+				from: SAP_Internal_V2_ApplicationConfigurationIOS().riskCalculationParameters)
+		)
+	]
 }

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -470,4 +470,36 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 			"Wrong hoursSinceHighRiskWarningAtTestRegistration protobuf mapping"
 		)
 	}
+	
+	// MARK: - Helpers
+	
+	private func createMockSubmitter(with store: MockTestStore) -> PPAnalyticsSubmitter {
+		let client = ClientMock()
+		let config = SAP_Internal_V2_ApplicationConfigurationIOS()
+		let appConfigurationProvider = CachedAppConfigurationMock(with: config)
+		return PPAnalyticsSubmitter(
+			store: store,
+			client: client,
+			appConfig: appConfigurationProvider
+		)
+	}
+
+	private func generateSHA256(_ window: ExposureWindow) -> String? {
+		let encoder = JSONEncoder()
+		do {
+			let windowData = try encoder.encode(window)
+			return windowData.sha256String()
+		} catch {
+			Log.error("ExposureWindow Encoding error", log: .ppa, error: error)
+		}
+		return nil
+	}
+	
+	private func formatToUnixTimestamp(for date: Date?) -> Int64 {
+		guard let date = date else {
+			Log.warning("mostRecentDate is nil", log: .ppa)
+			return -1
+		}
+		return Int64(date.timeIntervalSince1970)
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -5,6 +5,8 @@
 import XCTest
 @testable import ENA
 
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
 class PPAnalyticsSubmitterTests: XCTestCase {
 
 	// MARK: - Success

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -468,16 +468,15 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		store.riskCalculationResult = riskCalculationResult
 		store.dateOfConversionToHighRisk = dateOfRiskChangeToHigh
 		
-		let metadata = store.testResultMetadata
 		Analytics.collect(.testResultMetadata(.registerNewTestMetadata(registrationDate, registrationToken)))
-		XCTAssertEqual(metadata?.testRegistrationDate, registrationDate, "Wrong Registration date")
-		XCTAssertEqual(metadata?.riskLevelAtTestRegistration, riskLevel, "Wrong Risk Level")
-		XCTAssertEqual(metadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, numberOfDaysWithHightRisk, "Wrong number of days with this risk level")
-		XCTAssertEqual(metadata?.hoursSinceHighRiskWarningAtTestRegistration, differenceInHoursBetweenChangeToHighRiskAndRegistrationDate, "Wrong difference hoursSinceHighRiskWarningAtTestRegistration")
+		XCTAssertEqual(store.testResultMetadata?.testRegistrationDate, registrationDate, "Wrong Registration date")
+		XCTAssertEqual(store.testResultMetadata?.riskLevelAtTestRegistration, riskLevel, "Wrong Risk Level")
+		XCTAssertEqual(store.testResultMetadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, numberOfDaysWithHightRisk, "Wrong number of days with this risk level")
+		XCTAssertEqual(store.testResultMetadata?.hoursSinceHighRiskWarningAtTestRegistration, differenceInHoursBetweenChangeToHighRiskAndRegistrationDate, "Wrong difference hoursSinceHighRiskWarningAtTestRegistration")
 
 		Analytics.collect(.testResultMetadata(.updateTestResult(testResult, registrationToken)))
-		XCTAssertEqual(metadata?.testResult, testResult, "Wrong TestResult")
-		XCTAssertEqual(metadata?.hoursSinceTestRegistration, differenceInHoursBetweenRegistrationDateAndTestResult, "Wrong difference hoursSinceTestRegistration")
+		XCTAssertEqual(store.testResultMetadata?.testResult, testResult, "Wrong TestResult")
+		XCTAssertEqual(store.testResultMetadata?.hoursSinceTestRegistration, differenceInHoursBetweenRegistrationDateAndTestResult, "Wrong difference hoursSinceTestRegistration")
 
 		// Mapping to protobuf
 		let protobuf = analyticsSubmitter.gatherTestResultMetadata().first
@@ -534,20 +533,19 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 			minimumDistinctEncountersWithHighRiskPerDate: [:]
 		)
 
-		let metadata = store.currentRiskExposureMetadata
 		Analytics.collect(.riskExposureMetadata(.updateRiskExposureMetadata(riskCalculationResult)))
 		XCTAssertNotNil(store.currentRiskExposureMetadata, "riskMetadata should be allocated")
-		XCTAssertEqual(metadata?.riskLevel, riskLevel, "Wrong riskLevel")
-		XCTAssertEqual(metadata?.riskLevelChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
-		XCTAssertEqual(metadata?.dateChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
+		XCTAssertEqual(store.currentRiskExposureMetadata?.riskLevel, riskLevel, "Wrong riskLevel")
+		XCTAssertEqual(store.currentRiskExposureMetadata?.riskLevelChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
+		XCTAssertEqual(store.currentRiskExposureMetadata?.dateChangedComparedToPreviousSubmission, false, "should be false as this is the first submission")
 		
 		// Mapping to protobuf
 		let protobuf = analyticsSubmitter.gatherExposureRiskMetadata()
 		XCTAssertFalse(protobuf.isEmpty, "There should be at least one item in the array")
 		XCTAssertEqual(protobuf.first?.riskLevel, riskLevel.protobuf, "Wrong riskLevel mapped")
-		XCTAssertEqual(protobuf.first?.riskLevelChangedComparedToPreviousSubmission, metadata?.riskLevelChangedComparedToPreviousSubmission, "Wrong riskLevelChangedComparedToPreviousSubmission")
-		XCTAssertEqual(protobuf.first?.mostRecentDateAtRiskLevel, formatToUnixTimestamp(for: metadata?.mostRecentDateAtRiskLevel), "Wrong mostRecentDateAtRiskLevel")
-		XCTAssertEqual(protobuf.first?.dateChangedComparedToPreviousSubmission, metadata?.dateChangedComparedToPreviousSubmission, "Wrong dateChangedComparedToPreviousSubmission")
+		XCTAssertEqual(protobuf.first?.riskLevelChangedComparedToPreviousSubmission, store.currentRiskExposureMetadata?.riskLevelChangedComparedToPreviousSubmission, "Wrong riskLevelChangedComparedToPreviousSubmission")
+		XCTAssertEqual(protobuf.first?.mostRecentDateAtRiskLevel, formatToUnixTimestamp(for: store.currentRiskExposureMetadata?.mostRecentDateAtRiskLevel), "Wrong mostRecentDateAtRiskLevel")
+		XCTAssertEqual(protobuf.first?.dateChangedComparedToPreviousSubmission, store.currentRiskExposureMetadata?.dateChangedComparedToPreviousSubmission, "Wrong dateChangedComparedToPreviousSubmission")
 	}
 	
 	func testGatherExposureWindowsMetadata() {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/Models/ExposureWindow.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/Models/ExposureWindow.swift
@@ -9,7 +9,7 @@ extension ENCalibrationConfidence: Codable { }
 extension ENDiagnosisReportType: Codable { }
 extension ENInfectiousness: Codable { }
 
-struct ExposureWindow: Codable {
+struct ExposureWindow: Codable, Equatable {
 
 	// MARK: - Init
 
@@ -40,6 +40,16 @@ struct ExposureWindow: Codable {
 	enum CodingKeys: String, CodingKey {
 		case calibrationConfidence, reportType, infectiousness, scanInstances
 		case date = "ageInDays"
+	}
+
+	// MARK: - Protocol Equatable
+
+	static func == (lhs: ExposureWindow, rhs: ExposureWindow) -> Bool {
+		return  lhs.calibrationConfidence == rhs.calibrationConfidence &&
+			lhs.date == rhs.date &&
+			lhs.reportType == rhs.reportType &&
+			lhs.infectiousness == rhs.infectiousness &&
+			lhs.scanInstances == rhs.scanInstances
 	}
 
 	init(from decoder: Decoder) throws {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/Models/ScanInstance.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Calculation/Models/ScanInstance.swift
@@ -5,7 +5,7 @@
 import Foundation
 import ExposureNotification
 
-struct ScanInstance: Codable {
+struct ScanInstance: Codable, Equatable {
 
 	// MARK: - Init
 
@@ -13,6 +13,14 @@ struct ScanInstance: Codable {
 		minAttenuation = scanInstance.minimumAttenuation
 		typicalAttenuation = scanInstance.typicalAttenuation
 		secondsSinceLastScan = scanInstance.secondsSinceLastScan
+	}
+
+	// MARK: - Protocol Equatable
+
+	static func == (lhs: ScanInstance, rhs: ScanInstance) -> Bool {
+		return  lhs.minAttenuation == rhs.minAttenuation &&
+			lhs.typicalAttenuation == rhs.typicalAttenuation &&
+			lhs.secondsSinceLastScan == rhs.secondsSinceLastScan
 	}
 
 	// MARK: - Internal


### PR DESCRIPTION
## Description
PPA hoursSinceTestRegistration are not recieving the correct values

1- the bug was fixed by sending the correct parameter in the protobuf mapper
2- I also added more in depth tests that cover the **creation, persistence and mapping** of each metadata metric in once cycle so we can:

- compare what we saved compared to what we expected
- compare what was mapped to protobuf compared to what was saved.

NOTE: I completely removed the the **Log(ClientMetadata) parts** because it is only used in one unit test, while we create the actual data in the submitter not in the collector since all the parameters are from the system (example: iOS version, app version, etc
)
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5899

