### PR TITLE
Update Localizable.legal.strings

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -126,7 +126,7 @@
 
 "errorReport_Legal_DataPrivacy_Bullet2" = "Auf den Fehlerbericht haben zunächst nur Sie Zugriff. Sie können im Anschluss entscheiden, ob Sie den Fehlerbericht an den technischen Support senden, ob Sie den Fehlerbericht zunächst auf Ihrem Smartphone speichern oder die Aufzeichnung stoppen und löschen wollen. Wenn Sie den Fehlerbericht zunächst lokal speichern, haben Sie die Möglichkeit, sich den Fehlerbericht selbst anzuschauen, bevor Sie diesen an den Support übermitteln.";
 
-"errorReport_Legal_DataPrivacy_Bullet3" = "Der Fehlerbericht enthält sensible Informationen, zum Beispiel Angaben über Ihr Testergebnis oder das für Sie ermittelte Ansteckungsrisiko. Er enthält keine Informationen über die QR-Codes, die Sie bei der Testregistrierung verwendet haben, über Angaben, die Sie im Kontakt-Tagebuch erfasste haben oder Angaben zu Ihrer Identität.";
+"errorReport_Legal_DataPrivacy_Bullet3" = "Der Fehlerbericht enthält sensible Informationen, zum Beispiel Angaben über Ihr Testergebnis oder das für Sie ermittelte Ansteckungsrisiko. Er enthält keine Informationen über die QR-Codes, die Sie bei der Testregistrierung verwendet haben, über Angaben, die Sie im Kontakt-Tagebuch erfasst haben oder Angaben zu Ihrer Identität.";
 
 "errorReport_Legal_DataPrivacy_Bullet4" = "Wir empfehlen die Fehlerberichte nicht zu veröffentlichen und nicht per E-Mail zu versenden.";
 


### PR DESCRIPTION
Corrected typo https://github.com/corona-warn-app/cwa-app-ios/edit/release/2.2.x/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings#L129

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

## Link to Jira
<!-- Please add the link to the related Jira issue -->

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
