### PR TITLE
Fix/6370 background color check in screen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Assets/ena-colors.xcassets/Background Colors/ENA Background Light Gray Color.colorset/Contents.json
+++ b/src/xcode/ENA/ENA/Resources/Assets/ena-colors.xcassets/Background Colors/ENA Background Light Gray Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.122",
+          "green" : "0.118",
+          "red" : "0.118"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/xcode/ENA/ENA/Source/Extensions/ENAColor.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/ENAColor.swift
@@ -8,6 +8,7 @@ import UIKit
 public enum ENAColor: String, CaseIterable {
 	// MARK: - Background Colors
 	case background = "ENA Background Color"
+	case backgroundLightGray = "ENA Background Light Gray Color"
 	case darkBackground = "ENA Dark Background Color"
 	case cellBackground = "ENA Cell Background Color"
 	case hairline = "ENA Hairline Color"
@@ -67,6 +68,7 @@ public extension UIColor {
 	static func enaColor(for style: ENAColor, interface: UIUserInterfaceStyle = .unspecified) -> UIColor {
 		switch style {
 		case .background: return UIColor(rgb: 0xFFFFFF, alpha: 1.0)
+		case .backgroundLightGray: return UIColor(rgb: 0xF8F8F8, alpha: 1.0)
 		case .buttonPrimary: return UIColor(rgb: 0x007FAD, alpha: 1.0)
 		case .buttonHighlight: return UIColor(rgb: 0x17191A, alpha: 0.1)
 		case .listHighlight: return UIColor(rgb: 0x17191A, alpha: 0.2)

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.swift
@@ -73,7 +73,9 @@ class TraceLocationDetailViewController: UIViewController {
 	}
 
 	private func setupView() {
-		view.backgroundColor = .enaColor(for: .background)
+		// [KGA] One place
+		//view.backgroundColor = .enaColor(for: .background)
+		view.backgroundColor = .enaColor(for: .backgroundLightGray)
 		pickerButton.setTitleColor(.enaColor(for: .textPrimary1), for: .normal)
 		logoImageView.image = logoImageView.image?.withRenderingMode(.alwaysTemplate)
 		logoImageView.tintColor = .enaColor(for: .textContrast)

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.swift
@@ -73,8 +73,6 @@ class TraceLocationDetailViewController: UIViewController {
 	}
 
 	private func setupView() {
-		// [KGA] One place
-		//view.backgroundColor = .enaColor(for: .background)
 		view.backgroundColor = .enaColor(for: .backgroundLightGray)
 		pickerButton.setTitleColor(.enaColor(for: .textPrimary1), for: .normal)
 		logoImageView.image = logoImageView.image?.withRenderingMode(.alwaysTemplate)

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
@@ -161,6 +161,15 @@ deutschen SAP Anwendergruppe</string>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5E9-lv-fpC" userLabel="Additional Info View">
                                             <rect key="frame" x="0.0" y="227.5" width="382" height="40"/>
                                             <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ThY-E1-8vl">
+                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="40"/>
+                                                    <color key="backgroundColor" name="ENA Hairline Contrast Color"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                            <integer key="value" value="15"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Das Event beginnt erst am 21.01.21 um 18:00 Uhr. Wollen Sie bereits einchecken?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b0x-6m-KuJ" userLabel="Additional Info Label" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="20" width="350" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -168,12 +177,16 @@ deutschen SAP Anwendergruppe</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" name="ENA Hairline Contrast Color"/>
+                                            <color key="backgroundColor" name="ENA Background Color"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="b0x-6m-KuJ" secondAttribute="trailing" constant="16" id="6hJ-lt-nbx"/>
+                                                <constraint firstAttribute="bottom" secondItem="ThY-E1-8vl" secondAttribute="bottom" id="OR6-Kp-6Mr"/>
+                                                <constraint firstAttribute="trailing" secondItem="ThY-E1-8vl" secondAttribute="trailing" id="TfF-P6-PjG"/>
+                                                <constraint firstItem="ThY-E1-8vl" firstAttribute="top" secondItem="5E9-lv-fpC" secondAttribute="top" id="b7a-RR-EwV"/>
                                                 <constraint firstAttribute="bottom" secondItem="b0x-6m-KuJ" secondAttribute="bottom" constant="20" id="cM5-gn-arG"/>
                                                 <constraint firstItem="b0x-6m-KuJ" firstAttribute="top" secondItem="5E9-lv-fpC" secondAttribute="top" constant="20" id="ctq-I6-hrl"/>
                                                 <constraint firstItem="b0x-6m-KuJ" firstAttribute="leading" secondItem="5E9-lv-fpC" secondAttribute="leading" constant="16" id="mRj-JH-5Ru"/>
+                                                <constraint firstItem="ThY-E1-8vl" firstAttribute="leading" secondItem="5E9-lv-fpC" secondAttribute="leading" id="qsN-lm-C0p"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -184,6 +197,15 @@ deutschen SAP Anwendergruppe</string>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ek6-qj-gRz" userLabel="BottomStackView">
                                             <rect key="frame" x="0.0" y="233.5" width="382" height="382"/>
                                             <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yTk-ou-MeT">
+                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="382"/>
+                                                    <color key="backgroundColor" name="ENA Hairline Contrast Color"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                            <integer key="value" value="15"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="XlJ-Tn-Nyv">
                                                     <rect key="frame" x="16" y="0.0" width="350" height="382"/>
                                                     <subviews>
@@ -299,11 +321,15 @@ deutschen SAP Anwendergruppe</string>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" name="ENA Hairline Contrast Color"/>
+                                            <color key="backgroundColor" name="ENA Background Color"/>
                                             <constraints>
+                                                <constraint firstItem="yTk-ou-MeT" firstAttribute="leading" secondItem="Ek6-qj-gRz" secondAttribute="leading" id="KAh-iz-iUD"/>
                                                 <constraint firstAttribute="trailing" secondItem="XlJ-Tn-Nyv" secondAttribute="trailing" constant="16" id="W76-I2-IVv"/>
                                                 <constraint firstItem="XlJ-Tn-Nyv" firstAttribute="top" secondItem="Ek6-qj-gRz" secondAttribute="top" id="X3Y-NR-tVU"/>
                                                 <constraint firstItem="XlJ-Tn-Nyv" firstAttribute="leading" secondItem="Ek6-qj-gRz" secondAttribute="leading" constant="16" id="XaR-e0-5PT"/>
+                                                <constraint firstItem="yTk-ou-MeT" firstAttribute="top" secondItem="Ek6-qj-gRz" secondAttribute="top" id="YBO-hz-K4V"/>
+                                                <constraint firstAttribute="trailing" secondItem="yTk-ou-MeT" secondAttribute="trailing" id="cVY-m1-YbH"/>
+                                                <constraint firstAttribute="bottom" secondItem="yTk-ou-MeT" secondAttribute="bottom" id="cng-RH-e0r"/>
                                                 <constraint firstAttribute="bottom" secondItem="XlJ-Tn-Nyv" secondAttribute="bottom" id="zAO-2p-GAa"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
@@ -315,7 +315,6 @@ deutschen SAP Anwendergruppe</string>
                                     </subviews>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" name="ENA Background Color"/>
                             <constraints>
                                 <constraint firstItem="qe2-Cr-Hsf" firstAttribute="trailing" secondItem="fx9-sT-lVo" secondAttribute="trailing" constant="16" id="3f5-Yx-H9G"/>
                                 <constraint firstItem="oNa-7R-1wU" firstAttribute="top" secondItem="qe2-Cr-Hsf" secondAttribute="bottom" constant="12" id="429-LQ-bU1"/>

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckInDetail/TraceLocationDetailViewController.xib
@@ -113,7 +113,7 @@
                                                     <rect key="frame" x="16" y="30" width="350" height="161.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vereinsaktivität " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jzq-Fo-8cl" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="350" height="20.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="350" height="80"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" name="ENA Text Primary 2 Color"/>
                                                             <nil key="highlightedColor"/>
@@ -122,7 +122,7 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qEg-yG-yRz" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="30.5" width="350" height="100.5"/>
+                                                            <rect key="frame" x="0.0" y="90" width="350" height="41"/>
                                                             <string key="text">Jahrestreffen der 
 deutschen SAP Anwendergruppe</string>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -259,7 +259,7 @@ deutschen SAP Anwendergruppe</string>
                                                                     <rect key="frame" x="0.0" y="0.0" width="350" height="72"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatisch auschecken nach" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UBN-wb-TKy" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="241" height="72"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="269" height="72"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -268,7 +268,7 @@ deutschen SAP Anwendergruppe</string>
                                                                             </userDefinedRuntimeAttributes>
                                                                         </label>
                                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KL2-pg-6XN" customClass="ENAButton" customModule="ENA" customModuleProvider="target">
-                                                                            <rect key="frame" x="249" y="0.0" width="101" height="72"/>
+                                                                            <rect key="frame" x="277" y="0.0" width="73" height="72"/>
                                                                             <color key="tintColor" name="ENA Text Contrast Color"/>
                                                                             <state key="normal" title="03:00 Std.">
                                                                                 <color key="titleColor" name="ENA Text Primary 1 Color"/>
@@ -414,13 +414,13 @@ deutschen SAP Anwendergruppe</string>
             <size key="intrinsicContentSize" width="121" height="20.5"/>
         </designable>
         <designable name="KL2-pg-6XN">
-            <size key="intrinsicContentSize" width="101" height="50"/>
+            <size key="intrinsicContentSize" width="73" height="30"/>
         </designable>
         <designable name="LzL-ri-WCR">
-            <size key="intrinsicContentSize" width="108" height="50"/>
+            <size key="intrinsicContentSize" width="79" height="30"/>
         </designable>
         <designable name="M1z-st-0w7">
-            <size key="intrinsicContentSize" width="362" height="18"/>
+            <size key="intrinsicContentSize" width="402" height="20.5"/>
         </designable>
         <designable name="UBN-wb-TKy">
             <size key="intrinsicContentSize" width="209" height="18"/>
@@ -429,10 +429,10 @@ deutschen SAP Anwendergruppe</string>
             <size key="intrinsicContentSize" width="614.5" height="20.5"/>
         </designable>
         <designable name="qEg-yG-yRz">
-            <size key="intrinsicContentSize" width="434.5" height="67"/>
+            <size key="intrinsicContentSize" width="252" height="41"/>
         </designable>
         <designable name="qe2-Cr-Hsf">
-            <size key="intrinsicContentSize" width="123.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="117.5" height="20.5"/>
         </designable>
     </designables>
     <resources>

--- a/src/xcode/ENA/ENA/Source/Views/Common/HtmlTextView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/Common/HtmlTextView.swift
@@ -93,6 +93,7 @@ private extension ENAColor {
 		switch self {
 		// MARK: - Background Colors
 		case .background: return "background"
+		case .backgroundLightGray: return "lightGrayBackground"
 		case .darkBackground: return "darkBackground"
 		case .cellBackground: return "cellBackground"
 		case .hairline: return "hairline"


### PR DESCRIPTION
This PR changes the check-in background color from white to #f8f8f8 (light gray) as in the original Figma design (in light mode).

JIRA Ticket https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6370

![IMG_0521](https://user-images.githubusercontent.com/70148649/114877767-e3436c00-9dff-11eb-93fc-19b99ef1878e.PNG)
![IMG_0522](https://user-images.githubusercontent.com/70148649/114877775-e5a5c600-9dff-11eb-9e6a-527d8861252d.PNG)
