### PR TITLE
Fix/7397 qr code crash fix

### DIFF
--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "base45-swift",
-        "repositoryURL": "https://github.com/ehn-digital-green-development/base45-swift",
+        "repositoryURL": "https://github.com/corona-warn-app/base45-swift",
         "state": {
           "branch": "distribution/swiftpackage",
           "revision": "7c5d3e0640c7f0b949bba1905306867d06f2dbb3",

--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/corona-warn-app/base45-swift",
         "state": {
           "branch": "distribution/swiftpackage",
-          "revision": "79137104b9d23b5275c6b38dd15cee8e763e2803",
+          "revision": "56f4129457b904e2805a919f0961c0e5d362166e",
           "version": null
         }
       },

--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/corona-warn-app/base45-swift",
         "state": {
           "branch": "distribution/swiftpackage",
-          "revision": "7c5d3e0640c7f0b949bba1905306867d06f2dbb3",
+          "revision": "79137104b9d23b5275c6b38dd15cee8e763e2803",
           "version": null
         }
       },

--- a/src/xcode/ENA/HealthCertificateToolkit/Package.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR", .upToNextMajor(from: "0.4.3")),
-        .package(url: "https://github.com/ehn-digital-green-development/base45-swift", .branch("distribution/swiftpackage")),
+        .package(url: "https://github.com/corona-warn-app/base45-swift", .branch("distribution/swiftpackage")),
         .package(name: "JSONSchema", url: "https://github.com/kylef/JSONSchema.swift", .upToNextMajor(from: "0.6.0"))
     ],
     targets: [


### PR DESCRIPTION
## Description
Fix crash while scanning malicious QR code.
The actual fix is in the fork of the swift package for base45.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7397
