### PR TITLE
Remove Base32 from licenses

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -40,12 +40,5 @@
     "website": "https://github.com/OpenCombine/OpenCombine",
     "license": "MIT License",
     "licenseUrl": "https://raw.githubusercontent.com/OpenCombine/OpenCombine/master/LICENSE"
-  },
-  {
-    "component": "Base32",
-    "licensor": "Norio Nomura",
-    "website": "https://github.com/norio-nomura/Base32",
-    "license": "MIT License",
-    "licenseUrl": "https://raw.githubusercontent.com/norio-nomura/Base32/master/LICENSE"
   }
 ]

--- a/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+LegalModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AppInformation/AppInformationViewController+LegalModel.swift
@@ -143,17 +143,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-"""),
-		.legal(title: "Base32", licensor: "Norio Nomura", fullLicense: """
-The MIT License (MIT)
-
-Copyright (c) 2015 Norio Nomura
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """)
 	]
 }


### PR DESCRIPTION
## Description
Remove Base32 from licenses, since we don't use Base32 anymore.

