### PR TITLE
Compile SwiftLint from source to fix homebrew CDN hickup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
           command: |
             if ! command -v swiftlint &> /dev/null
             then
-              brew install swiftlint
+              brew install --build-from-source swiftlint
             fi
             swiftlint version
       - run:


### PR DESCRIPTION
## Description
HomeBrew CDN, seems to have some Issue, this PR compiles SwiftLint from Source to get the CI up and running for now again.

