### PR TITLE
Increase timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run:
           name: Run Fastlane tests
           command: cd src/xcode && bundle exec fastlane test
-          no_output_timeout: 20m
+          no_output_timeout: 25m
       - restore_cache:
           key: sonar-cloud-v2
       - run:
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: Snapshot
           command: cd src/xcode && bundle exec fastlane screenshot languages:<<parameters.language>> mode:<<parameters.displaymode>>
-          no_output_timeout: 20m
+          no_output_timeout: 25m
       - store_test_results:
           # Fastlane's snapshot only defines one output path which is intended forscreenshots
           # test results also land here which is the reason of this weird path


### PR DESCRIPTION
## Description
Tests keep "failing" since they take longer than 20 minutes. This PR increases this timeout to 25 minutes, so long until our CI runs smoother again. 

