### PR TITLE
Dont set the Textcolor in xib since it overrides the color on 12.5

### DIFF
--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionImageCardCell.xib
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/ExposureSubmissionImageCardCell.xib
@@ -27,7 +27,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" text="Title 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GZC-S1-aXb" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
                                 <rect key="frame" x="16" y="16" width="368.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" name="ENA Text Primary 1 Color"/>
+                                <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="title2"/>
@@ -47,7 +47,7 @@
                                                 <rect key="frame" x="16" y="0.0" width="276" height="101.5"/>
                                                 <string key="text">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</string>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" name="ENA Text Primary 1 Color"/>
+                                                <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="body"/>
@@ -135,9 +135,6 @@
         </namedColor>
         <namedColor name="ENA Chevron Color">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.30000001192092896" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="ENA Text Primary 1 Color">
-            <color red="0.090196078431372548" green="0.098039215686274508" blue="0.10196078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
## Description
Text color was set in xib which leads to overriding the text color on iOS 12.x

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7473

## Screenshots
![IMG_A9B524D94A1C-1](https://user-images.githubusercontent.com/10122052/121683570-d8cee700-cabd-11eb-8ca5-cf274ce07485.jpeg)
