### PR TITLE
Update OpenCombine to 0.12.0

### DIFF
--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
         "state": {
           "branch": null,
-          "revision": "9bba5081344163296ddf537048566b95513b8f39",
-          "version": "0.11.0"
+          "revision": "28993ae57de5a4ea7e164787636cafad442d568c",
+          "version": "0.12.0"
         }
       },
       {

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -8733,7 +8733,7 @@
 			repositoryURL = "https://github.com/OpenCombine/OpenCombine.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.11.0;
+				version = 0.12.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Description
We need OpenCombine 0.12.0 to get the implementation for ObservableObject
