### PR TITLE
Fix/6364 event store fix cleanup

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/Checkin.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/Checkin.swift
@@ -49,9 +49,6 @@ extension Checkin {
 
 extension Checkin {
 
-	/// a 10 minute interval
-	private static let INTERVAL_LENGTH: TimeInterval = 600
-
 	/// Extract and return the  trace location of the current checkin
 	var traceLocation: SAP_Internal_Pt_TraceLocation {
 		var loc = SAP_Internal_Pt_TraceLocation()
@@ -134,8 +131,8 @@ extension Checkin {
 
 		// 10 minute time interval; derived from the unix timestamps
 		// see: https://github.com/corona-warn-app/cwa-app-tech-spec/blob/proposal/event-registration-mvp/docs/spec/event-registration-client.md#derive-10-minute-interval-from-timestamp
-		checkin.startIntervalNumber = UInt32(checkinStartDate.timeIntervalSince1970 / Checkin.INTERVAL_LENGTH)
-		checkin.endIntervalNumber = UInt32(checkinEndDate.timeIntervalSince1970 / Checkin.INTERVAL_LENGTH)
+		checkin.startIntervalNumber = UInt32(checkinStartDate.timeIntervalSince1970 / EventStore.tenMinutesIntervalLength)
+		checkin.endIntervalNumber = UInt32(checkinEndDate.timeIntervalSince1970 / EventStore.tenMinutesIntervalLength)
 		assert(checkin.startIntervalNumber <= checkin.endIntervalNumber)
 		checkin.locationID = traceLocationId
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Risk.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Risk.swift
@@ -64,7 +64,7 @@ extension Risk {
 			$0.key < $1.key
 		})?.key
 
-		Log.debug("[Risk] mostRecentDateWithRiskLevel: \(mostRecentDateWithRiskLevel)", log: .riskDetection)
+		Log.debug("[Risk] mostRecentDateWithRiskLevel: \(String(describing: mostRecentDateWithRiskLevel))", log: .riskDetection)
 
 		let numberOfDaysWithRiskLevel = mergedRiskLevelPerDate.filter {
 			$1 == totalRiskLevel


### PR DESCRIPTION
## Description
Fixes the cleanup of EventStore.
Before this fix, the cleanup was deleting all matches. Also the matches which were still valid time wise.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6364

