### PR TITLE
Use grouped table view style to prevent headers and footers from floating above the cells

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -43,7 +43,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		self.onSettingsCellTap = onSettingsCellTap
 		self.showTestInformationResult = showTestInformationResult
 
-		super.init(style: .plain)
+		super.init(style: .grouped)
 
 		viewModel.$riskAndTestResultsRows
 			.receive(on: DispatchQueue.OCombine(.main))


### PR DESCRIPTION
## Description
With the introduction of the table view on the Home Screen we had the wrong background color for a while, so recently I fixed the color using header and footer views. Now the table view style needs to be set to grouped so they are not floating above the cells.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7098