### PR TITLE
Rearrange Backgroundtasks priority 

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -53,7 +53,8 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 			self.executeExposureDetectionRequest { _ in
 				Log.info("Done detecting Exposures…", log: .background)
 				
-				
+				/// ExposureDetection should be our highest Priority if we run all other tasks simultaneously we might get killed by the Watchdog while the Detection is running.
+				/// This could leave us in a dirty state which causes the ExposureDetection to run too often. This will then lead to Error 13. (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5836)
 				group.enter()
 				DispatchQueue.global().async {
 					Log.info("Trying to submit TEKs…", log: .background)

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -73,7 +73,6 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 					}
 				}
 
-
 				group.enter()
 				DispatchQueue.global().async {
 					Log.info("Starting FakeRequests…", log: .background)
@@ -120,7 +119,6 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 
 			}
 		}
-		
 		
 		group.notify(queue: .main) {
 			completion(true)


### PR DESCRIPTION
## Description
Currently the background task triggers all our Processes that need to run in the Background at the same time. 
This could lead to a situation that the Watchdog is killing our Background process, which could then lead to a situation that the ExposureDetection is triggered too often, which then will lead to Error 13.

This PR changes this behaviour and runs all Backgroundtasks AFTER the ExposureDetection is done.
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5836

