### PR TITLE
remove subscriptions after obtaining the TraceLocation or the error

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
@@ -166,8 +166,9 @@ final class CheckinCoordinator {
 			appConfigurationProvider: appConfiguration,
 			onSuccess: { [weak self] traceLocation in
 				self?.showTraceLocationDetails(traceLocation)
+				self?.verificationService.subscriptions.removeAll()
 			},
-			onError: { error in
+			onError: { [weak self] error in
 				let alert = UIAlertController(
 					title: AppStrings.Checkins.QRScanner.Error.title,
 					message: error.errorDescription,
@@ -182,7 +183,8 @@ final class CheckinCoordinator {
 						}
 					)
 				)
-				self.viewController.present(alert, animated: true)
+				self?.viewController.present(alert, animated: true)
+				self?.verificationService.subscriptions.removeAll()
 			}
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/QRCodeScanner/CheckinQRCodeScannerViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/QRCodeScanner/CheckinQRCodeScannerViewModel.swift
@@ -52,9 +52,11 @@ class CheckinQRCodeScannerViewModel: NSObject, AVCaptureMetadataOutputObjectsDel
 			appConfigurationProvider: appConfiguration,
 			onSuccess: { [weak self] traceLocation in
 				self?.onSuccess(traceLocation)
+				self?.verificationHelper.subscriptions.removeAll()
 			},
 			onError: { [weak self] error in
 				self?.onError?(error)
+				self?.verificationHelper.subscriptions.removeAll()
 			}
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/QRCodeVerificationHelper.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/QRCodeVerificationHelper.swift
@@ -14,8 +14,7 @@ protocol QRCodeVerificationHelperProviding {
 	)
 }
 class QRCodeVerificationHelper {
-	
-	private var subscriptions: Set<AnyCancellable> = []
+	var subscriptions: Set<AnyCancellable> = []
 
 	func verifyQrCode(
 		qrCodeString url: String,


### PR DESCRIPTION
## Description
When the app is removed from the memory and we scan a qrcode it crashes,
The reason for this crash is happening because of an invalid call to **os_unfair_lock_lock** through opencombine
this happend because the the subscriptions are always alive as we don't de-allocate the QRCodeVerificationHelperClass as long as we are inside the checkin tab
The solution was to remove all subscriptions from the class after getting the result in the completion handler, this way no un expected behavior can happen when we are  presenting the detail screen

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6290

## Screenshots
https://user-images.githubusercontent.com/15270737/114174897-98c27b00-9939-11eb-9578-874ba24b9892.MOV