### PR TITLE
Fix TraceWarningDiscoveryCall

### DIFF
--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -354,14 +354,16 @@ final class HTTPClient: Client {
 							TraceWarningDiscoveryResponse.self,
 							from: body
 						)
+						let eTag = response.httpResponse.value(forCaseInsensitiveHeaderField: "ETag")
+						
 						guard let oldest = decodedResponse.oldest,
 							  let latest = decodedResponse.latest else {
-							Log.error("Failed to get oldest or latest out of decoded response", log: .api)
-							completion(.failure(.decodingJsonError(response.statusCode)))
+							Log.info("Succesfully discovered that there are no availablePackagesOnCDN", log: .api)
+							// create an false package with latest < oldest, then computed property availablePackagesOnCDN will be empty for the downloading check later.
+							completion(.success(TraceWarningDiscovery(oldest: 0, latest: -1, eTag: eTag)))
 							return
 						}
 						
-						let eTag = response.httpResponse.value(forCaseInsensitiveHeaderField: "ETag")
 						let traceWarningDiscovery = TraceWarningDiscovery(oldest: oldest, latest: latest, eTag: eTag)
 						Log.info("Succesfully downloaded availablePackagesOnCDN", log: .api)
 						completion(.success(traceWarningDiscovery))

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/HTTPClient.swift
@@ -359,7 +359,7 @@ final class HTTPClient: Client {
 						guard let oldest = decodedResponse.oldest,
 							  let latest = decodedResponse.latest else {
 							Log.info("Succesfully discovered that there are no availablePackagesOnCDN", log: .api)
-							// create an false package with latest < oldest, then computed property availablePackagesOnCDN will be empty for the downloading check later.
+							// create false package with latest < oldest, then computed property availablePackagesOnCDN will be empty for the downloading check later.
 							completion(.success(TraceWarningDiscovery(oldest: 0, latest: -1, eTag: eTag)))
 							return
 						}

--- a/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/HTTPClient+TraceWarningPackageDiscoveryTests.swift
+++ b/src/xcode/ENA/ENA/Source/Client/HTTP Client/__tests__/HTTPClient+TraceWarningPackageDiscoveryTests.swift
@@ -71,11 +71,48 @@ final class HTTPClientTraceWarningPackageDiscoveryTests: XCTestCase {
 		XCTAssertEqual(responseError, TraceWarningError.defaultServerError(URLSession.Response.Failure.noResponse))
 	}
 	
-	func testGIVEN_Country_WHEN_MissingParamsInResponse_THEN_DecodingJsonErrorIsReturned() throws {
+	func testGIVEN_Country_WHEN_OldestLatestAreNil_THEN_OneAvailablePackagesOnCDNAreReturned() throws {
+
+		// GIVEN
+		let oldest = 448520
+		let latest = 448520
+		let jsonEncoder = JSONEncoder()
+		let encoded = try jsonEncoder.encode(TraceWarningDiscoveryResponse(oldest: oldest, latest: latest))
+		
+		let stack = MockNetworkStack(
+			httpStatus: 200,
+			responseData: encoded
+		)
+		let expectation = self.expectation(description: "completion handler is called without an error")
+		let expectedResponse = TraceWarningDiscovery(oldest: oldest, latest: latest, eTag: "FakeETag")
+		
+		// WHEN
+		var response: TraceWarningDiscovery?
+		HTTPClient.makeWith(mock: stack).traceWarningPackageDiscovery(country: "DE", completion: { result in
+			switch result {
+			case let .success(traceWarningDiscovery):
+				response = traceWarningDiscovery
+				expectation.fulfill()
+			case let .failure(error):
+				XCTFail("Test should not fail with error: \(error)")
+			}
+		})
+
+		// THEN
+		waitForExpectations(timeout: .short)
+		XCTAssertNotNil(response)
+		XCTAssertEqual(response?.oldest, expectedResponse.oldest)
+		XCTAssertEqual(response?.latest, expectedResponse.latest)
+		XCTAssertEqual(response?.availablePackagesOnCDN, expectedResponse.availablePackagesOnCDN)
+		XCTAssertEqual(response?.availablePackagesOnCDN.count, 1)
+	}
+	
+	func testGIVEN_Country_WHEN_OldestLatestAreNil_THEN_EmptyAvailablePackagesOnCDNAreReturned() throws {
 
 		// GIVEN
 		let jsonEncoder = JSONEncoder()
-		let encoded = try jsonEncoder.encode(TraceWarningDiscoveryResponse(oldest: nil, latest: nil))
+		// At least, one of the two must be nil to trigger an empty package response
+		let encoded = try jsonEncoder.encode(TraceWarningDiscoveryResponse(oldest: nil, latest: 33333))
 		
 		let stack = MockNetworkStack(
 			httpStatus: 200,
@@ -84,48 +121,27 @@ final class HTTPClientTraceWarningPackageDiscoveryTests: XCTestCase {
 		let expectation = self.expectation(description: "completion handler is called without an error")
 		
 		// WHEN
-		var responseError: TraceWarningError?
+		var expectedResponse: TraceWarningDiscovery?
 		HTTPClient.makeWith(mock: stack).traceWarningPackageDiscovery(country: "DE", completion: { result in
 			switch result {
-			case .success:
-				XCTFail("Test should not succeed")
-			case let .failure(error):
-				responseError = error
+			case let .success(traceWarningDiscovery):
+				expectedResponse = traceWarningDiscovery
 				expectation.fulfill()
+			case let .failure(error):
+				XCTFail("Test should not fail with error: \(error)")
 			}
 		})
 
 		// THEN
 		waitForExpectations(timeout: .short)
-		XCTAssertEqual(responseError, TraceWarningError.decodingJsonError(200))
+		guard let response = expectedResponse else {
+			XCTFail("Response should not be nil")
+			return
+		}
+		// If oldest or latest are nil, we expect for oldest 0 and latest -1. See also in HTTPClient, method traceWarningPackageDiscovery.
+		XCTAssertEqual(response.oldest, 0)
+		XCTAssertEqual(response.latest, -1)
+		XCTAssertTrue(response.availablePackagesOnCDN.isEmpty)
 	}
-	
-	func testGIVEN_Country_WHEN_WrongStatusCode400_THEN_InvalidResponseErrorIsReturned() throws {
 
-		// GIVEN
-		let jsonEncoder = JSONEncoder()
-		let encoded = try jsonEncoder.encode(TraceWarningDiscoveryResponse(oldest: nil, latest: nil))
-		
-		let stack = MockNetworkStack(
-			httpStatus: 401,
-			responseData: encoded
-		)
-		let expectation = self.expectation(description: "completion handler is called without an error")
-		
-		// WHEN
-		var responseError: TraceWarningError?
-		HTTPClient.makeWith(mock: stack).traceWarningPackageDiscovery(country: "DE", completion: { result in
-			switch result {
-			case .success:
-				XCTFail("Test should not succeed")
-			case let .failure(error):
-				responseError = error
-				expectation.fulfill()
-			}
-		})
-
-		// THEN
-		waitForExpectations(timeout: .short)
-		XCTAssertEqual(responseError, TraceWarningError.invalidResponseError(401))
-	}
 }


### PR DESCRIPTION
## Description
We must change the handling of nil latest or oldest property in the repsonse of the discovery call.
If we have one of them nil, we create a faked TraceWarningDiscovery that has set its properties as the computed property availablePackagesOnCDN return an empty array so the download knows, that there are no packages to download.
I also added a test for that scenario and fixed one when there is only one package on the cdn.

## Link to Jira
Urgent fix no jira ticket.