### PR TITLE
Screen "andere warnen" scrolls up if you navigate back from "Datenschutz"

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -362,6 +362,7 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 	}
 
 	private func showQRInfoScreen(supportedCountries: [Country]) {
+		
 		let vc = ExposureSubmissionQRInfoViewController(
 			supportedCountries: supportedCountries,
 			onPrimaryButtonTap: { [weak self] isLoading in
@@ -394,8 +395,22 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 			},
 			dismiss: { [weak self] in self?.dismiss() }
 		)
-
-		push(vc)
+		
+		let footerViewController = FooterViewController(
+			FooterViewModel(
+				primaryButtonName: AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle,
+				primaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.primaryButton,
+				isSecondaryButtonEnabled: false,
+				isSecondaryButtonHidden: true
+			)
+		)
+		
+		let topBottomContainerViewController = TopBottomContainerViewController(
+			topController: vc,
+			bottomController: footerViewController
+		)
+		
+		push(topBottomContainerViewController)
 	}
 
 	private func showQRScreen(isLoading: @escaping (Bool) -> Void) {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -400,6 +400,7 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 			FooterViewModel(
 				primaryButtonName: AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle,
 				primaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.primaryButton,
+				secondaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.secondaryButton,
 				isSecondaryButtonEnabled: false,
 				isSecondaryButtonHidden: true
 			)
@@ -517,8 +518,23 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 			},
 			dismiss: { [weak self] in self?.dismiss() }
 		)
-
-		push(vc)
+		
+		let footerViewController = FooterViewController(
+			FooterViewModel(
+				primaryButtonName: AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle,
+				primaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.primaryButton,
+				secondaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.secondaryButton,
+				isSecondaryButtonEnabled: false,
+				isSecondaryButtonHidden: true
+			)
+		)
+		
+		let topBottomContainerViewController = TopBottomContainerViewController(
+			topController: vc,
+			bottomController: footerViewController
+		)
+		
+		push(topBottomContainerViewController)
 	}
 
 	private func showThankYouScreen() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -303,7 +303,7 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 		)
 	}
 
-	private func createWarnOthersViewController() -> ExposureSubmissionWarnOthersViewController {
+	private func createWarnOthersViewController() -> UIViewController {
 		Analytics.collect(.keySubmissionMetadata(.lastSubmissionFlowScreen(.submissionFlowScreenWarnOthers)))
 
 		// ugly but works for the moment
@@ -331,7 +331,23 @@ class ExposureSubmissionCoordinator: NSObject, ExposureSubmissionCoordinating, R
 			},
 			dismiss: { [weak self] in self?.dismiss() }
 		)
-		return vc
+		
+		let footerViewController = FooterViewController(
+			FooterViewModel(
+				primaryButtonName: AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle,
+				primaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.primaryButton,
+				secondaryIdentifier: AccessibilityIdentifiers.ExposureSubmission.secondaryButton,
+				isSecondaryButtonEnabled: false,
+				isSecondaryButtonHidden: true
+			)
+		)
+		
+		let topBottomContainerViewController = TopBottomContainerViewController(
+			topController: vc,
+			bottomController: footerViewController
+		)
+		
+		return topBottomContainerViewController
 	}
 
 	// MARK: Screen Flow

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewController.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UIKit
 
-class ExposureSubmissionQRInfoViewController: DynamicTableViewController, ENANavigationControllerWithFooterChild {
+class ExposureSubmissionQRInfoViewController: DynamicTableViewController, FooterViewHandling {
 	
 	// MARK: - Init
 	
@@ -16,9 +16,8 @@ class ExposureSubmissionQRInfoViewController: DynamicTableViewController, ENANav
 	) {
 		self.viewModel = ExposureSubmissionQRInfoViewModel(supportedCountries: supportedCountries)
 		self.onPrimaryButtonTap = onPrimaryButtonTap
-
+		self.dismiss = dismiss
 		super.init(nibName: nil, bundle: nil)
-		navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
 	}
 
 	@available(*, unavailable)
@@ -30,25 +29,15 @@ class ExposureSubmissionQRInfoViewController: DynamicTableViewController, ENANav
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-
 		setupView()
-
-		footerView?.primaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.primaryButton
-		footerView?.secondaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.secondaryButton
-		footerView?.isHidden = false
 	}
 
-	override var navigationItem: UINavigationItem {
-		navigationFooterItem
-	}
+	// MARK: - Protocol FooterViewHandling
 
-	// MARK: - Protocol ENANavigationControllerWithFooterChild
-
-	func navigationController(_ navigationController: ENANavigationControllerWithFooter, didTapPrimaryButton button: UIButton) {
+	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		onPrimaryButtonTap { [weak self] isLoading in
 			DispatchQueue.main.async {
-				self?.navigationFooterItem?.isPrimaryButtonLoading = isLoading
-				self?.navigationFooterItem?.isPrimaryButtonEnabled = !isLoading
+				self?.footerView?.setLoadingIndicator(isLoading, disable: !isLoading, button: .primary)
 			}
 		}
 	}
@@ -64,20 +53,13 @@ class ExposureSubmissionQRInfoViewController: DynamicTableViewController, ENANav
 
 	private let viewModel: ExposureSubmissionQRInfoViewModel
 	private let onPrimaryButtonTap: (@escaping (Bool) -> Void) -> Void
