### PR TITLE
Fix/7556 no anonymous proof

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -870,6 +870,10 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionResult_Negative_Antigen_Proof_Desc" = "Sie können den hier angezeigten Befund auch als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwenden.\n\nBitte beachten Sie, dass Sie nur dann einen Nachweis über Ihr Schnelltest-Ergebnis erbringen müssen, wenn dies gesetzlich festgelegt ist. Sie können den Nachweis über die App oder auch auf andere Weise erbringen. Informieren Sie sich hierzu bitte auch über die Kriterien für die Anerkennung von Test-Nachweisen in Ihrem Bundesland.";
 
+"ExposureSubmissionResult_Negative_Antigen_NoProof_Title" = "Keine Nachweis-Funktion";
+
+"ExposureSubmissionResult_Negative_Antigen_NoProof_Desc" = "Da der hier angezeigte Befund anonymisiert ist, kann er nicht als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwendet werden.";
+
 /* Exposure Submission */
 
 "ExposureSubmissionError_ErrorPrefix" = "Es ist einen technischer Fehler bei der Übertragung Ihrer Daten aufgetreten. Wenden Sie sich bitte an die technische Hotline. Die Nummer finden Sie unter App-Informationen.";

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewModel.swift
@@ -535,7 +535,66 @@ extension ExposureSubmissionTestResultViewModel {
 	}
 	
 	private func negativeAntigenTestResultSections(test: AntigenTest) -> [DynamicSection] {
-		[
+		var cells = [DynamicCell]()
+
+		if test.testedPerson.fullName != nil && test.testedPerson.dateOfBirth != nil {
+			cells.append(contentsOf: [
+				.title2(
+					text: AppStrings.ExposureSubmissionResult.Antigen.proofTitle,
+					accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofTitle
+				),
+				.body(
+					text: AppStrings.ExposureSubmissionResult.Antigen.proofDesc,
+					accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofDesc
+				)
+			])
+		} else {
+			cells.append(contentsOf: [
+				.title2(
+					text: AppStrings.ExposureSubmissionResult.Antigen.noProofTitle,
+					accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofTitle
+				),
+				.body(
+					text: AppStrings.ExposureSubmissionResult.Antigen.noProofDesc,
+					accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofDesc
+				)
+			])
+		}
+
+		cells.append(contentsOf: [
+			.title2(
+				text: AppStrings.ExposureSubmissionResult.procedure,
+				accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.procedure
+			),
+			ExposureSubmissionDynamicCell.stepCell(
+				title: AppStrings.ExposureSubmissionResult.Antigen.testAdded,
+				description: AppStrings.ExposureSubmissionResult.Antigen.testAddedDesc,
+				icon: UIImage(named: "Icons_Grey_Check"),
+				hairline: .iconAttached
+			),
+			ExposureSubmissionDynamicCell.stepCell(
+				title: AppStrings.ExposureSubmissionResult.testNegative,
+				description: AppStrings.ExposureSubmissionResult.Antigen.testNegativeDesc,
+				icon: UIImage(named: "Icons_Grey_Error"),
+				hairline: .topAttached
+			),
+			ExposureSubmissionDynamicCell.stepCell(
+				title: AppStrings.ExposureSubmissionResult.testRemove,
+				description: AppStrings.ExposureSubmissionResult.testRemoveDesc,
+				icon: UIImage(named: "Icons_Grey_Entfernen"),
+				hairline: .none
+			),
+			.title2(
+				text: AppStrings.ExposureSubmissionResult.furtherInfos_Title,
+				accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.furtherInfos_Title
+			),
+			.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem1, spacing: .large),
+			.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem2, spacing: .large),
+			.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem3, spacing: .large),
+			.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_TestAgain, spacing: .large)
+		])
+
+		return [
 			.section(
 				header: .identifier(
 					ExposureSubmissionTestResultViewController.HeaderReuseIdentifier.antigenTestResult,
@@ -544,46 +603,7 @@ extension ExposureSubmissionTestResultViewModel {
 					}
 				),
 				separators: .none,
-				cells: [
-					.title2(
-						text: AppStrings.ExposureSubmissionResult.Antigen.proofTitle,
-						accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofTitle
-					),
-					.body(
-						text: AppStrings.ExposureSubmissionResult.Antigen.proofDesc,
-						accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.Antigen.proofDesc
-					),
-					.title2(
-						text: AppStrings.ExposureSubmissionResult.procedure,
-						accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.procedure
-					),
-					ExposureSubmissionDynamicCell.stepCell(
-						title: AppStrings.ExposureSubmissionResult.Antigen.testAdded,
-						description: AppStrings.ExposureSubmissionResult.Antigen.testAddedDesc,
-						icon: UIImage(named: "Icons_Grey_Check"),
-						hairline: .iconAttached
-					),
-					ExposureSubmissionDynamicCell.stepCell(
-						title: AppStrings.ExposureSubmissionResult.testNegative,
-						description: AppStrings.ExposureSubmissionResult.Antigen.testNegativeDesc,
-						icon: UIImage(named: "Icons_Grey_Error"),
-						hairline: .topAttached
-					),
-					ExposureSubmissionDynamicCell.stepCell(
-						title: AppStrings.ExposureSubmissionResult.testRemove,
-						description: AppStrings.ExposureSubmissionResult.testRemoveDesc,
-						icon: UIImage(named: "Icons_Grey_Entfernen"),
-						hairline: .none
-					),
-					.title2(
-						text: AppStrings.ExposureSubmissionResult.furtherInfos_Title,
-						accessibilityIdentifier: AccessibilityIdentifiers.ExposureSubmissionResult.furtherInfos_Title
-					),
-					.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem1, spacing: .large),
-					.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem2, spacing: .large),
-					.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_ListItem3, spacing: .large),
-					.bulletPoint(text: AppStrings.ExposureSubmissionResult.furtherInfos_TestAgain, spacing: .large)
-				]
+				cells: cells
 			)
 		]
 	}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -196,6 +196,8 @@ enum AppStrings {
 			static let timerTitle = NSLocalizedString("ExposureSubmissionResult_Timer_Title", comment: "")
 			static let proofTitle = NSLocalizedString("ExposureSubmissionResult_Negative_Antigen_Proof_Title", comment: "")
 			static let proofDesc = NSLocalizedString("ExposureSubmissionResult_Negative_Antigen_Proof_Desc", comment: "")
+			static let noProofTitle = NSLocalizedString("ExposureSubmissionResult_Negative_Antigen_NoProof_Title", comment: "")
+			static let noProofDesc = NSLocalizedString("ExposureSubmissionResult_Negative_Antigen_NoProof_Desc", comment: "")
 		}
 				
 		static let card_title = NSLocalizedString("ExposureSubmissionResult_CardTitle", comment: "")

