### PR TITLE
Antigen test profile creation: Add textContentType to text fields

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/CreateAntigenTestProfile/Cells/CreateAntigenTestProfileInputCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/CreateAntigenTestProfile/Cells/CreateAntigenTestProfileInputCell.swift
@@ -23,6 +23,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		firstNameTextField.placeholder = AppStrings.AntigenProfile.Create.firstNameTextFieldPlaceholder
 		firstNameTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.firstNameTextField
 		firstNameTextField.keyboardType = .default
+		firstNameTextField.textContentType = .givenName
 		contentView.addSubview(firstNameTextField)
 		textFields.append(firstNameTextField)
 
@@ -30,6 +31,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		lastNameTextField.placeholder = AppStrings.AntigenProfile.Create.lastNameTextFieldPlaceholder
 		lastNameTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.lastNameTextField
 		lastNameTextField.keyboardType = .default
+		lastNameTextField.textContentType = .familyName
 		contentView.addSubview(lastNameTextField)
 		textFields.append(lastNameTextField)
 
@@ -52,6 +54,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		addressLineTextField.placeholder = AppStrings.AntigenProfile.Create.streetTextFieldPlaceholder
 		addressLineTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.streetTextField
 		addressLineTextField.keyboardType = .default
+		addressLineTextField.textContentType = .streetAddressLine1
 		contentView.addSubview(addressLineTextField)
 		textFields.append(addressLineTextField)
 
@@ -59,6 +62,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		postalCodeTextField.placeholder = AppStrings.AntigenProfile.Create.postalCodeTextFieldPlaceholder
 		postalCodeTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.postalCodeTextField
 		postalCodeTextField.keyboardType = .numberPad
+		postalCodeTextField.textContentType = .postalCode
 		contentView.addSubview(postalCodeTextField)
 		textFields.append(postalCodeTextField)
 
@@ -66,6 +70,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		cityTextField.placeholder = AppStrings.AntigenProfile.Create.cityTextFieldPlaceholder
 		cityTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.cityTextField
 		cityTextField.keyboardType = .default
+		cityTextField.textContentType = .addressCity
 		contentView.addSubview(cityTextField)
 		textFields.append(cityTextField)
 
@@ -73,6 +78,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		phoneNumberTextField.placeholder = AppStrings.AntigenProfile.Create.phoneNumberTextFieldPlaceholder
 		phoneNumberTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.phoneNumberTextField
 		phoneNumberTextField.keyboardType = .phonePad
+		phoneNumberTextField.textContentType = .telephoneNumber
 		contentView.addSubview(phoneNumberTextField)
 		textFields.append(phoneNumberTextField)
 
@@ -80,6 +86,7 @@ class CreateAntigenTestProfileInputCell: UITableViewCell, ReuseIdentifierProvidi
 		emailAddressTextField.placeholder = AppStrings.AntigenProfile.Create.emailAddressTextFieldPlaceholder
 		emailAddressTextField.accessibilityIdentifier = AccessibilityIdentifiers.AntigenProfile.Create.emailAddressTextField
 		emailAddressTextField.keyboardType = .emailAddress
+		emailAddressTextField.textContentType = .emailAddress
 		contentView.addSubview(emailAddressTextField)
 		textFields.append(emailAddressTextField)
 


### PR DESCRIPTION
## Description

This PR adds `textContentType` to the text fields used to create the antigen test profile. 

Adding a [textContentType](https://developer.apple.com/documentation/uikit/uitextinputtraits/1649656-textcontenttype) attribute allows iOS to suggest input for fields like first name or last name. This allows for a quicker profile creation. See screenshots for a demonstration of the use in practice.

The API is available for iOS 10+ so compatibility is not an issue. 

## Link to Jira

N/A

## Screenshots

![IMG_1863](https://user-images.githubusercontent.com/15453/118373082-191d7100-b5b5-11eb-9e5a-f2f32033433b.PNG)

![IMG_1864](https://user-images.githubusercontent.com/15453/118373084-20447f00-b5b5-11eb-8375-77c9291ee8b9.PNG)
