### PR TITLE
Check that model is there when reloading too early on iOS 12

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
@@ -190,7 +190,10 @@ class HealthCertificateOverviewViewController: UITableViewController {
 			fatalError("Could not dequeue HomeHealthCertifiedPersonTableViewCell")
 		}
 
-		let healthCertifiedPerson = viewModel.healthCertifiedPersons[indexPath.row]
+		guard let healthCertifiedPerson = viewModel.healthCertifiedPersons[safe: indexPath.row] else {
+			return UITableViewCell()
+		}
+
 		let cellModel = HomeHealthCertifiedPersonCellModel(
 			healthCertifiedPerson: healthCertifiedPerson
 		)
@@ -216,8 +219,12 @@ class HealthCertificateOverviewViewController: UITableViewController {
 			fatalError("Could not dequeue HomeHealthCertifiedPersonTableViewCell")
 		}
 
+		guard let testCertificate = viewModel.testCertificates[safe: indexPath.row] else {
+			return UITableViewCell()
+		}
+
 		let cellModel = HomeHealthCertifiedPersonCellModel(
-			testCertificate: viewModel.testCertificates[indexPath.row]
+			testCertificate: testCertificate
 		)
 		cell.configure(with: cellModel)
 


### PR DESCRIPTION
## Description
On iOS 12 there seems to be an intermediate reload with the old model before the updated model triggers a new reload. Accessing the model array in a safe manner to prevent a crash.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7762
