### PR TITLE
Feature/6552 update anitigen qr code to use hash

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		8F3D71AA25A86AD300D52CCD /* HomeExposureLoggingCellModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3D71A925A86AD300D52CCD /* HomeExposureLoggingCellModelTests.swift */; };
 		8F43A3CB25D55A3E008FD630 /* ppa_data.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F43A3C925D55A3D008FD630 /* ppa_data.pb.swift */; };
 		8F43A3CC25D55A3E008FD630 /* ppa_data_request_ios.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F43A3CA25D55A3E008FD630 /* ppa_data_request_ios.pb.swift */; };
+		8F63407C262D8F4400077240 /* AntigenTestInformation+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F634077262D8EAA00077240 /* AntigenTestInformation+Mock.swift */; };
 		8F7C39CC261B430700AEC979 /* QRCodeVerificationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7C39CB261B430700AEC979 /* QRCodeVerificationHelperTests.swift */; };
 		8F7C3A1A261BB53700AEC979 /* CheckinQRScannerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7C3A19261BB53700AEC979 /* CheckinQRScannerError.swift */; };
 		8F7C3A2B261C5F3500AEC979 /* default_app_config_200 in Resources */ = {isa = PBXBuildFile; fileRef = 8F7C3A2A261C5F3500AEC979 /* default_app_config_200 */; };
@@ -1644,6 +1645,7 @@
 		8F3D71A925A86AD300D52CCD /* HomeExposureLoggingCellModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeExposureLoggingCellModelTests.swift; sourceTree = "<group>"; };
 		8F43A3C925D55A3D008FD630 /* ppa_data.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ppa_data.pb.swift; sourceTree = "<group>"; };
 		8F43A3CA25D55A3E008FD630 /* ppa_data_request_ios.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ppa_data_request_ios.pb.swift; sourceTree = "<group>"; };
+		8F634077262D8EAA00077240 /* AntigenTestInformation+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AntigenTestInformation+Mock.swift"; sourceTree = "<group>"; };
 		8F7C39CB261B430700AEC979 /* QRCodeVerificationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeVerificationHelperTests.swift; sourceTree = "<group>"; };
 		8F7C3A19261BB53700AEC979 /* CheckinQRScannerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckinQRScannerError.swift; sourceTree = "<group>"; };
 		8F7C3A2A261C5F3500AEC979 /* default_app_config_200 */ = {isa = PBXFileReference; lastKnownFileType = file; path = default_app_config_200; sourceTree = "<group>"; };
@@ -4511,6 +4513,7 @@
 				AB86B2AE26026AC3007C77B3 /* EventCheckoutServiceTests.swift */,
 				AB86B2B826033E8F007C77B3 /* CheckinSplittingServiceTests.swift */,
 				0109DB9926037E6A00624BB3 /* TraceLocation+Mock.swift */,
+				8F634077262D8EAA00077240 /* AntigenTestInformation+Mock.swift */,
 				0109DB8E26037E1F00624BB3 /* Checkin+Mock.swift */,
 			);
 			path = __tests__;
@@ -7310,6 +7313,7 @@
 				A328425D248E82BC006B1F09 /* ExposureSubmissionTestResultViewControllerTests.swift in Sources */,
 				BA6C8B0E254D6BF9008344F5 /* RiskCalculationTest.swift in Sources */,
 				F22C6E2324917E3200712A6B /* DynamicTableViewControllerRowsTests.swift in Sources */,
+				8F63407C262D8F4400077240 /* AntigenTestInformation+Mock.swift in Sources */,
 				ABAC9D2E2624938100EB183F /* TestResultTests.swift in Sources */,
 				BAB6C82325C4666900E042FB /* PPACServiceTest.swift in Sources */,
 				BA7D177925D547D4006B9EBF /* DataDonationModelTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 		8F43A3CB25D55A3E008FD630 /* ppa_data.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F43A3C925D55A3D008FD630 /* ppa_data.pb.swift */; };
 		8F43A3CC25D55A3E008FD630 /* ppa_data_request_ios.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F43A3CA25D55A3E008FD630 /* ppa_data_request_ios.pb.swift */; };
 		8F63407C262D8F4400077240 /* AntigenTestInformation+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F634077262D8EAA00077240 /* AntigenTestInformation+Mock.swift */; };
