### PR TITLE
Fix/screenshots

### DIFF
--- a/src/xcode/ENA/ENA/Source/RootCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/RootCoordinator.swift
@@ -117,7 +117,8 @@ class RootCoordinator: RequiresAppDependencies {
 		tabBarController.tabBar.tintColor = .enaColor(for: .tint)
 		tabBarController.tabBar.barTintColor = .enaColor(for: .background)
 		tabBarController.setViewControllers([homeCoordinator.rootViewController, checkInCoordinator.viewController, diaryCoordinator.viewController], animated: false)
-
+		
+		viewController.clearChildViewController()
 		viewController.embedViewController(childViewController: tabBarController)
 	}
 

--- a/src/xcode/ENA/ENAUITests/ENAUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ENAUITests.swift
@@ -128,7 +128,7 @@ class ENAUITests: XCTestCase {
 		// ScreenShot_0006: Negative result
 		try navigateThroughOnboarding()
 		XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Home.submitCardButton].waitForExistence(timeout: .medium))
-		app.buttons[AccessibilityIdentifiers.Home.submitCardButton].tap()
+		app.buttons[AccessibilityIdentifiers.Home.submitCardButton].firstMatch.tap()
 
 		if snapshotsActive { snapshot("AppStore_0006") }
 	}


### PR DESCRIPTION
## Description
This PR fixes the failing Screenshots.

The Tests failed because there where two navigation bars on screen. Two? You might ask yourself. Yes two. After we moved from the onboarding to the HomeScreen the Onboarding didn't got removed from the view hierarchy. This PR corrects this.