### PR TITLE
Fix/6692 migration

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -405,7 +405,7 @@ class CoronaTestService {
 				registrationToken: store.registrationToken,
 				testResult: keysSubmitted || store.positiveTestResultWasShown ? .positive : .pending,
 				finalTestResultReceivedDate: store.testResultReceivedTimeStamp.map { Date(timeIntervalSince1970: TimeInterval($0)) },
-				positiveTestResultWasShown: store.positiveTestResultWasShown,
+				positiveTestResultWasShown: store.positiveTestResultWasShown || keysSubmitted,
 				isSubmissionConsentGiven: store.isSubmissionConsentGiven,
 				submissionTAN: store.tan,
 				keysSubmitted: keysSubmitted,

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -397,9 +397,8 @@ class CoronaTestService {
 	}
 
 	func migrate() {
-		if store.registrationToken != nil || store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil, let testRegistrationTimestamp = store.devicePairingConsentAcceptTimestamp {
-			let keysSubmitted = store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil
-
+		let keysSubmitted = store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil
+		if store.registrationToken != nil || keysSubmitted, let testRegistrationTimestamp = store.devicePairingConsentAcceptTimestamp {
 			pcrTest = PCRTest(
 				registrationDate: Date(timeIntervalSince1970: TimeInterval(testRegistrationTimestamp)),
 				registrationToken: store.registrationToken,

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -399,12 +399,21 @@ class CoronaTestService {
 	func migrate() {
 		let keysSubmitted = store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil
 		if store.registrationToken != nil || keysSubmitted, let testRegistrationTimestamp = store.devicePairingConsentAcceptTimestamp {
+			// The registration token is set to nil after submission, therefore we cannot fetch the result from the server and need
+			// to infer a positive test result when keys were submitted. If the positive test result was shown we also can confidently set it to .positive.
+			// For all other cases we set it to .pending and fetch the actual test result afterwards, as we did not store it in v2.0 and earlier.
+			let testResult: TestResult = keysSubmitted || store.positiveTestResultWasShown ? .positive : .pending
+
+			// In v2.0 and earlier the `positiveTestResultWasShown` property was reset on submission,
+			// from v2.1 we keep it set to true even after the submission.
+			let positiveTestResultWasShown = store.positiveTestResultWasShown || keysSubmitted
+
 			pcrTest = PCRTest(
 				registrationDate: Date(timeIntervalSince1970: TimeInterval(testRegistrationTimestamp)),
 				registrationToken: store.registrationToken,
-				testResult: keysSubmitted || store.positiveTestResultWasShown ? .positive : .pending,
+				testResult: testResult,
 				finalTestResultReceivedDate: store.testResultReceivedTimeStamp.map { Date(timeIntervalSince1970: TimeInterval($0)) },
-				positiveTestResultWasShown: store.positiveTestResultWasShown || keysSubmitted,
+				positiveTestResultWasShown: positiveTestResultWasShown,
 				isSubmissionConsentGiven: store.isSubmissionConsentGiven,
 				submissionTAN: store.tan,
 				keysSubmitted: keysSubmitted,

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -398,15 +398,17 @@ class CoronaTestService {
 
 	func migrate() {
 		if store.registrationToken != nil || store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil, let testRegistrationTimestamp = store.devicePairingConsentAcceptTimestamp {
+			let keysSubmitted = store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil
+
 			pcrTest = PCRTest(
 				registrationDate: Date(timeIntervalSince1970: TimeInterval(testRegistrationTimestamp)),
 				registrationToken: store.registrationToken,
-				testResult: .pending,
+				testResult: keysSubmitted || store.positiveTestResultWasShown ? .positive : .pending,
 				finalTestResultReceivedDate: store.testResultReceivedTimeStamp.map { Date(timeIntervalSince1970: TimeInterval($0)) },
 				positiveTestResultWasShown: store.positiveTestResultWasShown,
 				isSubmissionConsentGiven: store.isSubmissionConsentGiven,
 				submissionTAN: store.tan,
-				keysSubmitted: store.lastSuccessfulSubmitDiagnosisKeyTimestamp != nil,
+				keysSubmitted: keysSubmitted,
 				journalEntryCreated: false
 			)
 


### PR DESCRIPTION
## Description
The migration of PCR tests submitted in v2.0 and earlier was not correct. As the registration token was already nil and the test result could not be fetched from the server anymore, we need to set the test result to .positive for submitted tests. And we need to keep the positiveTestResultShown flag set to true even after the submission because the home table view model logic is relying on that in v2.1.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6692