+		8F634084262DBB6900077240 /* Route+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F634083262DBB6900077240 /* Route+Equatable.swift */; };
 		8F7C39CC261B430700AEC979 /* QRCodeVerificationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7C39CB261B430700AEC979 /* QRCodeVerificationHelperTests.swift */; };
 		8F7C3A1A261BB53700AEC979 /* CheckinQRScannerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F7C3A19261BB53700AEC979 /* CheckinQRScannerError.swift */; };
 		8F7C3A2B261C5F3500AEC979 /* default_app_config_200 in Resources */ = {isa = PBXBuildFile; fileRef = 8F7C3A2A261C5F3500AEC979 /* default_app_config_200 */; };
@@ -1646,6 +1647,7 @@
 		8F43A3C925D55A3D008FD630 /* ppa_data.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ppa_data.pb.swift; sourceTree = "<group>"; };
 		8F43A3CA25D55A3E008FD630 /* ppa_data_request_ios.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ppa_data_request_ios.pb.swift; sourceTree = "<group>"; };
 		8F634077262D8EAA00077240 /* AntigenTestInformation+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AntigenTestInformation+Mock.swift"; sourceTree = "<group>"; };
+		8F634083262DBB6900077240 /* Route+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Equatable.swift"; sourceTree = "<group>"; };
 		8F7C39CB261B430700AEC979 /* QRCodeVerificationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeVerificationHelperTests.swift; sourceTree = "<group>"; };
 		8F7C3A19261BB53700AEC979 /* CheckinQRScannerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckinQRScannerError.swift; sourceTree = "<group>"; };
 		8F7C3A2A261C5F3500AEC979 /* default_app_config_200 */ = {isa = PBXFileReference; lastKnownFileType = file; path = default_app_config_200; sourceTree = "<group>"; };
@@ -3162,6 +3164,7 @@
 				EB1BB11125CC40030076CB67 /* PlausibleDeniabilityService.swift */,
 				EB1BB10C25CC3FD50076CB67 /* AppDelegate.swift */,
 				BA6898CC25ED49E00037A3EE /* Route.swift */,
+				8F634083262DBB6900077240 /* Route+Equatable.swift */,
 				35BF067425DB1BA900D3868B /* AppDelegate+QuickActions.swift */,
 				35B2FAA925B9CE8F009ABC8E /* main.swift */,
 				353412CB2525EE4A0086D15C /* Globals.swift */,
@@ -6430,6 +6433,7 @@
 				ABE9612D25EFEB4E00D0F699 /* DMInstallationDateViewController.swift in Sources */,
 				50BD2E6224FE1E8700932566 /* AppInformationModel.swift in Sources */,
 				B1A89F3B24819CE800DA1CEC /* SettingsLabelCell.swift in Sources */,
