### PR TITLE
Fix for RiskProvider tests

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		01D69491250272CE00B45BEA /* DatePickerDayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */; };
 		01DB708525068167008F7244 /* Calendar+GregorianLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */; };
 		01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */; };
+		01DDF4462654221A0043B4E1 /* DidSetPublishedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */; };
 		01DF186E2603B28200A002E4 /* TraceLocationsOverviewViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */; };
 		01DF188E2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */; };
 		01E4298E251DCDC90057FCBE /* Localizable.legal.strings in Resources */ = {isa = PBXBuildFile; fileRef = 01E42990251DCDC90057FCBE /* Localizable.legal.strings */; };
@@ -1412,6 +1413,7 @@
 		01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDayViewModel.swift; sourceTree = "<group>"; };
 		01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+GregorianLocale.swift"; sourceTree = "<group>"; };
 		01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublished.swift; sourceTree = "<group>"; };
+		01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublishedTests.swift; sourceTree = "<group>"; };
 		01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceLocationsOverviewViewModelTest.swift; sourceTree = "<group>"; };
 		01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TraceLocationConfigurationViewController.xib; sourceTree = "<group>"; };
 		01E25C6F24A3B52F007E33F8 /* Info_Testflight.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info_Testflight.plist; sourceTree = "<group>"; };
@@ -4995,6 +4997,7 @@
 			isa = PBXGroup;
 			children = (
 				AB68531825F9233200380F5A /* Store */,
+				01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */,
 			);
 			path = __tests__;
 			sourceTree = "<group>";
@@ -8022,6 +8025,7 @@
 				AB2F094F25D169DC00C16309 /* SurveyURLServiceTests.swift in Sources */,
 				BAA19D652612151B00CBBDDD /* CheckInTimeModelTests.swift in Sources */,
 				BAC7291226037BB6006D83C7 /* MissingPermissionsCellModelTests.swift in Sources */,
+				01DDF4462654221A0043B4E1 /* DidSetPublishedTests.swift in Sources */,
 				0185DDDE25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift in Sources */,
 				A1654F0224B43E8500C0E115 /* DynamicTableViewTextViewCellTests.swift in Sources */,
 				BA8848C6264AD91500EEA542 /* HealthCertificateKeyValueCellViewModelTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		014891B324F90D0B002A6F77 /* ENA.plist in Resources */ = {isa = PBXBuildFile; fileRef = 014891B224F90D0B002A6F77 /* ENA.plist */; };
 		014D803B26440E010077898D /* ENAUITests_11_QuickActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014D80382644077B0077898D /* ENAUITests_11_QuickActions.swift */; };
 		014D803D2644210B0077898D /* HealthCertificateServiceProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014D803C2644210B0077898D /* HealthCertificateServiceProviding.swift */; };
-		014D8043264422020077898D /* MockHealthCertificateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014D80402644219A0077898D /* MockHealthCertificateService.swift */; };
 		015178C22507D2E50074F095 /* ExposureSubmissionSymptomsOnsetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015178C12507D2A90074F095 /* ExposureSubmissionSymptomsOnsetViewControllerTests.swift */; };
 		015692E424B48C3F0033F35E /* TimeInterval+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015692E324B48C3F0033F35E /* TimeInterval+Convenience.swift */; };
 		0156F05C25D2DA2300543640 /* DeadmanNotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0156F05B25D2DA2300543640 /* DeadmanNotificationManagerTests.swift */; };
@@ -265,6 +264,7 @@
 		01EA17E52591399200E98E02 /* HomeInfoCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA17E42591399200E98E02 /* HomeInfoCellModel.swift */; };
 		01EA17EF259139B900E98E02 /* HomeInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01EA17732590F03000E98E02 /* HomeInfoTableViewCell.xib */; };
 		01EA17FE259217B100E98E02 /* HomeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EA17FD259217B100E98E02 /* HomeState.swift */; };
