### PR TITLE
Fix/6311 change check in time triggers UI issue

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/EditCheckInTime/Cells/CheckInDatePickerCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/EditCheckInTime/Cells/CheckInDatePickerCell.swift
@@ -19,6 +19,14 @@ class CheckInDatePickerCell: UITableViewCell, ReuseIdentifierProviding {
 		fatalError("init(coder:) has not been implemented")
 	}
 
+	// MARK: - Overrides
+
+	override func prepareForReuse() {
+		super.prepareForReuse()
+		subscriptions.forEach { $0.cancel() }
+		subscriptions.removeAll()
+	}
+
 	// MARK: - Internal
 
 	func configure(_ cellModel: CheckInTimeModel) {

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/EditCheckInTime/Cells/CheckInTimeCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/EditCheckInTime/Cells/CheckInTimeCell.swift
@@ -19,6 +19,14 @@ class CheckInTimeCell: UITableViewCell, ReuseIdentifierProviding {
 		fatalError("init(coder:) has not been implemented")
 	}
 
+	// MARK: - Overrides
+
+	override func prepareForReuse() {
+		super.prepareForReuse()
+		subscriptions.forEach { $0.cancel() }
+		subscriptions.removeAll()
+	}
+
 	// MARK: - Internal
 
 	func configure(_ cellModel: CheckInTimeModel) {


### PR DESCRIPTION
## Description
UI Issue showing wrong values, possibly caused by cell reuse.
Adde unsubscribe for value updates on prepare for reuse, because the model might still be in memory

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6311

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
