### PR TITLE
wrong open link method leads to crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/OnboardingInfoViewController+Extension.swift
@@ -181,7 +181,7 @@ extension OnboardingInfoViewController {
 
 extension OnboardingInfoViewController: UITextViewDelegate {
 	func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-		LinkHelper.openLink(withUrl: url, from: self)
+		LinkHelper.open(withUrl: url, from: self)
 		return false
 	}
 }


### PR DESCRIPTION
## Description
Wrong open link method leads to app crash 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7390