+		01EA24632654191100A97782 /* MockHealthCertificateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014D80402644219A0077898D /* MockHealthCertificateService.swift */; };
 		01EBC9BE25B706AF0003496F /* HomeStatisticsCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EBC9A525B6002C0003496F /* HomeStatisticsCardViewModelTests.swift */; };
 		01EBC9C325B70C310003496F /* SAP_Internal_Stats_Statistics+SupportedIDsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EBC9C225B70C310003496F /* SAP_Internal_Stats_Statistics+SupportedIDsTests.swift */; };
 		01EEC09F260224FF00924E15 /* MissingPermissionsCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EEC09E260224FF00924E15 /* MissingPermissionsCellModel.swift */; };
@@ -7229,7 +7229,6 @@
 				AB190EE525FF5B0D00FBFF0D /* ContactDiaryStoreSchemaV4.swift in Sources */,
 				ABF574DF25C308DF0098E315 /* SurveyConsentViewModel.swift in Sources */,
 				BA0F6C4E26317BA40046BA48 /* AntigenTestProfileViewController.swift in Sources */,
-				014D8043264422020077898D /* MockHealthCertificateService.swift in Sources */,
 				ABE63CF126010EFF0024F856 /* ContactDiaryStore+Creation.swift in Sources */,
 				137846492488027600A50AB8 /* OnboardingInfoViewController+Extension.swift in Sources */,
 				34CF3B1F2615C1D1004A9435 /* QRCodeErrorCorrectionLevelType.swift in Sources */,
@@ -8055,6 +8054,7 @@
 				AB68880625D6AC7300907465 /* ContactDiaryMigration2To3Tests.swift in Sources */,
 				2FD881CE249115E700BEC8FC /* ExposureSubmissionNavigationControllerTest.swift in Sources */,
 				50C029B225E4069400460FA4 /* KeySubmissionMetadataTests.swift in Sources */,
+				01EA24632654191100A97782 /* MockHealthCertificateService.swift in Sources */,
 				A1E419522495A6F20016E52A /* HTTPClient+TANForExposureSubmitTests.swift in Sources */,
 				BAA19D6D2612184E00CBBDDD /* CheckInDescriptionCellModelTests.swift in Sources */,
 				015178C22507D2E50074F095 /* ExposureSubmissionSymptomsOnsetViewControllerTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		01D6948F2502729000B45BEA /* DatePickerDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D6948E2502729000B45BEA /* DatePickerDay.swift */; };
 		01D69491250272CE00B45BEA /* DatePickerDayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */; };
 		01DB708525068167008F7244 /* Calendar+GregorianLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */; };
+		01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */; };
 		01DF186E2603B28200A002E4 /* TraceLocationsOverviewViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */; };
 		01DF188E2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */; };
 		01E4298E251DCDC90057FCBE /* Localizable.legal.strings in Resources */ = {isa = PBXBuildFile; fileRef = 01E42990251DCDC90057FCBE /* Localizable.legal.strings */; };
@@ -1410,6 +1411,7 @@
 		01D6948E2502729000B45BEA /* DatePickerDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDay.swift; sourceTree = "<group>"; };
 		01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDayViewModel.swift; sourceTree = "<group>"; };
 		01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+GregorianLocale.swift"; sourceTree = "<group>"; };
+		01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublished.swift; sourceTree = "<group>"; };
 		01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceLocationsOverviewViewModelTest.swift; sourceTree = "<group>"; };
 		01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TraceLocationConfigurationViewController.xib; sourceTree = "<group>"; };
 		01E25C6F24A3B52F007E33F8 /* Info_Testflight.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info_Testflight.plist; sourceTree = "<group>"; };
@@ -4793,6 +4795,7 @@
 				EBA403A82588F72A00D1F039 /* iOS12Support */,
 				AB126872254C05A7006E9194 /* ENAFormatter.swift */,
 				ABE9613E25EFEC3700D0F699 /* InstallationDate.swift */,
