### PR TITLE
"Data is being downloaded.." is shown every time you navigate back to the homescreen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/Model/TraceWarningSuccess.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/Model/TraceWarningSuccess.swift
@@ -9,4 +9,5 @@ enum TraceWarningSuccess {
 	case noCheckins
 	case emptyAvailablePackages
 	case emptySinglePackage
+	case noPackagesAvailable
 }

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -226,6 +226,12 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 		// 3. Clean up revoked Packages.
 		let revokedPackages = appConfig.keyDownloadParameters.revokedTraceWarningPackages
 		removeRevokedTraceWarningMetadataPackages(revokedPackages)
+				
+		guard !eventStore.traceWarningPackageMetadatasPublisher.value.isEmpty else {
+			Log.info("TraceWarningPackageDownload: Aborted due to checkin metadata database is empty.", log: .checkin)
+			completion(.success(.success))
+			return
+		}
 		
 		self.status = .downloading
 		

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -275,7 +275,7 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 		let packagesToDownload = determinePackagesToDownload(availables: availablePackagesOnCDN, earliest: earliestRelevantPackage)
 		
 		guard !packagesToDownload.isEmpty else {
-			Log.info("TraceWarningPackageDownload: Aborted due to checkin metadata database is empty.", log: .checkin)
+			Log.info("TraceWarningPackageDownload: Aborted due to no packages to download.", log: .checkin)
 			completion(.success(.success))
 			return
 		}

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -226,14 +226,6 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 		// 3. Clean up revoked Packages.
 		let revokedPackages = appConfig.keyDownloadParameters.revokedTraceWarningPackages
 		removeRevokedTraceWarningMetadataPackages(revokedPackages)
-				
-		guard !eventStore.traceWarningPackageMetadatasPublisher.value.isEmpty else {
-			Log.info("TraceWarningPackageDownload: Aborted due to checkin metadata database is empty.", log: .checkin)
-			completion(.success(.success))
-			return
-		}
-		
-		self.status = .downloading
 		
 		// 4. Determine availablePackagesOnCDN (http discovery)
 		client.traceWarningPackageDiscovery(country: country, completion: { [weak self] result in
@@ -281,6 +273,14 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 				
 		// 7. Determine packagesToDownload
 		let packagesToDownload = determinePackagesToDownload(availables: availablePackagesOnCDN, earliest: earliestRelevantPackage)
+		
+		guard !packagesToDownload.isEmpty else {
+			Log.info("TraceWarningPackageDownload: Aborted due to checkin metadata database is empty.", log: .checkin)
+			completion(.success(.success))
+			return
+		}
+		
+		status = .downloading
 
 		Log.info("TraceWarningPackageDownload: Determined packages to download: \(packagesToDownload). Proceed with downloading the single packages...")
 		self.downloadDeterminedPackages(packageIds: packagesToDownload, country: country, completion: completion)

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -210,6 +210,8 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 					completion(.success(.emptyAvailablePackages))
 				} else if successes.contains(.emptySinglePackage) {
 					completion(.success(.emptySinglePackage))
+				} else if successes.contains(.noPackagesAvailable) {
+					completion(.success(.noPackagesAvailable))
 				} else {
 					completion(.success(.success))
 				}
@@ -276,7 +278,7 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 		
 		guard !packagesToDownload.isEmpty else {
 			Log.info("TraceWarningPackageDownload: Aborted due to no packages to download.", log: .checkin)
-			completion(.success(.success))
+			completion(.success(.noPackagesAvailable))
 			return
 		}
 		

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/__tests__/TraceWarningPackageDownloadTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/__tests__/TraceWarningPackageDownloadTests.swift
@@ -93,7 +93,7 @@ class TraceWarningPackageDownloadTests: XCTestCase {
 		
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(responseCode, .noCheckins)
+		XCTAssertEqual(responseCode, .success)
 	}
 	
 	func testGIVEN_TraceWarningDownload_WHEN_AvailablePackagesOnCDNAreEmpty_THEN_Success() {

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/__tests__/TraceWarningPackageDownloadTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/__tests__/TraceWarningPackageDownloadTests.swift
@@ -93,7 +93,43 @@ class TraceWarningPackageDownloadTests: XCTestCase {
 		
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(responseCode, .success)
+		XCTAssertEqual(responseCode, .noCheckins)
+	}
+	
+	func testGIVEN_TraceWarningDownload_WHEN_CheckInDatabaseIsNotEmpty_THEN_Success() {
+		
+		// GIVEN
+		let appConfig = SAP_Internal_V2_ApplicationConfigurationIOS()
+		let eventStore = MockEventStore()
+		
+		let checkin = Checkin.mock()
+		eventStore.createCheckin(checkin)
+		
+		let traceWarningPackageDownload = TraceWarningPackageDownload(
+			client: ClientMock(),
+			store: MockTestStore(),
+			eventStore: eventStore
+		)
+		
+		let successExpectation = expectation(description: "TraceWarningPackage CheckInDatabaseIsNotEmpty_THEN_Success.")
+		
+		// WHEN
+		var responseCode: TraceWarningSuccess?
+		traceWarningPackageDownload.startTraceWarningPackageDownload(with: appConfig, completion: { result in
+			switch result {
+			
+			case let .success(success):
+				responseCode = success
+				print(responseCode)
+				successExpectation.fulfill()
+			case let .failure(error):
+				XCTFail("Test should not fail but did with error: \(error)")
+			}
+		})
+		
+		// THEN
+		waitForExpectations(timeout: .medium)
+		XCTAssertEqual(responseCode, .noPackagesAvailable)
 	}
 	
 	func testGIVEN_TraceWarningDownload_WHEN_AvailablePackagesOnCDNAreEmpty_THEN_Success() {
@@ -233,7 +269,7 @@ class TraceWarningPackageDownloadTests: XCTestCase {
 		
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(responseCodeSuccess, .success)
+		XCTAssertEqual(responseCodeSuccess, .noPackagesAvailable)
 		XCTAssertEqual(responseCodeError, .downloadIsRunning)
 	}
 	


### PR DESCRIPTION
## Description

Prevent package downloading if trace warning metadata is empty. No need to try discovering anything.

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6608
