### PR TITLE
Fix typo - add missing "e"

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -682,7 +682,7 @@
 
 "ExposureSubmissionResult_antigenTestAdded" = "Your rapid test was added.";
 
-"ExposureSubmissionResult_antigenTestAddedDesc" = "The test result is displayed her for 48 hours.";
+"ExposureSubmissionResult_antigenTestAddedDesc" = "The test result is displayed here for 48 hours.";
 
 "ExposureSubmissionResult_warnOthers" = "Warn Others";
 


### PR DESCRIPTION
## Description
There was one "e" missing in the "ExposureSubmissionResult_antigenTestAddedDesc" string, see https://github.com/corona-warn-app/cwa-documentation/issues/597

## Link to Jira
non (yet)

## Screenshots
Not able to since I can't get to this screen without a negative RAT.
