### PR TITLE
Deleted persons and locations reappear after reopening the app

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -263,7 +263,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		#else
 		return RiskProvider(
 			configuration: .default,
-			diaryStore: diaryStore,
+			store: store,
 			appConfigurationProvider: appConfigurationProvider,
 			exposureManagerState: exposureManager.exposureManagerState,
 			checkinRiskCalculation: checkinRiskCalculation,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -263,7 +263,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		#else
 		return RiskProvider(
 			configuration: .default,
-			store: store,
+			diaryStore: diaryStore,
 			appConfigurationProvider: appConfigurationProvider,
 			exposureManagerState: exposureManager.exposureManagerState,
 			checkinRiskCalculation: checkinRiskCalculation,

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/DiaryCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/DiaryCoordinator.swift
@@ -307,7 +307,8 @@ class DiaryCoordinator {
 
 		let viewController = DiaryEditEntriesViewController(
 			entryType: entryType,
-			store: diaryStore,
+			diaryStore: diaryStore,
+			eventStore: eventStore,
 			onCellSelection: { [weak self] entry in
 				self?.showAddAndEditEntryScreen(
 					mode: .edit(entry),

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
@@ -11,11 +11,12 @@ class DiaryEditEntriesViewController: UIViewController, UITableViewDataSource, U
 
 	init(
 		entryType: DiaryEntryType,
-		store: DiaryStoringProviding,
+		diaryStore: DiaryStoringProviding,
+		eventStore: EventStoringProviding,
 		onCellSelection: @escaping (DiaryEntry) -> Void,
 		onDismiss: @escaping () -> Void
 	) {
-		self.viewModel = DiaryEditEntriesViewModel(entryType: entryType, store: store)
+		self.viewModel = DiaryEditEntriesViewModel(entryType: entryType, diaryStore: diaryStore, eventStore: eventStore)
 		self.onCellSelection = onCellSelection
 		self.onDismiss = onDismiss
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/__test__/DiaryEditEntriesViewModelTest.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/__test__/DiaryEditEntriesViewModelTest.swift
@@ -10,7 +10,7 @@ import OpenCombine
 class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testContactPersonsStrings() throws {
-		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, store: MockDiaryStore())
+		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, diaryStore: MockDiaryStore(), eventStore: MockEventStore())
 
 		XCTAssertEqual(viewModel.title, AppStrings.ContactDiary.EditEntries.ContactPersons.title)
 
@@ -27,7 +27,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 	}
 
 	func testLocationsStrings() throws {
-		let viewModel = DiaryEditEntriesViewModel(entryType: .location, store: MockDiaryStore())
+		let viewModel = DiaryEditEntriesViewModel(entryType: .location, diaryStore: MockDiaryStore(), eventStore: MockEventStore())
 
 		XCTAssertEqual(viewModel.title, AppStrings.ContactDiary.EditEntries.Locations.title)
 
@@ -45,7 +45,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testContactPersonsEntriesUpdatedWhenStoreChanges() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2
@@ -66,7 +66,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testLocationsEntriesUpdatedWhenStoreChanges() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .location, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .location, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2
@@ -87,7 +87,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testRemoveContactPerson() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2
@@ -119,7 +119,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testRemoveLocation() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .location, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .location, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2
@@ -151,7 +151,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testRemoveAllContactPersons() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .contactPerson, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2
@@ -174,7 +174,7 @@ class DiaryEditEntriesViewModelTest: CWATestCase {
 
 	func testRemoveAllLocations() throws {
 		let store = makeMockStore()
-		let viewModel = DiaryEditEntriesViewModel(entryType: .location, store: store)
+		let viewModel = DiaryEditEntriesViewModel(entryType: .location, diaryStore: store, eventStore: MockEventStore())
 
 		let publisherExpectation = expectation(description: "Entries publisher called")
 		publisherExpectation.expectedFulfillmentCount = 2


### PR DESCRIPTION
## Description

Delete the referenced event checkin before deleting a location in the contact diary so no connection is left in the event store. 

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7588
