### PR TITLE
Feature/5474 flaky tests/test screenshot submission not possible

### DIFF
--- a/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureSubmission/ExposureSubmissionUITests.swift
@@ -292,12 +292,16 @@ class ENAUITests_04a_ExposureSubmission: XCTestCase {
 		)
 		app.buttons["AppStrings.ExposureSubmissionDispatch.tanButtonDescription"].tap()
 
+		let continueButton = app.buttons["AppStrings.ExposureSubmission.primaryButton"]
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertFalse(continueButton.isEnabled)
+
 		// Fill in dummy TAN.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].waitForExistence(timeout: .medium))
 		type(app, text: "qwdzxcsrhe")
 
 		// Click continue button.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].isEnabled)
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertTrue(continueButton.isEnabled)
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// TAN tests are ALWAYS positive!
@@ -485,12 +489,16 @@ class ENAUITests_04a_ExposureSubmission: XCTestCase {
 		snapshot("tan_submissionflow_tan_\(String(format: "%04d", (screenshotCounter.inc())))")
 		
 		// Fill in dummy TAN.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].waitForExistence(timeout: .medium))
+		let continueButton = app.buttons["AppStrings.ExposureSubmission.primaryButton"]
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertFalse(continueButton.isEnabled)
+		
 		type(app, text: "qwdzxcsrhe")
 		snapshot("tan_submissionflow_tan_\(String(format: "%04d", (screenshotCounter.inc())))")
 		
 		// Click continue button.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].isEnabled)
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertTrue(continueButton.isEnabled)
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 		
 		// TAN tests are ALWAYS positive!
@@ -575,12 +583,16 @@ class ENAUITests_04a_ExposureSubmission: XCTestCase {
 		)
 		app.buttons["AppStrings.ExposureSubmissionDispatch.tanButtonDescription"].tap()
 
+		let continueButton = app.buttons["AppStrings.ExposureSubmission.primaryButton"]
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertFalse(continueButton.isEnabled)
+
 		// Fill in dummy TAN.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].waitForExistence(timeout: .medium))
 		type(app, text: "qwdzxcsrhe")
 
 		// Click continue button.
-		XCTAssertTrue(app.buttons["AppStrings.ExposureSubmission.primaryButton"].isEnabled)
+		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
+		XCTAssertTrue(continueButton.isEnabled)
 		app.buttons["AppStrings.ExposureSubmission.primaryButton"].tap()
 
 		// TAN tests are ALWAYS positive!


### PR DESCRIPTION
## Description
should stabilize all UI Tests which enters in the TAN screen a TAN and proof for the enable state of the button.
Affects:

- test_SubmitTAN_CancelOnTestResultScreen()
- test_screenshot_SubmitTAN()
- test_screenshot_SubmissionNotPossible()

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5474
