### PR TITLE
Show the timetravel warning only once in foreground.

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -509,7 +509,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 					rootController: rootController
 				)
 			case .wrongDeviceTime:
-				return rootController.setupErrorAlert(message: didEndPrematurelyReason.localizedDescription)
+				if !self.store.wasDeviceTimeErrorShown {
+					self.store.wasDeviceTimeErrorShown = true
+					return rootController.setupErrorAlert(message: didEndPrematurelyReason.localizedDescription)
+				} else {
+					return nil
+				}
+
 			default:
 				return nil
 			}


### PR DESCRIPTION
## Description
We never checked if the time travel warning has been already shown in foreground. This PR fixes this Issue.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7547

## Screenshots
How do I show something that is no longer appearing? Use your imagination 🌈 