### PR TITLE
Match issue templates to Android ones

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bugs.md
+++ b/.github/ISSUE_TEMPLATE/01_bugs.md
@@ -9,19 +9,19 @@ Thanks for reporting a bug 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
 
-Also, be sure to check our documentation first: <URL>
+Also, be sure to check our documentation first: https://github.com/corona-warn-app/cwa-documentation
 -->
 
 ## Avoid duplicates
-
 * [ ] Bug is not mentioned in the [FAQ](https://www.coronawarn.app/en/faq/)
+* [ ] Bug is specific for iOS only, for general issues / questions that apply to iOS and Android please raise them in the [documentation repository](https://github.com/corona-warn-app/cwa-documentation)
 * [ ] Bug is not already reported in another issue
 
 ## Technical details
 
 - Device name:
-- iOS Version:
-- App Version:
+- iOS version:
+- App version:
 
 ## Describe the bug
 

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -9,9 +9,10 @@ Thanks for proposing an enhancement 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
 -->
-## Avoid duplicates
 
-* [ ] This issue has not already been raised before
+## Avoid duplicates
+* [ ] This enhancement request has not already been raised before
+* [ ] Enhancement request is specific for iOS only, for general issues / questions that apply to iOS and Android please raise them in [CWA-Wishlist](https://github.com/corona-warn-app/cwa-wishlist)
 * [ ] If you are proposing a new feature, please do so in [CWA-Wishlist](https://github.com/corona-warn-app/cwa-wishlist)
 
 ## Current Implementation

--- a/.github/ISSUE_TEMPLATE/03_questions.md
+++ b/.github/ISSUE_TEMPLATE/03_questions.md
@@ -12,6 +12,7 @@ Before opening a new issue, please make sure that we do not have any duplicates 
 
 ## Avoid duplicates
 * [ ] Question is not already answered in the [FAQ](https://www.coronawarn.app/en/faq/)
+* [ ] Question is specific for iOS only, for general issues / questions that apply to iOS and Android please raise them in the [documentation repository](https://github.com/corona-warn-app/cwa-documentation)
 * [ ] Question has not already been asked in another issue
 
 ## Your Question


### PR DESCRIPTION
## Description
The iOS repository issue templates differ from the [Android ones](https://github.com/corona-warn-app/cwa-app-android/tree/main/.github/ISSUE_TEMPLATE). This PR matches them.

## Link to Jira
n/a
