### PR TITLE
Fix/7680 ios13 crashes

### DIFF
--- a/src/xcode/ENA/ENA/Source/Client/Security/CoronaWarnURLSessionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/Client/Security/CoronaWarnURLSessionDelegate.swift
@@ -35,14 +35,21 @@ extension CoronaWarnURLSessionDelegate: URLSessionDelegate {
 		// that might return something different than `errSecSuccess`.
 		//
 		// [1]: https://developer.apple.com/documentation/security/certificate_key_and_trust_services/trust/evaluating_a_trust_and_parsing_the_result
+		//
+		// from the documentation about the method SecTrustEvaluateAsyncWithError
+		// Important: You must call this method from the same dispatch queue that you specify as the queue parameter.
+		//
 		if #available(iOS 13.0, *) {
-			SecTrustEvaluateAsyncWithError(trust, session.delegateQueue.underlyingQueue ?? .main) { [weak self] trust, isValid, error in
-				guard isValid else {
-					Log.error("Evaluation failed with error: \(error?.localizedDescription ?? "<nil>")", log: .api, error: error)
-					completionHandler(.cancelAuthenticationChallenge, /* credential */ nil)
-					return
+			let dispatchQueue = session.delegateQueue.underlyingQueue ?? DispatchQueue.global()
+			dispatchQueue.async {
+				SecTrustEvaluateAsyncWithError(trust, dispatchQueue) { [weak self] trust, isValid, error in
+					guard isValid else {
+						Log.error("Evaluation failed with error: \(error?.localizedDescription ?? "<nil>")", log: .api, error: error)
+						completionHandler(.cancelAuthenticationChallenge, /* credential */ nil)
+						return
+					}
+					self?.evaluate(challenge: challenge, trust: trust, completionHandler: completionHandler)
 				}
-				self?.evaluate(challenge: challenge, trust: trust, completionHandler: completionHandler)
 			}
 		} else {
 			var secresult = SecTrustResultType.invalid


### PR DESCRIPTION
## Description
Crashes on App start. `SecTrustEvaluateAsyncWithError` needed to get called from the same queue it expects as a parameter.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7680
