### PR TITLE
Fix/7702 wrong date in contact jounal

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -661,8 +661,10 @@ class CoronaTestService {
 
 					// only store test result in diary if negative or positive
 					if (testResult == .positive || testResult == .negative) && !coronaTest.journalEntryCreated {
-						// -> store
-						let stringDate = DateFormatter.packagesDayDateFormatter.string(from: registrationDate)
+						// PCR -> registration date
+						// antigen -> sample collection date if available otherwise we use point of care consent date
+						//
+						let stringDate = DateFormatter.packagesDayDateFormatter.string(from: coronaTest.testDate)
 						self.diaryStore.addCoronaTest(testDate: stringDate, testType: coronaTestType.rawValue, testResult: testResult.rawValue)
 
 						switch coronaTestType {


### PR DESCRIPTION
## Description
We no longer use the registration date of tests to make contact journal entries.
Depending on test type we will use:
* pcr -> registration date
* antigen -> sample collection date if not available the fallback will be the point of care consent date

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7702

