### PR TITLE
Fix/@Published timing issues

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		01D69491250272CE00B45BEA /* DatePickerDayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */; };
 		01DB708525068167008F7244 /* Calendar+GregorianLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */; };
 		01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */; };
+		01DDF4462654221A0043B4E1 /* DidSetPublishedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */; };
 		01DF186E2603B28200A002E4 /* TraceLocationsOverviewViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */; };
 		01DF188E2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */; };
 		01E4298E251DCDC90057FCBE /* Localizable.legal.strings in Resources */ = {isa = PBXBuildFile; fileRef = 01E42990251DCDC90057FCBE /* Localizable.legal.strings */; };
@@ -1412,6 +1413,7 @@
 		01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDayViewModel.swift; sourceTree = "<group>"; };
 		01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+GregorianLocale.swift"; sourceTree = "<group>"; };
 		01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublished.swift; sourceTree = "<group>"; };
+		01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublishedTests.swift; sourceTree = "<group>"; };
 		01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceLocationsOverviewViewModelTest.swift; sourceTree = "<group>"; };
 		01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TraceLocationConfigurationViewController.xib; sourceTree = "<group>"; };
 		01E25C6F24A3B52F007E33F8 /* Info_Testflight.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info_Testflight.plist; sourceTree = "<group>"; };
@@ -4995,6 +4997,7 @@
 			isa = PBXGroup;
 			children = (
 				AB68531825F9233200380F5A /* Store */,
+				01DDF4452654221A0043B4E1 /* DidSetPublishedTests.swift */,
 			);
 			path = __tests__;
 			sourceTree = "<group>";
@@ -8022,6 +8025,7 @@
 				AB2F094F25D169DC00C16309 /* SurveyURLServiceTests.swift in Sources */,
 				BAA19D652612151B00CBBDDD /* CheckInTimeModelTests.swift in Sources */,
 				BAC7291226037BB6006D83C7 /* MissingPermissionsCellModelTests.swift in Sources */,
+				01DDF4462654221A0043B4E1 /* DidSetPublishedTests.swift in Sources */,
 				0185DDDE25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift in Sources */,
 				A1654F0224B43E8500C0E115 /* DynamicTableViewTextViewCellTests.swift in Sources */,
 				BA8848C6264AD91500EEA542 /* HealthCertificateKeyValueCellViewModelTests.swift in Sources */,

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		01D6948F2502729000B45BEA /* DatePickerDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D6948E2502729000B45BEA /* DatePickerDay.swift */; };
 		01D69491250272CE00B45BEA /* DatePickerDayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */; };
 		01DB708525068167008F7244 /* Calendar+GregorianLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */; };
+		01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */; };
 		01DF186E2603B28200A002E4 /* TraceLocationsOverviewViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */; };
 		01DF188E2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */; };
 		01E4298E251DCDC90057FCBE /* Localizable.legal.strings in Resources */ = {isa = PBXBuildFile; fileRef = 01E42990251DCDC90057FCBE /* Localizable.legal.strings */; };
@@ -1410,6 +1411,7 @@
 		01D6948E2502729000B45BEA /* DatePickerDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDay.swift; sourceTree = "<group>"; };
 		01D69490250272CE00B45BEA /* DatePickerDayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerDayViewModel.swift; sourceTree = "<group>"; };
 		01DB708425068167008F7244 /* Calendar+GregorianLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+GregorianLocale.swift"; sourceTree = "<group>"; };
+		01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidSetPublished.swift; sourceTree = "<group>"; };
 		01DF186A2603B17000A002E4 /* TraceLocationsOverviewViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceLocationsOverviewViewModelTest.swift; sourceTree = "<group>"; };
 		01DF188D2608D3BB00A002E4 /* TraceLocationConfigurationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TraceLocationConfigurationViewController.xib; sourceTree = "<group>"; };
 		01E25C6F24A3B52F007E33F8 /* Info_Testflight.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info_Testflight.plist; sourceTree = "<group>"; };
@@ -4793,6 +4795,7 @@
 				EBA403A82588F72A00D1F039 /* iOS12Support */,
 				AB126872254C05A7006E9194 /* ENAFormatter.swift */,
 				ABE9613E25EFEC3700D0F699 /* InstallationDate.swift */,
+				01DDF44326541CEC0043B4E1 /* DidSetPublished.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -7183,6 +7186,7 @@
 				017AD10F259DC46E00FA2B3F /* HomeShownPositiveTestResultTableViewCell.swift in Sources */,
 				AB7420AC251B67A8006666AC /* DeltaOnboardingV15.swift in Sources */,
 				71F54191248BF677006DB793 /* HtmlTextView.swift in Sources */,
