### PR TITLE
Fix/6766 reset appconfig on environment change

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMServerEnvironmentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMServerEnvironmentViewController.swift
@@ -33,7 +33,7 @@ class DMServerEnvironmentViewController: UIViewController, UIPickerViewDelegate,
 
 		currentEnvironmentLabel = UILabel(frame: .zero)
 		currentEnvironmentLabel.translatesAutoresizingMaskIntoConstraints = false
-		updateCurrentEnviromentLabel()
+		updateCurrentEnvironmentLabel()
 
 		picker = UIPickerView(frame: .zero)
 		picker.translatesAutoresizingMaskIntoConstraints = false
@@ -86,7 +86,7 @@ class DMServerEnvironmentViewController: UIViewController, UIPickerViewDelegate,
 	private var currentEnvironmentLabel: UILabel!
 	private var picker: UIPickerView!
 
-	private func updateCurrentEnviromentLabel() {
+	private func updateCurrentEnvironmentLabel() {
 		currentEnvironmentLabel.text = "Selected Environment: \(store.selectedServerEnvironment.name)"
 	}
 
@@ -99,7 +99,7 @@ class DMServerEnvironmentViewController: UIViewController, UIPickerViewDelegate,
 
 			let selectedRow = self.picker.selectedRow(inComponent: 0)
 			self.store.selectedServerEnvironment = self.serverEnvironment.availableEnvironments()[selectedRow]
-			self.updateCurrentEnviromentLabel()
+			self.updateCurrentEnvironmentLabel()
 			self.store.appConfigMetadata = nil
 			self.store.enfRiskCalculationResult = nil
 			self.store.checkinRiskCalculationResult = nil

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMServerEnvironmentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMServerEnvironmentViewController.swift
@@ -100,6 +100,7 @@ class DMServerEnvironmentViewController: UIViewController, UIPickerViewDelegate,
 			let selectedRow = self.picker.selectedRow(inComponent: 0)
 			self.store.selectedServerEnvironment = self.serverEnvironment.availableEnvironments()[selectedRow]
 			self.updateCurrentEnviromentLabel()
+			self.store.appConfigMetadata = nil
 			self.store.enfRiskCalculationResult = nil
 			self.store.checkinRiskCalculationResult = nil
 			self.downloadedPackagesStore.reset()

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/CountryTests.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/__tests__/CountryTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class CountryTests: XCTestCase {
 
-	/// Identifier for the 'EU' region and coutries
+	/// Identifier for the 'EU' region and countries
 	let allCountryIDs = ["EU", "DE", "UK", "FR", "IT", "ES", "PL", "RO", "NL", "BE", "CZ", "EL", "SE", "PT", "HU", "AT", "CH", "BG", "DK", "FI", "SK", "NO", "IE", "HR", "SI", "LT", "LV", "EE", "CY", "LU", "MT", "IS"]
 
     func testCountryInit() throws {


### PR DESCRIPTION
## Description
Reset app config on environment switch so the country list is up to date when submitting keys immediately after switching the environment.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6766
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6781
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6783
