### PR TITLE
Update Localizable.legal.strings in EN and TR

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.legal.strings
@@ -31,7 +31,7 @@
 
 "ExposureSubmissionQRInfo_acknowledgement_2_1" = "If you have tested positive for coronavirus, the app will share your test result in order to warn other users whom you have encountered. This includes users of the official coronavirus apps of the countries mentioned above. If you provide additional information about the onset of your symptoms, this will also be shared.";
 
-"ExposureSubmissionQRInfo_acknowledgement_2_2" = "You can withdraw your consent at any time. The setting for this can be found under “Display Test”. Before sharing your test result, you will be reminded of your consent and asked to confirm your willingness to share your test result.";
+"ExposureSubmissionQRInfo_acknowledgement_2_2" = "You can withdraw your consent at any time. The setting for this can be found under “Display Test”. Before sharing your test result, you will be reminded of your consent.";
 
 /* Automatic share submission result consent */
 

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
@@ -31,7 +31,7 @@
 
 "ExposureSubmissionQRInfo_acknowledgement_2_1" = "Korona testiniz pozitif çıkmışsa, Uygulama karşılaştığınız kullanıcıları uyarmak üzere test sonucunuzu paylaşır. Bu, yukarıda belirtilen ülkelerdeki resmi Korona uygulamalarının kullanıcıları için geçerlidir. Ayrıca semptomlarınızın başlangıcı hakkında bilgi verirseniz, bu veri de paylaşılacaktır.";
 
-"ExposureSubmissionQRInfo_acknowledgement_2_2" = "Verdiğiniz rıza beyanını istediğiniz zaman geri alabilirsiniz. Bunun ayarını, “Testi Göster” altında bulabilirsiniz. Paylaşmadan önce, rıza beyanınıza ilişkin yeniden bilgilendirilecek ve test sonucunuzu yayınlamaya izin vermeniz istenecektir.";
+"ExposureSubmissionQRInfo_acknowledgement_2_2" = "Verdiğiniz rıza beyanını istediğiniz zaman geri alabilirsiniz. Bunun ayarını, “Testi Göster” altında bulabilirsiniz. Paylaşmadan önce, rıza beyanınıza ilişkin yeniden bilgilendirilecek.";
 
 /* Automatic share submission result consent */
 

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
@@ -31,7 +31,7 @@
 
 "ExposureSubmissionQRInfo_acknowledgement_2_1" = "Korona testiniz pozitif çıkmışsa, Uygulama karşılaştığınız kullanıcıları uyarmak üzere test sonucunuzu paylaşır. Bu, yukarıda belirtilen ülkelerdeki resmi Korona uygulamalarının kullanıcıları için geçerlidir. Ayrıca semptomlarınızın başlangıcı hakkında bilgi verirseniz, bu veri de paylaşılacaktır.";
 
-"ExposureSubmissionQRInfo_acknowledgement_2_2" = "Verdiğiniz rıza beyanını istediğiniz zaman geri alabilirsiniz. Bunun ayarını, “Testi Göster” altında bulabilirsiniz. Paylaşmadan önce, rıza beyanınıza ilişkin yeniden bilgilendirilecek.";
+"ExposureSubmissionQRInfo_acknowledgement_2_2" = "Verdiğiniz rıza beyanını istediğiniz zaman geri alabilirsiniz. Bunun ayarını, “Testi Göster” altında bulabilirsiniz. Paylaşmadan önce, rıza beyanınıza ilişkin yeniden bilgilendirileceksiniz.";
 
 /* Automatic share submission result consent */
 


### PR DESCRIPTION
## Description
String ExposureSubmissionQRInfo_acknowledgement_2_2 had been shortened in DE as per lawyer's instruction.
This PR adapts the EN and TR legal strings accordingly.