### PR TITLE
Event-Check-in Native Camera - wrong screenflow if installed app isn't onboarded

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -141,14 +141,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
 		// handle QR cdes scanned in the camera app
-		guard
-			userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-			let incomingURL = userActivity.webpageURL,
-			let route = Route(url: incomingURL),
-			store.isOnboarded
-		else {
+		
+		var route: Route?
+		if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let incomingURL = userActivity.webpageURL {
+			route = Route(url: incomingURL)
+		}
+		
+		guard store.isOnboarded else {
+			postOnboardingRoute = route
 			return false
 		}
+		
 		showHome(route)
 		return true
 	}
@@ -445,7 +448,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	private var exposureDetection: ExposureDetection?
 	private let consumer = RiskConsumer()
-
+	private var postOnboardingRoute: Route?
+	
 	private lazy var exposureDetectionExecutor: ExposureDetectionExecutor = {
 		ExposureDetectionExecutor(
 			client: self.client,
@@ -581,6 +585,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		if store.isOnboarded {
 			showHome(route)
 		} else {
+			postOnboardingRoute = route
 			showOnboarding()
 		}
 		UIImageView.appearance().accessibilityIgnoresInvertColors = true
@@ -691,7 +696,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	@objc
 	private func isOnboardedDidChange(_: NSNotification) {
-		store.isOnboarded ? showHome() : showOnboarding()
+		if store.isOnboarded {
+			showHome(postOnboardingRoute)
+			postOnboardingRoute = nil
+		} else {
+			showOnboarding()
+		}
 	}
 
 	@objc

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
@@ -71,8 +71,8 @@ final class CheckinCoordinator {
 				self.viewController.setViewControllers([topBottomContainerViewController], animated: false)
 				self.infoScreenShown = true // remember and don't show it again
 				// open trace location details screen if necessary
-				if let qrCode = self.showTraceLocationDetailsAfterInfoScreen {
-					self.showTraceLocationDetailsAfterInfoScreen = nil
+				if let qrCode = self.qrCodeAfterInfoScreen {
+					self.qrCodeAfterInfoScreen = nil
 					self.showTraceLocationDetailsFromExternalCamera(qrCode)
 				}
 			},
@@ -114,7 +114,7 @@ final class CheckinCoordinator {
 		guard infoScreenShown else {
 			Log.debug("Checkin info screen not shown. Skipping further navigation", log: .ui)
 			// set this to true to open trace location details screen after info screen has been dismissed
-			showTraceLocationDetailsAfterInfoScreen = qrCodeString
+			qrCodeAfterInfoScreen = qrCodeString
 			return
 		}
 		verificationService.verifyQrCode(
@@ -158,7 +158,7 @@ final class CheckinCoordinator {
 		get { store.checkinInfoScreenShown }
 		set { store.checkinInfoScreenShown = newValue }
 	}
-	private var showTraceLocationDetailsAfterInfoScreen: String?
+	private var qrCodeAfterInfoScreen: String?
 	
 	private lazy var checkinsOverviewViewModel: CheckinsOverviewViewModel = {
 		CheckinsOverviewViewModel(

--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/CheckinCoordinator.swift
@@ -70,6 +70,11 @@ final class CheckinCoordinator {
 				// Set as the only controller on the navigation stack to avoid back gesture etc.
 				self.viewController.setViewControllers([topBottomContainerViewController], animated: false)
 				self.infoScreenShown = true // remember and don't show it again
+				// open trace location details screen if necessary
+				if let qrCode = self.showTraceLocationDetailsAfterInfoScreen {
+					self.showTraceLocationDetailsAfterInfoScreen = nil
+					self.showTraceLocationDetailsFromExternalCamera(qrCode)
+				}
 			},
 			showDetail: { detailViewController in
 				self.viewController.pushViewController(detailViewController, animated: true)
@@ -105,9 +110,16 @@ final class CheckinCoordinator {
 	}
 	
 	func showTraceLocationDetailsFromExternalCamera(_ qrCodeString: String) {
+		// Info view MUST be shown
+		guard infoScreenShown else {
+			Log.debug("Checkin info screen not shown. Skipping further navigation", log: .ui)
+			// set this to true to open trace location details screen after info screen has been dismissed
+			showTraceLocationDetailsAfterInfoScreen = qrCodeString
+			return
+		}
 		verificationService.verifyQrCode(
 			qrCodeString: qrCodeString,
-			appConfigurationProvider: appConfiguration,
+			appConfigurationProvider: self.appConfiguration,
 			onSuccess: { [weak self] traceLocation in
 				self?.showTraceLocationDetails(traceLocation)
 				self?.verificationService.subscriptions.removeAll()
@@ -146,6 +158,7 @@ final class CheckinCoordinator {
 		get { store.checkinInfoScreenShown }
 		set { store.checkinInfoScreenShown = newValue }
 	}
+	private var showTraceLocationDetailsAfterInfoScreen: String?
 	
 	private lazy var checkinsOverviewViewModel: CheckinsOverviewViewModel = {
 		CheckinsOverviewViewModel(


### PR DESCRIPTION
## Description

Show event checkin after onboarding if user launched the app by scanning a QR code and hasn't completed onboarding yet.

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6448