+				01DDF44426541CEC0043B4E1 /* DidSetPublished.swift in Sources */,
 				BA5B7FCF26458EF400502087 /* HealthCertificateViewController.swift in Sources */,
 				ABF0F605260B347600E50B0F /* CheckinRiskCalculation.swift in Sources */,
 				BA6C8B05254D6B1F008344F5 /* RiskCalculation.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
@@ -22,16 +22,23 @@ class HomeTableViewModel {
 		self.healthCertificateService = healthCertificateService
 		self.onTestResultCellTap = onTestResultCellTap
 
-		coronaTestService.$tests
-			.sink { [weak self] in
-				self?.update(pcrTest: $0.pcr, antigenTest: $0.antigen)
+		coronaTestService.$pcrTest
+			.sink { [weak self] _ in
+				self?.update()
+			}
+			.store(in: &subscriptions)
+
+		coronaTestService.$antigenTest
+			.sink { [weak self] _ in
+				self?.update()
 			}
 			.store(in: &subscriptions)
 		
-		healthCertificateService.healthCertifiedPersons.sink { healthCertifiedPersons in
-			self.healthCertifiedPersons = healthCertifiedPersons
-		}
-		.store(in: &subscriptions)
+		healthCertificateService.healthCertifiedPersons
+			.sink { healthCertifiedPersons in
+				self.healthCertifiedPersons = healthCertifiedPersons
+			}
+			.store(in: &subscriptions)
 	}
 
 	// MARK: - Internal
@@ -198,29 +205,14 @@ class HomeTableViewModel {
 	private let healthCertificateService: HealthCertificateServiceProviding
 	private var subscriptions = Set<AnyCancellable>()
 
-	private func update(pcrTest: PCRTest?, antigenTest: AntigenTest?) {
-		let updatedRiskAndTestResultsRows = self.computedRiskAndTestResultsRows(pcrTest: pcrTest, antigenTest: antigenTest)
-
-		if updatedRiskAndTestResultsRows.contains(.risk) && !self.riskAndTestResultsRows.contains(.risk) {
-			self.state.requestRisk(userInitiated: true)
-		}
-
-		if updatedRiskAndTestResultsRows != self.riskAndTestResultsRows {
-			isUpdating = true
-			self.riskAndTestResultsRows = updatedRiskAndTestResultsRows
-		}
-	}
-
-	private func computedRiskAndTestResultsRows(pcrTest: PCRTest?, antigenTest: AntigenTest?) -> [RiskAndTestResultsRow] {
+	private var computedRiskAndTestResultsRows: [RiskAndTestResultsRow] {
 		var riskAndTestResultsRows = [RiskAndTestResultsRow]()
 
-		let hasAtLeastOneShownPositiveOrSubmittedTest = pcrTest?.positiveTestResultWasShown == true || pcrTest?.keysSubmitted == true || antigenTest?.positiveTestResultWasShown == true || antigenTest?.keysSubmitted == true
-
-		if !hasAtLeastOneShownPositiveOrSubmittedTest {
+		if !coronaTestService.hasAtLeastOneShownPositiveOrSubmittedTest {
 			riskAndTestResultsRows.append(.risk)
 		}
 
-		if let pcrTest = pcrTest {
+		if let pcrTest = coronaTestService.pcrTest {
 			let testResultState: TestResultState
 			if pcrTest.testResult == .positive && pcrTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown
@@ -230,7 +222,7 @@ class HomeTableViewModel {
 			riskAndTestResultsRows.append(.pcrTestResult(testResultState))
 		}
 
-		if let antigenTest = antigenTest {
+		if let antigenTest = coronaTestService.antigenTest {
 			let testResultState: TestResultState
 			if antigenTest.testResult == .positive && antigenTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown
@@ -241,6 +233,19 @@ class HomeTableViewModel {
 		}
 
 		return riskAndTestResultsRows
+	}
+
+	private func update() {
+		let updatedRiskAndTestResultsRows = self.computedRiskAndTestResultsRows
+
+		if updatedRiskAndTestResultsRows.contains(.risk) && !self.riskAndTestResultsRows.contains(.risk) {
+			self.state.requestRisk(userInitiated: true)
+		}
+
+		if updatedRiskAndTestResultsRows != self.riskAndTestResultsRows {
+			isUpdating = true
+			self.riskAndTestResultsRows = updatedRiskAndTestResultsRows
+		}
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -57,15 +57,13 @@ class CoronaTestService {
 
 	// MARK: - Protocol CoronaTestServiceProviding
 
-	@OpenCombine.Published var pcrTest: PCRTest?
-	@OpenCombine.Published var antigenTest: AntigenTest?
+	@DidSetPublished var pcrTest: PCRTest?
+	@DidSetPublished var antigenTest: AntigenTest?
 
-	@OpenCombine.Published private(set) var tests: (pcr: PCRTest?, antigen: AntigenTest?)
+	@DidSetPublished var antigenTestIsOutdated: Bool = false
 
-	@OpenCombine.Published var antigenTestIsOutdated: Bool = false
-
-	@OpenCombine.Published var pcrTestResultIsLoading: Bool = false
-	@OpenCombine.Published var antigenTestResultIsLoading: Bool = false
+	@DidSetPublished var pcrTestResultIsLoading: Bool = false
+	@DidSetPublished var antigenTestResultIsLoading: Bool = false
 
 	var hasAtLeastOneShownPositiveOrSubmittedTest: Bool {
 		pcrTest?.positiveTestResultWasShown == true || pcrTest?.keysSubmitted == true ||
@@ -418,7 +416,6 @@ class CoronaTestService {
 		$pcrTest
 			.sink { [weak self] pcrTest in
 				self?.store.pcrTest = pcrTest
-				self?.tests.pcr = pcrTest
 
 				if pcrTest?.keysSubmitted == true {
 					self?.warnOthersReminder.cancelNotifications(for: .pcr)
@@ -429,7 +426,6 @@ class CoronaTestService {
 		$antigenTest
 			.sink { [weak self] antigenTest in
 				self?.store.antigenTest = antigenTest
-				self?.tests.antigen = antigenTest
 
 				if antigenTest?.keysSubmitted == true {
 					self?.warnOthersReminder.cancelNotifications(for: .antigen)

--- a/src/xcode/ENA/ENA/Source/Utils/DidSetPublished.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/DidSetPublished.swift
@@ -1,0 +1,25 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import OpenCombine
+
+@propertyWrapper
+class DidSetPublished<Value> {
+
+	init(wrappedValue value: Value) {
+		projectedValue = CurrentValueSubject(value)
+	}
+
+	var wrappedValue: Value {
+		get {
+			projectedValue.value
+		}
+		set {
+			projectedValue.value = newValue
+		}
+	}
+
+	var projectedValue: OpenCombine.CurrentValueSubject<Value, Never>
+
+}

--- a/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
@@ -12,8 +12,8 @@ class DidSetPublishedTests: XCTestCase {
 
 		let expectedValues = [false, false, true, true, false]
 
-		let expectation = expectation(description: "Received value")
-		expectation.expectedFulfillmentCount = expectedValues.count
+		let publishingExpectation = expectation(description: "Received value")
+		publishingExpectation.expectedFulfillmentCount = expectedValues.count
 
 		var receivedValues = [Bool]()
 		let subscription = publishingStruct.$publishingBool
@@ -22,7 +22,7 @@ class DidSetPublishedTests: XCTestCase {
 				XCTAssertEqual($0, publishingStruct.publishingBool)
 				receivedValues.append($0)
 
-				expectation.fulfill()
+				publishingExpectation.fulfill()
 			}
 
 		publishingStruct.publishingBool = false

--- a/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
+++ b/src/xcode/ENA/ENA/Source/Utils/__tests__/DidSetPublishedTests.swift
@@ -1,0 +1,48 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import XCTest
+@testable import ENA
+
+class DidSetPublishedTests: XCTestCase {
+
+    func testExample() throws {
+		let publishingStruct = PublishingStruct()
+
+		let expectedValues = [false, false, true, true, false]
+
+		let expectation = expectation(description: "Received value")
+		expectation.expectedFulfillmentCount = expectedValues.count
+
+		var receivedValues = [Bool]()
+		let subscription = publishingStruct.$publishingBool
+			.sink {
+				// Check that the value is already set on the publishing struct and we receive it afterwards
+				XCTAssertEqual($0, publishingStruct.publishingBool)
+				receivedValues.append($0)
+
+				expectation.fulfill()
+			}
+
+		publishingStruct.publishingBool = false
+		publishingStruct.publishingBool = true
+		publishingStruct.publishingBool = true
+		publishingStruct.publishingBool = false
+
+		waitForExpectations(timeout: .short)
+
+		XCTAssertEqual(receivedValues, expectedValues)
+
+		subscription.cancel()
+    }
+
+	// MARK: - Private
+
+	private struct PublishingStruct {
+
+		@DidSetPublished var publishingBool: Bool = false
+
+	}
+
+}


### PR DESCRIPTION
## Description
This PR introduces the `@DidSetPublished` property wrapper to solve timing issues that originally lead to a bug (linked below) where the risk provider did not provide a risk even though the test was already supposed to be deleted. This was due to the publisher triggering on `willSet` and the `RiskProvider` still seeing the tests that were about to be deleted and returning early.

This is basically part 2 to this pull request: [#2721](https://github.com/corona-warn-app/cwa-app-ios/pull/2721) as it allows the risk provider to be triggered immediately after deleting a corona test.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7076