+				8F634084262DBB6900077240 /* Route+Equatable.swift in Sources */,
 				EB855EFD25EED0C900FEE17C /* PDFDocument+EmbedImage.swift in Sources */,
 				50B5057D25CAEF5C00EEA380 /* OTPToken.swift in Sources */,
 				01CBD884261B3CF700158B3E /* ClientMock.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route+Equatable.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route+Equatable.swift
@@ -1,0 +1,51 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+// swiftlint:disable cyclomatic_complexity
+extension Route: Equatable {
+	static func == (lhs: Route, rhs: Route) -> Bool {
+		switch lhs {
+		case .rapidAntigen(let lhsResult):
+			switch rhs {
+			case .rapidAntigen(let rhsResult):
+				// lhs = rapidAntigen, rhs = rapidAntigen
+				switch lhsResult {
+				// comparing rapidAntigen results on both sides
+				case .failure(let lhsError):
+					switch rhsResult {
+					case .failure(let rhsError):
+						// lhs = failure, rhs = failure --> compare the error codes and return the result
+						return lhsError == rhsError
+					case .success:
+						// lhs = failure, rhs = success
+						return false
+					}
+				case .success(let lhsTestInformation):
+					switch rhsResult {
+					case .success(let rhsTestInformation):
+						// lhs = success, rhs = success --> compare the CoronaTestQRCodeInformation codes and return the result
+						return lhsTestInformation == rhsTestInformation
+					case .failure:
+						// lhs = success, rhs = failure
+						return false
+					}
+				}
+			case .checkIn:
+				// lhs = rapidAntigen, rhs = checkIn
+				return false
+			}
+		// comparing checkIn on both checkIn
+		case .checkIn(let lhsUrlString):
+			switch rhs {
+			case .checkIn(let rhsUrlString):
+				// lhs = checkIn, rhs = checkIn, compare the URL strings and return the result
+				return lhsUrlString == rhsUrlString
+			case .rapidAntigen:
+				// lhs = checkIn, rhs = rapidAntigen
+				return false
+			}
+		}
+	}
+}

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route+Equatable.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route+Equatable.swift
@@ -3,49 +3,23 @@
 //
 
 import Foundation
-// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable pattern_matching_keywords
 extension Route: Equatable {
 	static func == (lhs: Route, rhs: Route) -> Bool {
-		switch lhs {
-		case .rapidAntigen(let lhsResult):
-			switch rhs {
-			case .rapidAntigen(let rhsResult):
-				// lhs = rapidAntigen, rhs = rapidAntigen
-				switch lhsResult {
-				// comparing rapidAntigen results on both sides
-				case .failure(let lhsError):
-					switch rhsResult {
-					case .failure(let rhsError):
-						// lhs = failure, rhs = failure --> compare the error codes and return the result
-						return lhsError == rhsError
-					case .success:
-						// lhs = failure, rhs = success
-						return false
-					}
-				case .success(let lhsTestInformation):
-					switch rhsResult {
-					case .success(let rhsTestInformation):
-						// lhs = success, rhs = success --> compare the CoronaTestQRCodeInformation codes and return the result
-						return lhsTestInformation == rhsTestInformation
-					case .failure:
-						// lhs = success, rhs = failure
-						return false
-					}
-				}
-			case .checkIn:
-				// lhs = rapidAntigen, rhs = checkIn
+		switch (lhs, rhs) {
+		case (.rapidAntigen(let lhsResult), .rapidAntigen(let rhsResult)):
+			switch (lhsResult, rhsResult) {
+			case (.failure(let lhsError), .failure(let rhsError)):
+				return lhsError == rhsError
+			case (.success(let lhsTestInformation), .success(let rhsTestInformation)):
+				return lhsTestInformation == rhsTestInformation
+			case (.success, .failure), (.failure, .success):
 				return false
 			}
-		// comparing checkIn on both checkIn
-		case .checkIn(let lhsUrlString):
-			switch rhs {
-			case .checkIn(let rhsUrlString):
-				// lhs = checkIn, rhs = checkIn, compare the URL strings and return the result
-				return lhsUrlString == rhsUrlString
-			case .rapidAntigen:
-				// lhs = checkIn, rhs = rapidAntigen
-				return false
-			}
+		case (.checkIn(let lhsUrlString), .checkIn(let rhsUrlString)):
+			return lhsUrlString == rhsUrlString
+		case (.checkIn, .rapidAntigen), (.rapidAntigen, .checkIn):
+			return false
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route.swift
@@ -32,11 +32,10 @@ enum Route {
 
 			// extract payload
 			guard let testInformation = AntigenTestInformation(payload: payloadUrl),
-				  testInformation.guid.range(
-					of: #"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"#,
+				  testInformation.hash.range(
+					of: #"^[0-9A-Fa-f]{64}$"#,
 					options: .regularExpression
 				  ) != nil,
-				  testInformation.guid.count == 36,
 				  testInformation.timestamp >= 0
 			else {
 				self = .rapidAntigen( .failure(.invalidTestCode))

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/RouteTests.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/RouteTests.swift
@@ -9,7 +9,7 @@ class RouteTests: XCTestCase {
 
 	func testGIVEN_validRATUrl_WHEN_parseRoute_THEN_isValid() {
 		// GIVEN
-		let validRATTestURL = "https://s.coronawarn.app?v=1#eyJ0aW1lc3RhbXAiOjE2MTg0ODI2MzksImd1aWQiOiIzM0MxNDNENS0yMTgyLTQ3QjgtOTM4NS02ODBGMzE4RkU0OTMiLCJmbiI6IlJveSIsImxuIjoiRnJhc3NpbmV0aSIsImRvYiI6IjE5ODEtMTItMDEifQ=="
+		let validRATTestURL = "https://s.coronawarn.app?v=1#eyJ0aW1lc3RhbXAiOjE2MTg4MjQwNjIsInNhbHQiOiI1NjkxMDIzMTAyNkEzQ0Y3RDg5MTk3RkI4MjFDRDg3RDNFNDc1NEJCMDIwMzI1REU1MjA3RDcxNDM5OEI0MTlBIiwidGVzdElkIjoiM2U0YWQ1OGQtOWY5MS00NTgyLThhMmUtYWI5ZjkzMTg3YTBlIiwiaGFzaCI6IjI3N2ZiZDBhYzFlMTBjNWVmZDMxOTU1M2NlYmVmZjljODM3NGY4MGM1MTg3NmRhMDNjZjQxYWRkMmIzZmE3YWYiLCJmbiI6IkR1c3RpbiIsImxuIjoiRmVycmkiLCJkb2IiOiIxOTkxLTA3LTIxIn0="
 
 		// WHEN
 		let route = Route(validRATTestURL)

--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
@@ -9,13 +9,13 @@ struct AntigenTestInformation: Codable, Equatable {
 	// MARK: - Init
 
 	init(
-		guid: String,
+		hash: String,
 		timestamp: Int,
 		firstName: String?,
 		lastName: String?,
 		dateOfBirth: Date?
 	) {
-		self.guid = guid
+		self.hash = guid
 		self.timestamp = timestamp
 		self.firstName = firstName
 		self.lastName = lastName
@@ -57,18 +57,16 @@ struct AntigenTestInformation: Codable, Equatable {
 	// MARK: - Protocol Codable
 
 	enum CodingKeys: String, CodingKey {
-		case guid
+		case hash
 		case timestamp
 		case firstName = "fn"
 		case lastName = "ln"
 		case dateOfBirth = "dob"
 	}
-
-	// MARK: - Public
-
+		
 	// MARK: - Internal
 	
-	let guid: String
+	let hash: String
 	let timestamp: Int
 	let firstName: String?
 	let lastName: String?
@@ -90,6 +88,19 @@ struct AntigenTestInformation: Codable, Equatable {
 		}
 		return AntigenTestInformation.isoFormatter.string(from: dateOfBirth)
 	}
+	var hashOfTheHash: String {
+		guard let hashData = hash.data(using: .utf8) else {
+			Log.error("hash string couldn't be parsed to a data object", log: .qrCode)
+			return ""
+		}
+		return hashData.sha256String()
+	}
+	
+	// MARK: - Private
+	
+	private enum CodingKeys: String, CodingKey {
+		case hash, timestamp, firstName = "fn", lastName = "ln", dateOfBirth = "dob"
+	}
 
 	// MARK: - Private
 
@@ -99,5 +110,4 @@ struct AntigenTestInformation: Codable, Equatable {
 		isoFormatter.timeZone = TimeZone.current
 		return isoFormatter
 	}()
-
 }

--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
@@ -15,7 +15,7 @@ struct AntigenTestInformation: Codable, Equatable {
 		lastName: String?,
 		dateOfBirth: Date?
 	) {
-		self.hash = guid
+		self.hash = hash
 		self.timestamp = timestamp
 		self.firstName = firstName
 		self.lastName = lastName
@@ -95,13 +95,7 @@ struct AntigenTestInformation: Codable, Equatable {
 		}
 		return hashData.sha256String()
 	}
-	
-	// MARK: - Private
-	
-	private enum CodingKeys: String, CodingKey {
-		case hash, timestamp, firstName = "fn", lastName = "ln", dateOfBirth = "dob"
-	}
-
+		
 	// MARK: - Private
 
 	static let isoFormatter: ISO8601DateFormatter = {

--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/CoronaTestQRCodeInformation.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/CoronaTestQRCodeInformation.swift
@@ -3,8 +3,7 @@
 //
 
 import Foundation
-
-
+// swiftlint:disable pattern_matching_keywords
 enum QRCodeError: Error {
 	case invalidTestCode
 }
@@ -27,21 +26,13 @@ enum CoronaTestQRCodeInformation {
 
 extension CoronaTestQRCodeInformation: Equatable {
 	static func == (lhs: CoronaTestQRCodeInformation, rhs: CoronaTestQRCodeInformation) -> Bool {
-		switch lhs {
-		case .pcr(let lhsGuid):
-			switch rhs {
-			case .pcr(let rhsGuid):
-				return lhsGuid == rhsGuid
-			default:
-				return false
-			}
-		case .antigen(let lhsAntigenTestInformation):
-			switch rhs {
-			case .antigen(let rhsAntigenTestInformation):
-				return lhsAntigenTestInformation == rhsAntigenTestInformation
-			default:
-				return false
-			}
+		switch (lhs, rhs) {
+		case (.pcr(let lhsGuid), .pcr(let rhsGuid)):
+			return lhsGuid == rhsGuid
+		case (.antigen(let lhsAntigenTestInformation), .antigen(let rhsAntigenTestInformation)):
+			return lhsAntigenTestInformation == rhsAntigenTestInformation
+		case (.antigen, .pcr), (.pcr, .antigen):
+			return false
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/CoronaTestQRCodeInformation.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/CoronaTestQRCodeInformation.swift
@@ -24,3 +24,24 @@ enum CoronaTestQRCodeInformation {
 		}
 	}
 }
+
+extension CoronaTestQRCodeInformation: Equatable {
+	static func == (lhs: CoronaTestQRCodeInformation, rhs: CoronaTestQRCodeInformation) -> Bool {
+		switch lhs {
+		case .pcr(let lhsGuid):
+			switch rhs {
+			case .pcr(let rhsGuid):
+				return lhsGuid == rhsGuid
+			default:
+				return false
+			}
+		case .antigen(let lhsAntigenTestInformation):
+			switch rhs {
+			case .antigen(let rhsAntigenTestInformation):
+				return lhsAntigenTestInformation == rhsAntigenTestInformation
+			default:
+				return false
+			}
+		}
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/__tests_/AntigenTestInformationTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/__tests_/AntigenTestInformationTests.swift
@@ -14,7 +14,7 @@ class AntigenTestInformationTests: XCTestCase {
 
 		// GIVEN
 		let antigenTestInformation = AntigenTestInformation(
-			guid: "GUID123",
+			hash: "asbf3242",
 			timestamp: 123456789,
 			firstName: "Thomase",
 			lastName: "Mustermann",

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/AntigenTestInformation+Mock.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/AntigenTestInformation+Mock.swift
@@ -11,7 +11,7 @@ extension AntigenTestInformation {
 		timestamp: Int = 5,
 		firstName: String? = nil,
 		lastName: String? = nil,
-		dateOfBirth: String? = nil
+		dateOfBirth: Date? = nil
 	) -> Self? {
 		AntigenTestInformation(
 			hash: hash,

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/AntigenTestInformation+Mock.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/__tests__/AntigenTestInformation+Mock.swift
@@ -1,0 +1,24 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+@testable import ENA
+
+extension AntigenTestInformation {
+	static func mock(
+		hash: String = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b7414464086",
+		timestamp: Int = 5,
+		firstName: String? = nil,
+		lastName: String? = nil,
+		dateOfBirth: String? = nil
+	) -> Self? {
+		AntigenTestInformation(
+			hash: hash,
+			timestamp: timestamp,
+			firstName: firstName,
+			lastName: lastName,
+			dateOfBirth: dateOfBirth
+		)
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
@@ -143,7 +143,7 @@ class ExposureSubmissionCoordinatorModel {
 			)
 		case .antigen(let rapidTest):
 			coronaTestService.registerAntigenTestAndGetResult(
-				with: rapidTest.guid,
+				with: rapidTest.hashOfTheHash,
 				pointOfCareConsentDate: rapidTest.pointOfCareConsentDate,
 				name: rapidTest.fullName,
 				birthday: rapidTest.dateOfBirthString,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
@@ -438,7 +438,34 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		// THEN
 		XCTAssertNil(result)
 	}
-	
+	func testAntigen_hashIsTooShort() {
+		let invalidHash = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b741446408"
+		let antigenTestInformation = AntigenTestInformation.mock(hash: invalidHash)
+		
+		do {
+			let payloadData = try XCTUnwrap(JSONEncoder().encode(antigenTestInformation))
+			let payloadString = payloadData.base64EncodedString()
+			let url = "https://s.coronawarn.app/?v=1#\(payloadString)"
+			let route = Route(url)
+			XCTAssertEqual(route, Route.rapidAntigen( .failure(.invalidTestCode)), "incorrect hash should trigger an error")
+		} catch {
+			XCTFail("Caught an error while trying to encode the Antigen test")
+		}
+	}
+	func testAntigen_hashIsNotHex() {
+		let invalidHash = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b741446408G"
+		let antigenTestInformation = AntigenTestInformation.mock(hash: invalidHash)
+		
+		do {
+			let payloadData = try XCTUnwrap(JSONEncoder().encode(antigenTestInformation))
+			let payloadString = payloadData.base64EncodedString()
+			let url = "https://s.coronawarn.app/?v=1#\(payloadString)"
+			let route = Route(url)
+			XCTAssertEqual(route, Route.rapidAntigen( .failure(.invalidTestCode)), "incorrect hash should trigger an error")
+		} catch {
+			XCTFail("Caught an error while trying to encode the Antigen test")
+		}
+	}
 	func testHashOFTheHash() {
 		// both the hash and the expectedHashOfTheHash are extracted from a known valid Antigen test from the Tech specs
 		let hash = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b7414464086"

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
@@ -79,8 +79,8 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 	}
 	
 	func testSuccessfulAntigenScan_Base64URL() throws {
-		let payload = "eyJ0aW1lc3RhbXAiOjE2MTgzMDYwNTYsImd1aWQiOiI1OEM0MERBMC00Q0M1LTQ4ODAtOTIyMS0xNjBCNjA1OTIxQzAiLCJmbiI6IkpvZWwiLCJsbiI6IkdyYXppYW5pIiwiZG9iIjoiMTk4OC0wNy0wOSJ9"
-		let antigenTestInformation = try XCTUnwrap(AntigenTestInformation(payload: payload))
+		let payload = "eyJ0aW1lc3RhbXAiOjE2MTg4MjA0MDAsInNhbHQiOiIxNUE3MUZBQkYzRDMzODUzMTk3Mzk4MTJERTA0RDMwNUUwNDA4MkZEREQ0OEEzRTk4N0IwOUNBMUVBRUUwODJFIiwidGVzdElkIjoiZTA2ZGNlMDgtZTExYy00Yjg2LWI2NTUtNTljMzVjYTE4ODVkIiwiaGFzaCI6ImYxMjAwZDk2NTBmMWZkNjczZDU4ZjUyODExZjk4ZjE0MjdmYWI0MGI0OTk2ZTljMmQwZGE4Yjc0MTQ0NjQwODYiLCJmbiI6IkFsdGEiLCJsbiI6IkdyaWZmaW4iLCJkb2IiOiIxOTY0LTEwLTI0In0"
+		let validAntigenHash = try XCTUnwrap(self.validAntigenHash(validPayload: payload))
 
 		let onSuccessExpectation = expectation(description: "onSuccess called")
 		onSuccessExpectation.expectedFulfillmentCount = 1
@@ -93,7 +93,7 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 			onSuccess: { testInformation in
 				switch testInformation {
 				case .antigen(let testInformation):
-					XCTAssertEqual(testInformation.guid, antigenTestInformation.guid)
+					XCTAssertEqual(testInformation.hash, validAntigenHash)
 				case .pcr:
 					XCTFail("Expected antigen test")
 				}
@@ -115,8 +115,8 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		waitForExpectations(timeout: .short)
 	}
 	func testSuccessfulAntigenScan_base64() throws {
-		let payload = "eyJ0aW1lc3RhbXAiOjE2MTgzMDY1MzAsImd1aWQiOiJDQzcyMEI2Ni1CNTBFLTQ1NzAtQUNCNC02RUExNEFEMDdGRDIiLCJmbiI6Ikhlcm1hbiIsImxuIjoiTWFydGluZXoiLCJkb2IiOiIxOTY0LTA5LTI3In0="
-		let antigenTestInformation = try XCTUnwrap(AntigenTestInformation(payload: payload))
+		let payload = "eyJ0aW1lc3RhbXAiOjE2MTg4MjQwNjIsInNhbHQiOiI1NjkxMDIzMTAyNkEzQ0Y3RDg5MTk3RkI4MjFDRDg3RDNFNDc1NEJCMDIwMzI1REU1MjA3RDcxNDM5OEI0MTlBIiwidGVzdElkIjoiM2U0YWQ1OGQtOWY5MS00NTgyLThhMmUtYWI5ZjkzMTg3YTBlIiwiaGFzaCI6IjI3N2ZiZDBhYzFlMTBjNWVmZDMxOTU1M2NlYmVmZjljODM3NGY4MGM1MTg3NmRhMDNjZjQxYWRkMmIzZmE3YWYiLCJmbiI6IkR1c3RpbiIsImxuIjoiRmVycmkiLCJkb2IiOiIxOTkxLTA3LTIxIn0="
+		let validAntigenHash = try XCTUnwrap(self.validAntigenHash(validPayload: payload))
 
 		let onSuccessExpectation = expectation(description: "onSuccess called")
 		onSuccessExpectation.expectedFulfillmentCount = 1
@@ -129,7 +129,7 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 			onSuccess: { testInformation in
 				switch testInformation {
 				case .antigen(let testInformation):
-					XCTAssertEqual(testInformation.guid, antigenTestInformation.guid)
+					XCTAssertEqual(testInformation.hash, validAntigenHash)
 				case .pcr:
 					XCTFail("Expected antigen test")
 				}
@@ -279,7 +279,7 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		XCTAssertNil(result)
 	}
 
-	func testQRCodeExtration_someUTF8Text() {
+	func testQRCodeExtraction_someUTF8Text() {
 		let viewModel = createViewModel()
 
 		let result = viewModel.coronaTestQRCodeInformation(from: "This is a Test ん鞠")
@@ -323,23 +323,6 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		let viewModel = createViewModel()
 
 		let result = viewModel.coronaTestQRCodeInformation(from: "https://localhost/?\(validPcrGuid.dropLast(4))")
-
-		XCTAssertNil(result)
-	}
-
-	func testAntigenQRCodeExtraction_GUIDLengthExceeded() throws {
-
-		let viewModel = createViewModel()
-		let antigenInformation = try XCTUnwrap(AntigenTestInformation(payload: validAntigenPayLoad))
-		let result = viewModel.coronaTestQRCodeInformation(from: "https://s.coronawarn.app/?v=1#\(antigenInformation)-BEEF")
-
-		XCTAssertNil(result)
-	}
-
-	func testAntigenPcrQRCodeExtraction_GUIDTooShort() throws {
-		let viewModel = createViewModel()
-		let invalidPayload = String(validAntigenPayLoad.dropLast(4))
-		let result = viewModel.coronaTestQRCodeInformation(from: invalidPayload)
 
 		XCTAssertNil(result)
 	}
@@ -456,11 +439,40 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 		XCTAssertNil(result)
 	}
 	
-	private let validPcrGuid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
-	private let validAntigenPayLoad = "eyJ0aW1lc3RhbXAiOjE2MTgzMDY1MzAsImd1aWQiOiJDQzcyMEI2Ni1CNTBFLTQ1NzAtQUNCNC02RUExNEFEMDdGRDIiLCJmbiI6Ikhlcm1hbiIsImxuIjoiTWFydGluZXoiLCJkb2IiOiIxOTY0LTA5LTI3In0="
+	func testHashOFTheHash() {
+		// both the hash and the expectedHashOfTheHash are extracted from a known valid Antigen test from the Tech specs
+		let hash = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b7414464086"
+		let expectedHashOfTheHash = "0984a938a78a33331d65c9341f5d272286e0b621adfa283237e788237a081ccb"
+		
+		let antigenTestInformation = AntigenTestInformation.mock(hash: hash)
+		XCTAssertEqual(antigenTestInformation?.hashOfTheHash, expectedHashOfTheHash, "Hash Does not match expected hash")
+	}
 
+	private let validPcrGuid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
+	private func validAntigenHash(validPayload: String) -> String? {
+
+		let jsonData: Data
+		if validPayload.isBase64Encoded {
+			guard let parsedData = Data(base64Encoded: validPayload) else {
+				return nil
+			}
+			jsonData = parsedData
+		} else {
+			guard let parsedData = Data(base64URLEncoded: validPayload) else {
+				return nil
+			}
+			jsonData = parsedData
+		}
+		do {
+			let testInformation = try JSONDecoder().decode(AntigenTestInformation.self, from: jsonData)
+			return testInformation.hash
+		} catch {
+			Log.debug("Failed to read / parse district json", log: .ppac)
+			return nil
+		}
+	}
+	
 	private func createViewModel() -> ExposureSubmissionQRScannerViewModel {
 		ExposureSubmissionQRScannerViewModel(onSuccess: { _ in }, onError: { _, _ in })
 	}
-
 }


### PR DESCRIPTION
## Description
Update the QR code scan handling for Antigen tests to use the Hash instead of the guid and update unit tests accordingly.
**Side note**: with the current implementation of the Antigen tests "Payload have to be parsed into 64 bit data then parsed as a JSON object" makes it harder to test the verification process of the hash as it is encapsulated inside the Payload, I will create a separate PR for adding this extra tests

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6552