--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/AntigenExposureSubmissionNegativeTestResultHeaderView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/AntigenExposureSubmissionNegativeTestResultHeaderView.swift
@@ -199,10 +199,6 @@ class AntigenExposureSubmissionNegativeTestResultHeaderView: DynamicTableViewHea
 		// personLabel
 		if let name = coronaTest.testedPerson.fullName, let birthday = coronaTest.testedPerson.formattedDateOfBirth {
 			personLabel.text = name + "\n" + AppStrings.ExposureSubmissionResult.Antigen.personBirthdayPrefix + " " + birthday
-		} else if let name = coronaTest.testedPerson.fullName {
-			personLabel.text = name
-		} else if let birthday = coronaTest.testedPerson.formattedDateOfBirth {
-			personLabel.text = AppStrings.ExposureSubmissionResult.Antigen.personBirthdayPrefix + " " + birthday
 		} else {
 			personLabel.text = nil
 		}


### PR DESCRIPTION
## Description
Showing new "No proof functionality" information on anonymous antigen test, replacing the text that did not apply to them.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7556

## Screenshots
![IMG_0112](https://user-images.githubusercontent.com/1157991/120176319-6cbfc980-c207-11eb-99a4-1461e22b6136.PNG)
![IMG_0114](https://user-images.githubusercontent.com/1157991/120176331-6f222380-c207-11eb-85df-6a1a9c0ae80c.PNG)

