### PR TITLE
fix/6508 missing checkin background image

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Checkin/Overview/CheckinsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Checkin/Overview/CheckinsOverviewViewController.swift
@@ -41,6 +41,9 @@ class CheckinsOverviewViewController: UITableViewController, FooterViewHandling 
 		parent?.navigationItem.title = AppStrings.Checkins.Overview.title
 		updateRightBarButtonItem(isEditing: false)
 
+		tableView.reloadData()
+		updateEmptyState()
+
 		viewModel.onUpdate = { [weak self] in
 			self?.animateChanges()
 		}


### PR DESCRIPTION
## Description
Trigger reload is not called on viewDidLoad, so we have to explicitly update the empty state in order to show the image. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6508

## Screenshots
![0e584b71-6957-4a5e-95a5-291a25f4ddce](https://user-images.githubusercontent.com/77438487/115015603-324ad900-9eb4-11eb-8665-94ddf6357147.jpeg)

