### PR TITLE
Schedule warn others notifications if consent is NOT given

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -374,7 +374,7 @@ class CoronaTestService {
 
 		DeadmanNotificationManager(coronaTestService: self).resetDeadmanNotification()
 
-		if let coronaTest = coronaTest(ofType: coronaTestType), coronaTest.isSubmissionConsentGiven,
+		if let coronaTest = coronaTest(ofType: coronaTestType), !coronaTest.isSubmissionConsentGiven,
 			coronaTest.positiveTestResultWasShown, !coronaTest.keysSubmitted {
 			warnOthersReminder.scheduleNotifications(for: coronaTestType)
 		}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/ExposureSubmissionService.swift
@@ -173,11 +173,10 @@ class ENAExposureSubmissionService: ExposureSubmissionService {
 		diagnosisKeysRetrieval.exposureManagerState
 	}
 
-var checkins: [Checkin] {
-get { store.submissionCheckins }
-set { store.submissionCheckins = newValue }
-}
-
+	var checkins: [Checkin] {
+		get { store.submissionCheckins }
+		set { store.submissionCheckins = newValue }
+	}
 
 	// MARK: - Private
 


### PR DESCRIPTION
## Description
The logic is the wrong way around, warn others notifications need to be scheduled if the submission consent is **not** given

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6690
