### PR TITLE
do not show loading indicators when we navigate back from warn others…

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
@@ -281,8 +281,8 @@ extension ExposureSubmissionTestResultViewModel {
 								activityIndicatorView.startAnimating()
 								cell?.accessoryView = isLoading ? activityIndicatorView : nil
 								cell?.isUserInteractionEnabled = !isLoading
-								self?.footerViewModel?.setLoadingIndicator(false, disable: isLoading, button: .primary)
-								self?.footerViewModel?.setLoadingIndicator(false, disable: isLoading, button: .secondary)
+								self?.footerViewModel?.setEnabled(isLoading, button: .primary)
+								self?.footerViewModel?.setEnabled(isLoading, button: .secondary)
 							}
 						},
 						configure: { _, cell, _ in

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
@@ -281,8 +281,8 @@ extension ExposureSubmissionTestResultViewModel {
 								activityIndicatorView.startAnimating()
 								cell?.accessoryView = isLoading ? activityIndicatorView : nil
 								cell?.isUserInteractionEnabled = !isLoading
-								self?.footerViewModel?.setLoadingIndicator(true, disable: isLoading, button: .primary)
-								self?.footerViewModel?.setLoadingIndicator(true, disable: isLoading, button: .secondary)
+								self?.footerViewModel?.setLoadingIndicator(false, disable: isLoading, button: .primary)
+								self?.footerViewModel?.setLoadingIndicator(false, disable: isLoading, button: .secondary)
 							}
 						},
 						configure: { _, cell, _ in


### PR DESCRIPTION

## Description
When we navigate back from warn others screen the pending test result buttons are loading.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6528