-
-	private lazy var navigationFooterItem: ENANavigationFooterItem = {
-		let item = ENANavigationFooterItem()
-
-		item.primaryButtonTitle = AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle
-		item.isPrimaryButtonEnabled = true
-		item.isSecondaryButtonHidden = true
-
-		item.title = AppStrings.ExposureSubmissionQRInfo.title
-
-		return item
-	}()
-
+	private let dismiss: () -> Void
+	
 	private func setupView() {
+		
+		parent?.navigationItem.title = AppStrings.ExposureSubmissionQRInfo.title
+		parent?.navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
+		
 		view.backgroundColor = .enaColor(for: .background)
 
 		tableView.register(

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionQRInfoViewController.swift
@@ -37,7 +37,7 @@ class ExposureSubmissionQRInfoViewController: DynamicTableViewController, Footer
 	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		onPrimaryButtonTap { [weak self] isLoading in
 			DispatchQueue.main.async {
-				self?.footerView?.setLoadingIndicator(isLoading, disable: !isLoading, button: .primary)
+				self?.footerView?.setLoadingIndicator(isLoading, disable: isLoading, button: .primary)
 			}
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
@@ -5,7 +5,7 @@
 import Foundation
 import UIKit
 
-class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, ENANavigationControllerWithFooterChild {
+class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, FooterViewHandling {
 	
 	// MARK: - Init
 
@@ -16,8 +16,8 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, EN
 	) {
 		self.viewModel = viewModel
 		self.onPrimaryButtonTap = onPrimaryButtonTap
+		self.dismiss = dismiss
 		super.init(nibName: nil, bundle: nil)
-		navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
 	}
 
 	@available(*, unavailable)
@@ -29,25 +29,15 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, EN
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-
 		setupView()
-		
-		footerView?.primaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.primaryButton
-		footerView?.secondaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.ExposureSubmission.secondaryButton
-		footerView?.isHidden = false
 	}
 
-	override var navigationItem: UINavigationItem {
-		navigationFooterItem
-	}
+	// MARK: - Protocol FooterViewHandling
 
-	// MARK: - Protocol ENANavigationControllerWithFooterChild
-
-	func navigationController(_ navigationController: ENANavigationControllerWithFooter, didTapPrimaryButton button: UIButton) {
+	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		onPrimaryButtonTap { [weak self] isLoading in
 			DispatchQueue.main.async {
-				self?.navigationFooterItem?.isPrimaryButtonLoading = isLoading
-				self?.navigationFooterItem?.isPrimaryButtonEnabled = !isLoading
+				self?.footerView?.setLoadingIndicator(isLoading, disable: !isLoading, button: .primary)
 			}
 		}
 	}
@@ -63,21 +53,14 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, EN
 
 	private let viewModel: ExposureSubmissionWarnOthersViewModel
 	private let onPrimaryButtonTap: (@escaping (Bool) -> Void) -> Void
-
-	private lazy var navigationFooterItem: ENANavigationFooterItem = {
-		let item = ENANavigationFooterItem()
-
-		item.primaryButtonTitle = AppStrings.ExposureSubmissionQRInfo.primaryButtonTitle
-		item.isPrimaryButtonEnabled = true
-		item.isSecondaryButtonHidden = true
-		item.hidesBackButton = true
-
-		item.title = AppStrings.ExposureSubmissionWarnOthers.title
-
-		return item
-	}()
+	private let dismiss: () -> Void
 
 	private func setupView() {
+		
+		parent?.navigationItem.title = AppStrings.ExposureSubmissionWarnOthers.title
+		parent?.navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
+		parent?.navigationItem.hidesBackButton = true
+				
 		view.backgroundColor = .enaColor(for: .background)
 
 		tableView.register(

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
@@ -37,7 +37,7 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, Fo
 	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		onPrimaryButtonTap { [weak self] isLoading in
 			DispatchQueue.main.async {
-				self?.footerView?.setLoadingIndicator(isLoading, disable: !isLoading, button: .primary)
+				self?.footerView?.setLoadingIndicator(isLoading, disable: isLoading, button: .primary)
 			}
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorTests.swift
@@ -165,6 +165,6 @@ class ExposureSubmissionCoordinatorTests: XCTestCase {
 		store.positiveTestResultWasShown = true
 
 		let positive = coordinator.getInitialViewController(with: .positive)
-		XCTAssertTrue(positive.self is ExposureSubmissionWarnOthersViewController)
+		XCTAssertTrue(positive is TopBottomContainerViewController<ExposureSubmissionWarnOthersViewController, FooterViewController>)
 	}
 }

--- a/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
@@ -745,7 +745,7 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// Open Warn Others screen.
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionWarnOthersView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// Open Thank You screen.

--- a/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
@@ -73,11 +73,11 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 		app.buttons["AppStrings.ExposureSubmissionDispatch.qrCodeButtonDescription"].tap()
 
 		// QR Code Info Screen
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionQRInfoView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// QR Code Scanner Screen
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionQRScannerView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 	}
 	
 	func test_Switch_consentSubmission() {
@@ -396,7 +396,7 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionWarnOthersView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionThankYouView"].waitForExistence(timeout: .medium))
@@ -452,7 +452,7 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionWarnOthersView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		snapshot("tan_submissionflow_tan_\(String(format: "%04d", (screenshotCounter.inc() )))")
 		
@@ -575,7 +575,7 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
 		// Open Warn Others screen.
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionWarnOthersView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// Open Thank You screen.
@@ -628,7 +628,7 @@ class ENAUITests_04_ExposureSubmissionUITests: XCTestCase {
 		app.alerts.firstMatch.buttons[AccessibilityIdentifiers.General.cancelButton].tap()
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
-		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionWarnOthersView"].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.navigationBars["ExposureSubmissionNavigationController"].waitForExistence(timeout: .medium))
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
 		XCTAssertTrue(app.navigationBars["ENA.ExposureSubmissionThankYouView"].waitForExistence(timeout: .medium))


### PR DESCRIPTION
## Description

Replace ENANavigationControllerWithFooterChild with FooterViewHandling in some view controllers to prevent scroll offset change bugs

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5431