+				01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -7183,6 +7186,7 @@
 				017AD10F259DC46E00FA2B3F /* HomeShownPositiveTestResultTableViewCell.swift in Sources */,
 				AB7420AC251B67A8006666AC /* DeltaOnboardingV15.swift in Sources */,
 				71F54191248BF677006DB793 /* HtmlTextView.swift in Sources */,
+				01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */,
 				BA5B7FCF26458EF400502087 /* HealthCertificateViewController.swift in Sources */,
 				ABF0F605260B347600E50B0F /* CheckinRiskCalculation.swift in Sources */,
 				BA6C8B05254D6B1F008344F5 /* RiskCalculation.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/Consent/__tests__/HealthCertificateConsentViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/Consent/__tests__/HealthCertificateConsentViewModelTests.swift
@@ -16,7 +16,7 @@ class HealthCertificateConsentViewModelTests: XCTestCase {
 
 		// THEN
 		XCTAssertEqual(dynamicTableViewModel.numberOfSection, 3)
-		XCTAssertEqual(dynamicTableViewModel.numberOfRows(section: 0), 8)
+		XCTAssertEqual(dynamicTableViewModel.numberOfRows(section: 0), 4)
 		XCTAssertEqual(dynamicTableViewModel.numberOfRows(section: 1), 1)
 		XCTAssertEqual(dynamicTableViewModel.numberOfRows(section: 2), 1)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
@@ -11,11 +11,12 @@ class HealthCertificateViewModelTests: XCTestCase {
 	func testGIVEN_HealthCertificateViewModel_TableViewSection_THEN_SectionsAreCorrect() {
 
 		// THEN
-		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.numberOfSections, 4)
+		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.numberOfSections, 5)
 		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(0), .headline)
-		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(1), .topCorner)
-		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(2), .details)
-		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(3), .bottomCorner)
+		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(1), .qrCode)
+		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(2), .topCorner)
+		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(3), .details)
+		XCTAssertEqual(HealthCertificateViewModel.TableViewSection.map(4), .bottomCorner)
 	}
 
 	func testGIVEN_HealthCertificate_WHEN_CreateViewModel_THEN_IsSetup() throws {
@@ -41,8 +42,9 @@ class HealthCertificateViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.headlineCellViewModel.font, .enaFont(for: .headline))
 		XCTAssertEqual(viewModel.headlineCellViewModel.accessibilityTraits, .staticText)
 		XCTAssertEqual(viewModel.numberOfItems(in: .headline), 0)
+		XCTAssertEqual(viewModel.numberOfItems(in: .qrCode), 1)
 		XCTAssertEqual(viewModel.numberOfItems(in: .topCorner), 1)
-		XCTAssertEqual(viewModel.numberOfItems(in: .details), 1)
+		XCTAssertEqual(viewModel.numberOfItems(in: .details), 2)
 		XCTAssertEqual(viewModel.numberOfItems(in: .bottomCorner), 1)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/QRCodeScanner/__tests__/HealthCertificateQRCodeScannerViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificate/QRCodeScanner/__tests__/HealthCertificateQRCodeScannerViewModelTests.swift
@@ -35,8 +35,8 @@ final class TestableHealthCertificateQRCodeScannerViewModelTests: HealthCertific
 
 class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 
-	func testSuccessfulPcrScan() {
-		let guid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
+	func testSuccessfulScan() {
+		let base45 = mockBase45
 
 		let onSuccessExpectation = expectation(description: "onSuccess called")
 		onSuccessExpectation.expectedFulfillmentCount = 1
@@ -48,7 +48,7 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 		onErrorExpectation.expectedFulfillmentCount = 1
 
 		let viewModel = TestableHealthCertificateQRCodeScannerViewModelTests(
-			healthCertificateService: MockHealthCertificateService(),
+			healthCertificateService: HealthCertificateService(store: MockTestStore()),
 			onSuccess: { _ in
 				onSuccessExpectation.fulfill()
 			},
@@ -57,7 +57,7 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 			}
 		)
 
-		let metaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC1:\(guid)")
+		let metaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC1:\(base45)")
 		viewModel.activateScanning()
 		viewModel.didScan(metadataObjects: [metaDataObject])
 
@@ -68,7 +68,7 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 	}
 		
 	func testUnsuccessfulScan_invalidPrefix() {
-		let validGuid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
+		let base45 = mockBase45
 
 		let onSuccessExpectation = expectation(description: "onSuccess not called")
 		onSuccessExpectation.isInverted = true
@@ -77,7 +77,7 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 		onErrorExpectation.expectedFulfillmentCount = 1
 
 		let viewModel = TestableHealthCertificateQRCodeScannerViewModelTests(
-			healthCertificateService: MockHealthCertificateService(),
+			healthCertificateService: HealthCertificateService(store: MockTestStore()),
 			onSuccess: { _ in
 				onSuccessExpectation.fulfill()
 			},
@@ -87,7 +87,7 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 		)
 
 		viewModel.activateScanning()
-		let metaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC:\(validGuid)")
+		let metaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC:\(base45)")
 		viewModel.didScan(metadataObjects: [metaDataObject])
 
 		// Check that scanning is deactivated after one unsuccessful scan
@@ -98,8 +98,8 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 	}
 
 	func testInitalUnsuccessfulScanWithSuccessfulRetry() {
-		let validGuid = "3D6D08-3567F3F2-4DCF-43A3-8737-4CD1F87D6FDA"
-		let emptyGuid = ""
+		let validBase45 = mockBase45
+		let emptyBase45 = ""
 
 		let onSuccessExpectation = expectation(description: "onSuccess called")
 		onSuccessExpectation.expectedFulfillmentCount = 1
@@ -108,32 +108,31 @@ class HealthCertificateQRCodeScannerViewModelTests: XCTestCase {
 		onErrorExpectation.expectedFulfillmentCount = 1
 
 		let viewModel = TestableHealthCertificateQRCodeScannerViewModelTests(
-			healthCertificateService: MockHealthCertificateService(),
+			healthCertificateService: HealthCertificateService(store: MockTestStore()),
 			onSuccess: { _ in
 				onSuccessExpectation.fulfill()
 			},
-			onError: { error in
-				switch error {
-				case .cameraPermissionDenied:
-					onErrorExpectation.fulfill()
-				case .codeNotFound:
-					onErrorExpectation.fulfill()
-				default:
-					XCTFail("unexpected error")
-				}
+			onError: { _ in
+				onErrorExpectation.fulfill()
 			}
 		)
 		viewModel.activateScanning()
 
-		let invalidMetaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: emptyGuid)
+		let invalidMetaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: emptyBase45)
 		viewModel.didScan(metadataObjects: [invalidMetaDataObject])
 		
 		wait(for: [onErrorExpectation], timeout: .short)
 		
-		let validMetaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC1:\(validGuid)")
+		let validMetaDataObject = FakeMetadataMachineReadableCodeObject(stringValue: "HC1:\(validBase45)")
 		viewModel.activateScanning()
 		viewModel.didScan(metadataObjects: [validMetaDataObject])
 		
 		wait(for: [onSuccessExpectation], timeout: .short)
 	}
+
+	// MARK: - Private
+
+	// swiftlint:disable:next line_length
+	private let mockBase45 = "6BFOXN*TS0BI$ZD4N9:9S6RCVN5+O30K3/XIV0W23NTDEXWK G2EP4J0BGJLFX3R3VHXK.PJ:2DPF6R:5SVBHABVCNN95SWMPHQUHQN%A0SOE+QQAB-HQ/HQ7IR.SQEEOK9SAI4- 7Y15KBPD34  QWSP0WRGTQFNPLIR.KQNA7N95U/3FJCTG90OARH9P1J4HGZJKBEG%123ZC$0BCI757TLXKIBTV5TN%2LXK-$CH4TSXKZ4S/$K%0KPQ1HEP9.PZE9Q$95:UENEUW6646936HRTO$9KZ56DE/.QC$Q3J62:6LZ6O59++9-G9+E93ZM$96TV6NRN3T59YLQM1VRMP$I/XK$M8PK66YBTJ1ZO8B-S-*O5W41FD$ 81JP%KNEV45G1H*KESHMN2/TU3UQQKE*QHXSMNV25$1PK50C9B/9OK5NE1 9V2:U6A1ELUCT16DEETUM/UIN9P8Q:KPFY1W+UN MUNU8T1PEEG%5TW5A 6YO67N6BBEWED/3LS3N6YU.:KJWKPZ9+CQP2IOMH.PR97QC:ACZAH.SYEDK3EL-FIK9J8JRBC7ADHWQYSK48UNZGG NAVEHWEOSUI2L.9OR8FHB0T5HM7I"
+
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
@@ -22,16 +22,23 @@ class HomeTableViewModel {
 		self.healthCertificateService = healthCertificateService
 		self.onTestResultCellTap = onTestResultCellTap
 
-		coronaTestService.$tests
-			.sink { [weak self] in
-				self?.update(pcrTest: $0.pcr, antigenTest: $0.antigen)
+		coronaTestService.$pcrTest
+			.sink { [weak self] _ in
+				self?.update()
+			}
+			.store(in: &subscriptions)
+
+		coronaTestService.$antigenTest
+			.sink { [weak self] _ in
+				self?.update()
 			}
 			.store(in: &subscriptions)
 		
-		healthCertificateService.healthCertifiedPersons.sink { healthCertifiedPersons in
-			self.healthCertifiedPersons = healthCertifiedPersons
-		}
-		.store(in: &subscriptions)
+		healthCertificateService.healthCertifiedPersons
+			.sink { healthCertifiedPersons in
+				self.healthCertifiedPersons = healthCertifiedPersons
+			}
+			.store(in: &subscriptions)
 	}
 
 	// MARK: - Internal
@@ -198,29 +205,14 @@ class HomeTableViewModel {
 	private let healthCertificateService: HealthCertificateServiceProviding
 	private var subscriptions = Set<AnyCancellable>()
 
-	private func update(pcrTest: PCRTest?, antigenTest: AntigenTest?) {
-		let updatedRiskAndTestResultsRows = self.computedRiskAndTestResultsRows(pcrTest: pcrTest, antigenTest: antigenTest)
-
-		if updatedRiskAndTestResultsRows.contains(.risk) && !self.riskAndTestResultsRows.contains(.risk) {
-			self.state.requestRisk(userInitiated: true)
-		}
-
-		if updatedRiskAndTestResultsRows != self.riskAndTestResultsRows {
-			isUpdating = true
-			self.riskAndTestResultsRows = updatedRiskAndTestResultsRows
-		}
-	}
-
-	private func computedRiskAndTestResultsRows(pcrTest: PCRTest?, antigenTest: AntigenTest?) -> [RiskAndTestResultsRow] {
+	private var computedRiskAndTestResultsRows: [RiskAndTestResultsRow] {
 		var riskAndTestResultsRows = [RiskAndTestResultsRow]()
 
-		let hasAtLeastOneShownPositiveOrSubmittedTest = pcrTest?.positiveTestResultWasShown == true || pcrTest?.keysSubmitted == true || antigenTest?.positiveTestResultWasShown == true || antigenTest?.keysSubmitted == true
-
-		if !hasAtLeastOneShownPositiveOrSubmittedTest {
+		if !coronaTestService.hasAtLeastOneShownPositiveOrSubmittedTest {
 			riskAndTestResultsRows.append(.risk)
 		}
 
-		if let pcrTest = pcrTest {
+		if let pcrTest = coronaTestService.pcrTest {
 			let testResultState: TestResultState
 			if pcrTest.testResult == .positive && pcrTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown
@@ -230,7 +222,7 @@ class HomeTableViewModel {
 			riskAndTestResultsRows.append(.pcrTestResult(testResultState))
 		}
 
-		if let antigenTest = antigenTest {
+		if let antigenTest = coronaTestService.antigenTest {
 			let testResultState: TestResultState
 			if antigenTest.testResult == .positive && antigenTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown
@@ -241,6 +233,19 @@ class HomeTableViewModel {
 		}
 
 		return riskAndTestResultsRows
+	}
+
+	private func update() {
+		let updatedRiskAndTestResultsRows = self.computedRiskAndTestResultsRows
+
+		if updatedRiskAndTestResultsRows.contains(.risk) && !self.riskAndTestResultsRows.contains(.risk) {
+			self.state.requestRisk(userInitiated: true)
+		}
+
+		if updatedRiskAndTestResultsRows != self.riskAndTestResultsRows {
+			isUpdating = true
+			self.riskAndTestResultsRows = updatedRiskAndTestResultsRows
+		}
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -57,15 +57,13 @@ class CoronaTestService {
 
 	// MARK: - Protocol CoronaTestServiceProviding
 
-	@OpenCombine.Published var pcrTest: PCRTest?
-	@OpenCombine.Published var antigenTest: AntigenTest?
+	@DidSetPublished var pcrTest: PCRTest?
+	@DidSetPublished var antigenTest: AntigenTest?
 
-	@OpenCombine.Published private(set) var tests: (pcr: PCRTest?, antigen: AntigenTest?)
+	@DidSetPublished var antigenTestIsOutdated: Bool = false
 
-	@OpenCombine.Published var antigenTestIsOutdated: Bool = false
-
-	@OpenCombine.Published var pcrTestResultIsLoading: Bool = false
-	@OpenCombine.Published var antigenTestResultIsLoading: Bool = false
+	@DidSetPublished var pcrTestResultIsLoading: Bool = false
+	@DidSetPublished var antigenTestResultIsLoading: Bool = false
 
 	var hasAtLeastOneShownPositiveOrSubmittedTest: Bool {
 		pcrTest?.positiveTestResultWasShown == true || pcrTest?.keysSubmitted == true ||
@@ -418,7 +416,6 @@ class CoronaTestService {
 		$pcrTest
 			.sink { [weak self] pcrTest in
 				self?.store.pcrTest = pcrTest
-				self?.tests.pcr = pcrTest
 
 				if pcrTest?.keysSubmitted == true {
 					self?.warnOthersReminder.cancelNotifications(for: .pcr)
@@ -429,7 +426,6 @@ class CoronaTestService {
 		$antigenTest
 			.sink { [weak self] antigenTest in
 				self?.store.antigenTest = antigenTest
-				self?.tests.antigen = antigenTest
 
 				if antigenTest?.keysSubmitted == true {
 					self?.warnOthersReminder.cancelNotifications(for: .antigen)

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -55,13 +55,17 @@ class HealthCertifiedPerson: Codable, Equatable {
 		didSet {
 			updateVaccinationState()
 
-			objectDidChange.send(self)
+			if healthCertificates != oldValue {
+				objectDidChange.send(self)
+			}
 		}
 	}
 
 	@OpenCombine.Published var vaccinationState: VaccinationState = .partiallyVaccinated {
 		didSet {
-			objectDidChange.send(self)
+			if vaccinationState != oldValue {
+				objectDidChange.send(self)
+			}
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertifiedPersonTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertifiedPersonTests.swift
@@ -12,7 +12,7 @@ class HealthCertifiedPersonTests: XCTestCase {
 
 	func testHealthCertifiedPersonObjectDidChangeTriggered() throws {
 		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [])
-		let healthCertificate = HealthCertificate.mock()
+		let healthCertificate = HealthCertificate.mock(base45: HealthCertificate.firstBase45Mock)
 
 		let objectDidChangeExpectation = expectation(description: "objectDidChange publisher updated")
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__test__/MockHealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__test__/MockHealthCertificateService.swift
@@ -4,6 +4,7 @@
 
 import OpenCombine
 import HealthCertificateToolkit
+@testable import ENA
 
 class MockHealthCertificateService: HealthCertificateServiceProviding {
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProviding.swift
@@ -9,6 +9,7 @@ typealias RiskProviderResult = Result<Risk, RiskProviderError>
 
 enum RiskProviderError: Error {
 	case inactive
+	case deactivatedDueToActiveTest
 	case timeout
 	case riskProviderIsRunning
 	case missingAppConfig
@@ -50,7 +51,7 @@ enum RiskProviderError: Error {
 	}
 }
 
-enum RiskProviderActivityState {
+enum RiskProviderActivityState: Int {
 	case idle
 	case riskRequested
 	case downloading

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -584,16 +584,23 @@ final class RiskProviderTests: XCTestCase {
 		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk not to be called")
 		didCalculateRiskExpectation.isInverted = true
 
-		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
-		didFailCalculateRiskExpectation.isInverted = true
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk to be called")
 
-		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called")
-		didChangeActivityStateExpectation.expectedFulfillmentCount = 2
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
+		didChangeActivityStateExpectation.isInverted = true
 
 		consumer.didCalculateRisk = { _ in
 			didCalculateRiskExpectation.fulfill()
 		}
-		consumer.didFailCalculateRisk = { _ in
+		consumer.didFailCalculateRisk = { error in
+			// Make sure that exposure windows where NOT requested.
+			XCTAssertFalse(exposureDetectionDelegateStub.exposureWindowsWereDetected)
+
+			guard case .deactivatedDueToActiveTest = error else {
+				XCTFail("deactivatedDueToActiveTest error expected.")
+				didFailCalculateRiskExpectation.fulfill()
+				return
+			}
 			didFailCalculateRiskExpectation.fulfill()
 		}
 		consumer.didChangeActivityState = { _ in
@@ -643,16 +650,23 @@ final class RiskProviderTests: XCTestCase {
 		let didCalculateRiskExpectation = expectation(description: "expect didCalculateRisk not to be called")
 		didCalculateRiskExpectation.isInverted = true
 
-		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk not to be called")
-		didFailCalculateRiskExpectation.isInverted = true
+		let didFailCalculateRiskExpectation = expectation(description: "expect didFailCalculateRisk to be called")
 
-		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState to be called")
-		didChangeActivityStateExpectation.expectedFulfillmentCount = 2
+		let didChangeActivityStateExpectation = expectation(description: "expect didChangeActivityState not to be called")
+		didChangeActivityStateExpectation.isInverted = true
 
 		consumer.didCalculateRisk = { _ in
 			didCalculateRiskExpectation.fulfill()
 		}
-		consumer.didFailCalculateRisk = { _ in
+		consumer.didFailCalculateRisk = { error in
+			// Make sure that exposure windows where NOT requested.
+			XCTAssertFalse(exposureDetectionDelegateStub.exposureWindowsWereDetected)
+
+			guard case .deactivatedDueToActiveTest = error else {
+				XCTFail("deactivatedDueToActiveTest error expected.")
+				didFailCalculateRiskExpectation.fulfill()
+				return
+			}
 			didFailCalculateRiskExpectation.fulfill()
 		}
 		consumer.didChangeActivityState = { _ in

--- a/src/xcode/ENA/ENA/Source/Utils/DidSetPublished.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/DidSetPublished.swift
@@ -1,0 +1,25 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import OpenCombine
+
+@propertyWrapper
+class DidSetPublished<Value> {
+
+	init(wrappedValue value: Value) {
+		projectedValue = CurrentValueSubject(value)
+	}
+
+	var wrappedValue: Value {
+		get {
+			projectedValue.value
+		}
+		set {
+			projectedValue.value = newValue
+		}
+	}
+
+	var projectedValue: OpenCombine.CurrentValueSubject<Value, Never>
+
+}

--- a/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
@@ -12,8 +12,8 @@ class DidSetPublishedTests: XCTestCase {
 
 		let expectedValues = [false, false, true, true, false]
 
-		let expectation = expectation(description: "Received value")
-		expectation.expectedFulfillmentCount = expectedValues.count
+		let publishingExpectation = expectation(description: "Received value")
+		publishingExpectation.expectedFulfillmentCount = expectedValues.count
 
 		var receivedValues = [Bool]()
 		let subscription = publishingStruct.$publishingBool
@@ -22,7 +22,7 @@ class DidSetPublishedTests: XCTestCase {
 				XCTAssertEqual($0, publishingStruct.publishingBool)
 				receivedValues.append($0)
 
-				expectation.fulfill()
+				publishingExpectation.fulfill()
 			}
 
 		publishingStruct.publishingBool = false

--- a/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
@@ -1,0 +1,48 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import XCTest
+@testable import ENA
+
+class DidSetPublishedTests: XCTestCase {
+
+    func testExample() throws {
+		let publishingStruct = PublishingStruct()
+
+		let expectedValues = [false, false, true, true, false]
+
+		let expectation = expectation(description: "Received value")
+		expectation.expectedFulfillmentCount = expectedValues.count
+
+		var receivedValues = [Bool]()
+		let subscription = publishingStruct.$publishingBool
+			.sink {
+				// Check that the value is already set on the publishing struct and we receive it afterwards
+				XCTAssertEqual($0, publishingStruct.publishingBool)
+				receivedValues.append($0)
+
+				expectation.fulfill()
+			}
+
+		publishingStruct.publishingBool = false
+		publishingStruct.publishingBool = true
+		publishingStruct.publishingBool = true
+		publishingStruct.publishingBool = false
+
+		waitForExpectations(timeout: .short)
+
+		XCTAssertEqual(receivedValues, expectedValues)
+
+		subscription.cancel()
+    }
+
+	// MARK: - Private
+
+	private struct PublishingStruct {
+
+		@DidSetPublished var publishingBool: Bool = false
+
+	}
+
+}

--- a/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
+++ b/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
@@ -58,7 +58,7 @@ class ENAUITests_12_AntigenTestProfile: XCTestCase {
 		
 		/// Legal Text Screen
 
-		XCTAssertTrue(app.images[AccessibilityIdentifiers.AppInformation.privacyImageDescription].waitForExistence(timeout: .short))
+		XCTAssertTrue(app.images[AccessibilityIdentifiers.AppInformation.privacyImageDescription].waitForExistence(timeout: .extraLong))
 
 		let backButton = try XCTUnwrap(app.navigationBars.buttons.element(boundBy: 0))
 		XCTAssertTrue(backButton.waitForExistence(timeout: .short))

--- a/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
+++ b/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
@@ -58,6 +58,8 @@ class ENAUITests_12_AntigenTestProfile: XCTestCase {
 		
 		/// Legal Text Screen
 
+		XCTAssertTrue(app.images[AccessibilityIdentifiers.AppInformation.privacyImageDescription].waitForExistence(timeout: .short))
+
 		let backButton = try XCTUnwrap(app.navigationBars.buttons.element(boundBy: 0))
 		XCTAssertTrue(backButton.waitForExistence(timeout: .short))
 		backButton.tap()


### PR DESCRIPTION
## Description
If there is an active test, avoid requesting exposure windows if previous calculation result is missing.
