### PR TITLE
Make whole UA Team Codeowner instead of single people

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @corona-warn-app/cwa-app-ios-members
 
 # Code owners of all german texts
-/src/xcode/ENA/ENA/Resources/Localization/de.lproj/* @janetback @SabineLoss
+/src/xcode/ENA/ENA/Resources/Localization/de.lproj/* @corona-warn-app/cwa-app-user-assistance


### PR DESCRIPTION
## Description
Make whole UA Team Codeowner instead of single people

