### PR TITLE
daysSinceMostRecentDateAtRiskLevelAtTestRegistration should be -1 if …

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsCollector/PPAnalyticsCollector.swift
@@ -205,7 +205,8 @@ enum PPAnalyticsCollector {
 			testResultMetadata.daysSinceMostRecentDateAtRiskLevelAtTestRegistration = daysSinceMostRecentDateAtRiskLevelAtTestRegistration
 			Log.debug("daysSinceMostRecentDateAtRiskLevelAtTestRegistration: \(String(describing: daysSinceMostRecentDateAtRiskLevelAtTestRegistration))", log: .ppa)
 		} else {
-			Log.warning("Could not set daysSinceMostRecentDateAtRiskLevelAtTestRegistration because mostRecentDateWithCurrentRiskLevel is nil", log: .ppa)
+			testResultMetadata.daysSinceMostRecentDateAtRiskLevelAtTestRegistration = -1
+			Log.warning("daysSinceMostRecentDateAtRiskLevelAtTestRegistration: -1", log: .ppa)
 		}
 
 		Analytics.collect(.testResultMetadata(.create(testResultMetadata)))


### PR DESCRIPTION
## Description

- daysSinceMostRecentDateAtRiskLevelAtTestRegistration should be -1 if there is no risk

- Update unit tests

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5647