### PR TITLE
Add difference in days between mostRecentRisk and registrationDate in…

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Metadata/Test Result Metadata/TestResultMetadata.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Metadata/Test Result Metadata/TestResultMetadata.swift
@@ -54,7 +54,7 @@ struct TestResultMetadata: Codable {
 	// the risk level on the riskcard i.e totalRiskLevel
 	var riskLevelAtTestRegistration: RiskLevel?
 	
-	// Number of days on the risk card
+	// test registration date - Most Recent Date at RiskLevel
 	var daysSinceMostRecentDateAtRiskLevelAtTestRegistration: Int?
 	
 	// if high = timestamp of when the risk card turned red -  timestamp of test registration

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -199,7 +199,14 @@ enum PPAnalyticsCollector {
 		var testResultMetadata = TestResultMetadata(registrationToken: token)
 		testResultMetadata.testRegistrationDate = date
 		testResultMetadata.riskLevelAtTestRegistration = riskCalculationResult.riskLevel
-		testResultMetadata.daysSinceMostRecentDateAtRiskLevelAtTestRegistration = riskCalculationResult.numberOfDaysWithCurrentRiskLevel
+		
+		if let mostRecentRiskCalculationDate = riskCalculationResult.mostRecentDateWithCurrentRiskLevel {
+			let daysSinceMostRecentDateAtRiskLevelAtTestRegistration = Calendar.current.dateComponents([.day], from: mostRecentRiskCalculationDate, to: date).day
+			testResultMetadata.daysSinceMostRecentDateAtRiskLevelAtTestRegistration = daysSinceMostRecentDateAtRiskLevelAtTestRegistration
+			Log.warning("daysSinceMostRecentDateAtRiskLevelAtTestRegistration: \(String(describing: daysSinceMostRecentDateAtRiskLevelAtTestRegistration))", log: .ppa)
+		} else {
+			Log.warning("Could not set daysSinceMostRecentDateAtRiskLevelAtTestRegistration because mostRecentDateWithCurrentRiskLevel is nil", log: .ppa)
+		}
 
 		Analytics.collect(.testResultMetadata(.create(testResultMetadata)))
 

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -203,7 +203,7 @@ enum PPAnalyticsCollector {
 		if let mostRecentRiskCalculationDate = riskCalculationResult.mostRecentDateWithCurrentRiskLevel {
 			let daysSinceMostRecentDateAtRiskLevelAtTestRegistration = Calendar.current.dateComponents([.day], from: mostRecentRiskCalculationDate, to: date).day
 			testResultMetadata.daysSinceMostRecentDateAtRiskLevelAtTestRegistration = daysSinceMostRecentDateAtRiskLevelAtTestRegistration
-			Log.warning("daysSinceMostRecentDateAtRiskLevelAtTestRegistration: \(String(describing: daysSinceMostRecentDateAtRiskLevelAtTestRegistration))", log: .ppa)
+			Log.debug("daysSinceMostRecentDateAtRiskLevelAtTestRegistration: \(String(describing: daysSinceMostRecentDateAtRiskLevelAtTestRegistration))", log: .ppa)
 		} else {
 			Log.warning("Could not set daysSinceMostRecentDateAtRiskLevelAtTestRegistration because mostRecentDateWithCurrentRiskLevel is nil", log: .ppa)
 		}

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -443,12 +443,12 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		// collect testResultMetadata
 		
 		let today = Date()
+		let differenceBetweenMostRecentRiskDateAndRegistrationDate = 5
 		let registrationDate = Calendar.current.date(byAdding: .day, value: -10, to: today) ?? Date()
-		let mostRecentDayWithRisk = Calendar.current.date(byAdding: .day, value: -5, to: today)
+		let mostRecentDayWithRisk = Calendar.current.date(byAdding: .day, value: -differenceBetweenMostRecentRiskDateAndRegistrationDate, to: registrationDate)
 		let dateOfRiskChangeToHigh = Calendar.current.date(byAdding: .day, value: -12, to: today)
 		let registrationToken = "123"
 		let testResult: TestResult = .negative
-		let numberOfDaysWithHightRisk = 25
 		let riskLevel: RiskLevel = .high
 		let differenceInHoursBetweenChangeToHighRiskAndRegistrationDate = Calendar.current.dateComponents([.hour], from: dateOfRiskChangeToHigh ?? Date(), to: registrationDate).hour
 		let differenceInHoursBetweenRegistrationDateAndTestResult = Calendar.current.dateComponents([.hour], from: registrationDate, to: today).hour
@@ -460,7 +460,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 			mostRecentDateWithLowRisk: nil,
 			mostRecentDateWithHighRisk: mostRecentDayWithRisk,
 			numberOfDaysWithLowRisk: 0,
-			numberOfDaysWithHighRisk: numberOfDaysWithHightRisk,
+			numberOfDaysWithHighRisk: 0,
 			calculationDate: Date(),
 			riskLevelPerDate: [:],
 			minimumDistinctEncountersWithHighRiskPerDate: [:]
@@ -471,7 +471,7 @@ class PPAnalyticsSubmitterTests: XCTestCase {
 		Analytics.collect(.testResultMetadata(.registerNewTestMetadata(registrationDate, registrationToken)))
 		XCTAssertEqual(store.testResultMetadata?.testRegistrationDate, registrationDate, "Wrong Registration date")
 		XCTAssertEqual(store.testResultMetadata?.riskLevelAtTestRegistration, riskLevel, "Wrong Risk Level")
-		XCTAssertEqual(store.testResultMetadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, numberOfDaysWithHightRisk, "Wrong number of days with this risk level")
+		XCTAssertEqual(store.testResultMetadata?.daysSinceMostRecentDateAtRiskLevelAtTestRegistration, differenceBetweenMostRecentRiskDateAndRegistrationDate, "Wrong number of days with this risk level")
 		XCTAssertEqual(store.testResultMetadata?.hoursSinceHighRiskWarningAtTestRegistration, differenceInHoursBetweenChangeToHighRiskAndRegistrationDate, "Wrong difference hoursSinceHighRiskWarningAtTestRegistration")
 
 		Analytics.collect(.testResultMetadata(.updateTestResult(testResult, registrationToken)))


### PR DESCRIPTION
## Description

- The expected value for daysSinceMostRecentDateAtRiskLevelAtTestRegistration was not clear in the tech specs, according to the last update we decided to change it to **test registration date - Most Recent Date at RiskLevel**

- update unit tests accordingly

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5647
