### PR TITLE
remove the hashing from the AntigenTestInformation model

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Submisstion/AntigenTestInformation.swift
@@ -88,13 +88,6 @@ struct AntigenTestInformation: Codable, Equatable {
 		}
 		return AntigenTestInformation.isoFormatter.string(from: dateOfBirth)
 	}
-	var hashOfTheHash: String {
-		guard let hashData = hash.data(using: .utf8) else {
-			Log.error("hash string couldn't be parsed to a data object", log: .qrCode)
-			return ""
-		}
-		return hashData.sha256String()
-	}
 		
 	// MARK: - Private
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
@@ -143,7 +143,7 @@ class ExposureSubmissionCoordinatorModel {
 			)
 		case .antigen(let antigenTest):
 			coronaTestService.registerAntigenTestAndGetResult(
-				with: antigenTest.hashOfTheHash,
+				with: antigenTest.hash,
 				pointOfCareConsentDate: antigenTest.pointOfCareConsentDate,
 				firstName: antigenTest.firstName,
 				lastName: antigenTest.lastName,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/QRScanner/ExposureSubmissionQRScannerViewModelTests.swift
@@ -466,14 +466,6 @@ final class ExposureSubmissionQRScannerViewModelTests: XCTestCase {
 			XCTFail("Caught an error while trying to encode the Antigen test")
 		}
 	}
-	func testHashOFTheHash() {
-		// both the hash and the expectedHashOfTheHash are extracted from a known valid Antigen test from the Tech specs
-		let hash = "f1200d9650f1fd673d58f52811f98f1427fab40b4996e9c2d0da8b7414464086"
-		let expectedHashOfTheHash = "0984a938a78a33331d65c9341f5d272286e0b621adfa283237e788237a081ccb"
-		
-		let antigenTestInformation = AntigenTestInformation.mock(hash: hash)
-		XCTAssertEqual(antigenTestInformation?.hashOfTheHash, expectedHashOfTheHash, "Hash Does not match expected hash")
-	}
 
 	private let validPcrGuid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
 	private func validAntigenHash(validPayload: String) -> String? {

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -197,7 +197,7 @@ class CoronaTestService {
 	}
 
 	func registerAntigenTestAndGetResult(
-		with guid: String,
+		with hash: String,
 		pointOfCareConsentDate: Date,
 		firstName: String?,
 		lastName: String?,
@@ -205,10 +205,10 @@ class CoronaTestService {
 		isSubmissionConsentGiven: Bool,
 		completion: @escaping TestResultHandler
 	) {
-		Log.info("[CoronaTestService] Registering antigen test (guid: \(guid), pointOfCareConsentDate: \(pointOfCareConsentDate), firstName: \(String(describing: firstName)), lastName: \(String(describing: lastName)), dateOfBirth: \(String(describing: dateOfBirth)), isSubmissionConsentGiven: \(isSubmissionConsentGiven))", log: .api)
+		Log.info("[CoronaTestService] Registering antigen test (hash: \(hash), pointOfCareConsentDate: \(pointOfCareConsentDate), firstName: \(String(describing: firstName)), lastName: \(String(describing: lastName)), dateOfBirth: \(String(describing: dateOfBirth)), isSubmissionConsentGiven: \(isSubmissionConsentGiven))", log: .api)
 
 		getRegistrationToken(
-			forKey: ENAHasher.sha256(guid),
+			forKey: ENAHasher.sha256(hash),
 			withType: "GUID",
 			completion: { [weak self] result in
 				switch result {


### PR DESCRIPTION
## Description
We were hashing the Antigen test hash twice while we should hash it only once before registering it

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6622
