### PR TITLE
TestResult metadata should not be sent if status is pending and under 165 hours 

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -247,7 +247,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		   differenceBetweenRegistrationAndCurrentDateInHours >= hoursSinceTestRegistrationToSubmitTestResultMetadata {
 			return true
 		}
-		return true
+		return false
 	}
 	
 	private func generatePPACAndSubmitData(disableExposureWindowsProbability: Bool = false, completion: ((Result<Void, PPASError>) -> Void)? = nil) {


### PR DESCRIPTION
## Description
we should return false if all the checks has not been met

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6519
