### PR TITLE
Fix/6288 checkin submission fixes

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/Checkin+Mock.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/Checkin+Mock.swift
@@ -7,81 +7,44 @@ import Foundation
 
 extension Checkin {
 
-
 	/// Provide a set of default parameters to quickly generate a `Checkin`
 	/// - Returns: A mocked `Checkin`
 	static func mock(
-
-	id: Int = 0,
-
-	traceLocationId: Data = Data(),
-
-	traceLocationIdHash: Data = Data(),
-
-	traceLocationVersion: Int = 0,
-
-	traceLocationType: TraceLocationType = .locationTypeUnspecified,
-
-	traceLocationDescription: String = "",
-
-	traceLocationAddress: String = "",
-
-	traceLocationStartDate: Date? = nil,
-
-	traceLocationEndDate: Date? = nil,
-
-	traceLocationDefaultCheckInLengthInMinutes: Int? = nil,
-
-	cryptographicSeed: Data = Data(),
-
-	cnPublicKey: Data = Data(),
-
-	checkinStartDate: Date = Date(),
-
-	checkinEndDate: Date = Date(),
-
-	checkinCompleted: Bool = false,
-
-	createJournalEntry: Bool = false
-
+		id: Int = 0,
+		traceLocationId: Data = Data(),
+		traceLocationIdHash: Data = Data(),
+		traceLocationVersion: Int = 0,
+		traceLocationType: TraceLocationType = .locationTypeUnspecified,
+		traceLocationDescription: String = "",
+		traceLocationAddress: String = "",
+		traceLocationStartDate: Date? = nil,
+		traceLocationEndDate: Date? = nil,
+		traceLocationDefaultCheckInLengthInMinutes: Int? = nil,
+		cryptographicSeed: Data = Data(),
+		cnPublicKey: Data = Data(),
+		checkinStartDate: Date = Date(),
+		checkinEndDate: Date = Date(),
+		checkinCompleted: Bool = false,
+		createJournalEntry: Bool = false
 	) -> Self {
-
-	Checkin(
-
-	id: id,
-
-	traceLocationId: traceLocationId,
-
-	traceLocationIdHash: traceLocationIdHash,
-
-	traceLocationVersion: traceLocationVersion,
-
-	traceLocationType: traceLocationType,
-
-	traceLocationDescription: traceLocationDescription,
-
-	traceLocationAddress: traceLocationAddress,
-
-	traceLocationStartDate: traceLocationStartDate,
-
-	traceLocationEndDate: traceLocationEndDate,
-
-	traceLocationDefaultCheckInLengthInMinutes: traceLocationDefaultCheckInLengthInMinutes,
-
-	cryptographicSeed: cryptographicSeed,
-
-	cnPublicKey: cnPublicKey,
-
-	checkinStartDate: checkinStartDate,
-
-	checkinEndDate: checkinEndDate,
-
-	checkinCompleted: checkinCompleted,
-
-	createJournalEntry: createJournalEntry
-
-	)
-
-	   }
+		Checkin(
+			id: id,
+			traceLocationId: traceLocationId,
+			traceLocationIdHash: traceLocationIdHash,
+			traceLocationVersion: traceLocationVersion,
+			traceLocationType: traceLocationType,
+			traceLocationDescription: traceLocationDescription,
+			traceLocationAddress: traceLocationAddress,
+			traceLocationStartDate: traceLocationStartDate,
+			traceLocationEndDate: traceLocationEndDate,
+			traceLocationDefaultCheckInLengthInMinutes: traceLocationDefaultCheckInLengthInMinutes,
+			cryptographicSeed: cryptographicSeed,
+			cnPublicKey: cnPublicKey,
+			checkinStartDate: checkinStartDate,
+			checkinEndDate: checkinEndDate,
+			checkinCompleted: checkinCompleted,
+			createJournalEntry: createJournalEntry
+		)
+	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+CheckinSubmission.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService+CheckinSubmission.swift
@@ -10,8 +10,12 @@ extension ExposureSubmissionService {
 	///
 	///  Details on the implementation can be found in the [tech spec](https://github.com/corona-warn-app/cwa-app-tech-spec/blob/proposal/event-registration-mvp/docs/spec/event-registration-client.md#attendee-check-in-submission).
 	/// - Returns: A list of converted checkins
-	func preparedCheckinsForSubmission(with eventStore: EventStoringProviding, appConfig: SAP_Internal_V2_ApplicationConfigurationIOS, symptomOnset: SymptomsOnset, completion: @escaping (_ transformed: [SAP_Internal_Pt_CheckIn]) -> Void) {
-		
+	func preparedCheckinsForSubmission(
+		with eventStore: EventStoringProviding,
+		appConfig: SAP_Internal_V2_ApplicationConfigurationIOS,
+		symptomOnset: SymptomsOnset,
+		completion: @escaping (_ transformed: [SAP_Internal_Pt_CheckIn]) -> Void
+	) {
 		let rawCheckins = eventStore.checkinsPublisher.value
 
 		let css = CheckinSplittingService()
@@ -26,10 +30,10 @@ extension ExposureSubmissionService {
 			}
 			// transform for submission
 			.compactMap { checkin -> SAP_Internal_Pt_CheckIn? in
-				var transformed = checkin.prepareForSubmission()
+				var preparedCheckin = checkin.prepareForSubmission()
 				// Determine Transmission Risk Level
 				let transmissionRiskLevel: Int
-				if let ageInDays = Calendar.current.dateComponents([.day], from: checkin.checkinStartDate).day {
+				if let ageInDays = Calendar.current.dateComponents([.day], from: checkin.checkinStartDate, to: Date()).day {
 					let riskVector = symptomOnset.transmissionRiskVector
 					transmissionRiskLevel = Int(riskVector[safe: ageInDays] ?? 1)
 				} else {
@@ -37,13 +41,17 @@ extension ExposureSubmissionService {
 				}
 
 				// Filter out irrelevant checkins, i.e. ones with a risk value of zero
-				guard transmissionRiskValueMapping[transmissionRiskLevel].transmissionRiskValue > 0 else {
+				guard
+					let transmissionRiskValue = transmissionRiskValueMapping.first(where: { $0.transmissionRiskLevel == transmissionRiskLevel })?.transmissionRiskValue,
+					transmissionRiskValue > 0
+				else {
 					return nil
 				}
 
-				transformed.transmissionRiskLevel = UInt32(transmissionRiskLevel)
-				return transformed
+				preparedCheckin.transmissionRiskLevel = UInt32(transmissionRiskLevel)
+				return preparedCheckin
 			}
+
 		completion(checkins)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__test__/ExposureSubmissionCheckinTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__test__/ExposureSubmissionCheckinTests.swift
@@ -11,62 +11,107 @@ class ExposureSubmissionCheckinTests: XCTestCase {
         let service = MockExposureSubmissionService()
 		let appConfig = CachedAppConfigurationMock.defaultAppConfiguration
 
-		let eventStore = try XCTUnwrap(EventStore(url: EventStore.storeURL))
-		
-		// create dummy data
-		(0...3).forEach { _ in
-			let result = eventStore.createCheckin(Checkin.mock())
-			switch result {
-			case .success:
-				break
-			case .failure(let error):
-				XCTFail(error.localizedDescription)
-			}
-		}
-
-		debugPrint(eventStore.checkinsPublisher.value)
+		let eventStore = MockEventStore()
+		eventStore.createCheckin(Checkin.mock(
+			checkinStartDate: try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -20, to: Date())),
+			checkinEndDate: Date()
+		))
 
 		// process checkins
 		let processingDone = expectation(description: "processing done")
-		service.preparedCheckinsForSubmission(with: eventStore, appConfig: appConfig, symptomOnset: .noInformation) { checkins in
-			XCTAssertEqual(checkins.count, 4)
+		service.preparedCheckinsForSubmission(
+			with: eventStore,
+			appConfig: appConfig,
+			symptomOnset: .daysSinceOnset(0)
+		) { checkins in
+			XCTAssertEqual(checkins.count, 5)
+
+			XCTAssertEqual(checkins[0].transmissionRiskLevel, 4)
+			XCTAssertEqual(checkins[1].transmissionRiskLevel, 6)
+			XCTAssertEqual(checkins[2].transmissionRiskLevel, 7)
+			XCTAssertEqual(checkins[3].transmissionRiskLevel, 8)
+			XCTAssertEqual(checkins[4].transmissionRiskLevel, 8)
+
 			processingDone.fulfill()
 		}
 
 		waitForExpectations(timeout: .short)
 		eventStore.cleanup()
     }
-/*
-	func testCheckinTransformation() throws {
-		// create a mock checkin and check preconditions
 
+	func testPrepareCheckinForSubmission() throws {
+		let traceLocationId = "asdf".data(using: .utf8) ?? Data()
+
+		// create a mock checkin and check preconditions
 		for i in stride(from: 1, to: 600, by: 10) {
 			let checkin = Checkin.mock(
+				traceLocationId: traceLocationId,
 				checkinStartDate: Date(timeIntervalSinceNow: -(Double(i * 10))),
 				checkinEndDate: Date()
 			)
 			XCTAssertGreaterThan(checkin.checkinEndDate, checkin.checkinStartDate)
-			XCTAssertGreaterThanOrEqual(try XCTUnwrap(checkin.traceLocationEndDate), try XCTUnwrap(checkin.traceLocationEndDate))
 
-			let transformed = checkin.prepareForSubmission()
-			XCTAssertTrue(type(of: transformed) == SAP_Internal_Pt_CheckIn.self)
-			XCTAssertGreaterThanOrEqual(transformed.endIntervalNumber, transformed.startIntervalNumber)
+			let transformedCheckin = checkin.prepareForSubmission()
+			XCTAssertGreaterThanOrEqual(transformedCheckin.endIntervalNumber, transformedCheckin.startIntervalNumber)
 
-			// check calculated interval numbers and compare to star/end dates
+			// check calculated interval numbers and compare to start/end dates
 			XCTAssertEqual(
-				TimeInterval(transformed.startIntervalNumber * 600),
+				TimeInterval(transformedCheckin.startIntervalNumber * 600),
 				checkin.checkinStartDate.timeIntervalSince1970,
-				accuracy: 600)
+				accuracy: 600
+			)
 
 			XCTAssertEqual(
-				TimeInterval(transformed.startIntervalNumber * 600),
-				checkin.checkinStartDate.timeIntervalSince1970,
-				accuracy: 600)
+				TimeInterval(transformedCheckin.endIntervalNumber * 600),
+				checkin.checkinEndDate.timeIntervalSince1970,
+				accuracy: 600
+			)
 
-			// trace location conversion
-			let location = checkin.traceLocation
-			XCTAssertEqual(location.startTimestamp, UInt64(checkin.traceLocationStartDate?.timeIntervalSince1970 ?? 0))
-			XCTAssertEqual(location.endTimestamp, UInt64(checkin.traceLocationEndDate?.timeIntervalSince1970 ?? 0))
+			XCTAssertEqual(transformedCheckin.locationID, traceLocationId)
 		}
-	}*/
+	}
+
+	func testCheckinTransformationWithTraceLocationStartAndEndDate() throws {
+		// create a mock checkin and check preconditions
+		let startDate = Date(timeIntervalSinceNow: -200)
+		let endDate = Date(timeIntervalSinceNow: 200)
+
+		let checkin = Checkin.mock(
+			traceLocationId: "traceLocationId".data(using: .utf8) ?? Data(),
+			traceLocationVersion: 17,
+			traceLocationDescription: "Description",
+			traceLocationAddress: "Address",
+			traceLocationStartDate: startDate,
+			traceLocationEndDate: endDate
+		)
+
+		let protobufTraceLocation = checkin.traceLocation
+
+		XCTAssertEqual(protobufTraceLocation.version, 17)
+		XCTAssertEqual(protobufTraceLocation.description_p, "Description")
+		XCTAssertEqual(protobufTraceLocation.address, "Address")
+		XCTAssertEqual(protobufTraceLocation.startTimestamp, UInt64(startDate.timeIntervalSince1970))
+		XCTAssertEqual(protobufTraceLocation.endTimestamp, UInt64(endDate.timeIntervalSince1970))
+	}
+
+	func testCheckinTransformationWithoutTraceLocationStartAndEndDate() throws {
+		// create a mock checkin and check preconditions
+		let checkin = Checkin.mock(
+			traceLocationId: "traceLocationId".data(using: .utf8) ?? Data(),
+			traceLocationVersion: 17,
+			traceLocationDescription: "Description",
+			traceLocationAddress: "Address",
+			traceLocationStartDate: nil,
+			traceLocationEndDate: nil
+		)
+
+		let protobufTraceLocation = checkin.traceLocation
+
+		XCTAssertEqual(protobufTraceLocation.version, 17)
+		XCTAssertEqual(protobufTraceLocation.description_p, "Description")
+		XCTAssertEqual(protobufTraceLocation.address, "Address")
+		XCTAssertEqual(protobufTraceLocation.startTimestamp, 0)
+		XCTAssertEqual(protobufTraceLocation.endTimestamp, 0)
+	}
+
 }


### PR DESCRIPTION
## Description
Fixes two issues with checkin preparation for submission:
- `ageInDays` was not calculated correctly and used calendar day instead
- Uses the correct transmission risk level mapping entry now based on the transmission risk level instead of the index

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6288
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6286
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6291