### PR TITLE
CWA crashes at Start

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -385,7 +385,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			let installationDate = store.appInstallationDate
 
 			let newKey = try KeychainHelper().generateDatabaseKey()
-			store.clearAll(key: newKey)
+			store.wipeAll(key: newKey)
 
 			/// write excluded values back to the 'new' store
 			store.ppacApiTokenEdus = ppacEdusApiToken

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -41,7 +41,7 @@ final class MockTestStore: Store, PPAnalyticsData {
 	var submissionSymptomsOnset: SymptomsOnset = .noInformation
 	var journalWithExposureHistoryInfoScreenShown: Bool = false
 	
-	func clearAll(key: String?) {}
+	func wipeAll(key: String?) {}
 	#if !RELEASE
 	// Settings from the debug menu.
 	var fakeSQLiteError: Int32?

--- a/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/SQLiteKeyValueStore.swift
@@ -158,7 +158,7 @@ final class SQLiteKeyValueStore {
 
 	/// Removes all key/value pairs from the Store and creates a new database with a given key
 	/// - Parameters The new database key/password. If the key is nil, the action is same as the `resetDatabase`
-	func clearAll(key: String?) throws {
+	func wipeAll(key: String?) throws {
 		try resetDatabase()
 		guard let key = key else {
 			return

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -42,9 +42,9 @@ final class SecureStore: Store, AntigenTestProfileStoring {
 	/// - Parameter key: the key for the new database; if no key is given, no new database will be created
 	///
 	/// - Note: This is just a wrapper to the `SQLiteKeyValueStore:clearAll:` call
-	func clearAll(key: String?) {
+	func wipeAll(key: String?) {
 		do {
-			try kvStore.clearAll(key: key)
+			try kvStore.wipeAll(key: key)
 		} catch {
 			Log.error("kv store error", log: .localData, error: error)
 		}

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -71,7 +71,7 @@ protocol StoreProtocol: AnyObject {
 
 	var journalWithExposureHistoryInfoScreenShown: Bool { get set }
 
-	func clearAll(key: String?)
+	func wipeAll(key: String?)
 
 	#if !RELEASE
 	/// Settings from the debug menu.

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -127,7 +127,7 @@ final class StoreTests: CWATestCase {
 		XCTAssertNotEqual(databaseKey, keychain.loadFromKeychain(key: SecureStore.keychainDatabaseKey))
 
 		// cleanup
-		store.clearAll(key: nil)
+		store.wipeAll(key: nil)
 	}
 
 	func testConfigCaching() throws {

--- a/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/__tests__/SQLiteKeyValueStoreTests.swift
@@ -74,7 +74,7 @@ final class SQLiteKeyValueStoreTests: CWATestCase {
 		kvStore[rawMockData[0].key] = rawMockData[0].data
 		kvStore[rawMockData[1].key] = rawMockData[1].data
 
-		try kvStore.clearAll(key: "newPassword")
+		try kvStore.wipeAll(key: "newPassword")
 
 		XCTAssertNil(kvStore[rawMockData[0].key])
 		XCTAssertNil(kvStore[rawMockData[1].key])


### PR DESCRIPTION
## Description

This function renaming is a possible fix for the crashes on app launch or while onboarding. I suspect the issue lies somewhere in the area of a namespace conflict or an actual compile error. As `clearAll` is a common function name I renamed it to `wipeAll` which resolved the crash issues on my device. Let's see if it also helps others.

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7595
