### PR TITLE
Add certificates tab app store screenshot

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -36,7 +36,8 @@ class HealthCertificateService {
 			if LaunchArguments.healthCertificate.testCertificateRegistered.boolValue {
 				let result = DigitalGreenCertificateFake.makeBase45Fake(
 					from: DigitalGreenCertificate.fake(
-						testEntries: [TestEntry.fake()]
+						name: .fake(familyName: "Schneider", givenName: "Andrea", standardizedFamilyName: "SCHNEIDER", standardizedGivenName: "ANDREA"),
+						testEntries: [TestEntry.fake(dateTimeOfSampleCollection: "2021-04-12T16:01:00Z")]
 					),
 					and: CBORWebTokenHeader.fake()
 				)

--- a/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
@@ -24,7 +24,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 
 	// MARK: - Tests
 
-	func test_shownConsentScreenAndDisclaimer() throws {
+	func test_screenshot_shownConsentScreenAndDisclaimer() throws {
 		app.launch()
 
 		app.buttons[AccessibilityIdentifiers.TabBar.certificates].waitAndTap()
@@ -48,7 +48,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		XCTAssertTrue(app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.vaccinationCertificateRegistrationCell].waitForExistence(timeout: .short))
 	}
 
-	func test_CreateAntigenTestProfileWithFirstCertificate() throws {
+	func test_screenshot_CreateAntigenTestProfileWithFirstCertificate() throws {
 		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
 		app.launch()
 
@@ -73,7 +73,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		snapshot("screenshot_first_health_certificate")
 	}
 
-	func test_CreateAntigenTestProfileWithLastCertificate() throws {
+	func test_screenshot_CreateAntigenTestProfileWithLastCertificate() throws {
 		app.setLaunchArgument(LaunchArguments.healthCertificate.firstHealthCertificate, to: true)
 		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
 		app.launch()
@@ -105,7 +105,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		snapshot("screenshot_second_health_certificate")
 	}
 
-	func test_ShowCertificate() throws {
+	func test_screenshot_ShowCertificate() throws {
 		app.setLaunchArgument(LaunchArguments.healthCertificate.firstAndSecondHealthCertificate, to: true)
 		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
 		app.launch()
@@ -128,7 +128,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		XCTAssertEqual(app.cells.matching(identifier: AccessibilityIdentifiers.HealthCertificate.Person.certificateCell).count, 2)
 	}
 
-	func test_TestCertificate() throws {
+	func test_screenshot_TestCertificate() throws {
 		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
 		app.setLaunchArgument(LaunchArguments.healthCertificate.testCertificateRegistered, to: true)
 		app.launch()
@@ -151,7 +151,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		snapshot("screenshot_test_certificate")
 	}
 
-	func test_CompleteVaccinationProtectionWithTestCertificate() throws {
+	func test_screenshot_CompleteVaccinationProtectionWithTestCertificate() throws {
 		app.setLaunchArgument(LaunchArguments.healthCertificate.firstAndSecondHealthCertificate, to: true)
 		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
 		app.setLaunchArgument(LaunchArguments.healthCertificate.testCertificateRegistered, to: true)

--- a/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
@@ -151,4 +151,19 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		snapshot("screenshot_test_certificate")
 	}
 
+	func test_CompleteVaccinationProtectionWithTestCertificate() throws {
+		app.setLaunchArgument(LaunchArguments.healthCertificate.firstAndSecondHealthCertificate, to: true)
+		app.setLaunchArgument(LaunchArguments.infoScreen.healthCertificateInfoScreenShown, to: true)
+		app.setLaunchArgument(LaunchArguments.healthCertificate.testCertificateRegistered, to: true)
+		app.launch()
+
+		// Navigate to Certificates Tab.
+		app.buttons[AccessibilityIdentifiers.TabBar.certificates].waitAndTap()
+
+		let healthCertificateCell = app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.vaccinationCertificateCell]
+		XCTAssertTrue(healthCertificateCell.waitForExistence(timeout: .short))
+
+		snapshot("screenshot_certificate_overview_vaccination_and_test_certificate")
+	}
+
 }

--- a/src/xcode/ENA/TestPlans/Screenshots.xctestplan
+++ b/src/xcode/ENA/TestPlans/Screenshots.xctestplan
@@ -69,9 +69,11 @@
         "ENAUITests_08_UpdateOS\/test_screenshot_UpdateOS()",
         "ENAUITests_09_TraceLocations\/test_screenshots_of_traceLocation_print_flow()",
         "ENAUITests_10_CheckIns\/test_screenshot_WHEN_scan_QRCode_THEN_checkin_and_checkout()",
+        "ENAUITests_13_CreateHealthCertificate\/test_CompleteVaccinationProtectionWithTestCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_CreateAntigenTestProfileWithFirstCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_CreateAntigenTestProfileWithLastCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_ShowCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_TestCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_shownConsentScreenAndDisclaimer()"
       ],
       "target" : {

--- a/src/xcode/ENA/TestPlans/Screenshots.xctestplan
+++ b/src/xcode/ENA/TestPlans/Screenshots.xctestplan
@@ -69,12 +69,12 @@
         "ENAUITests_08_UpdateOS\/test_screenshot_UpdateOS()",
         "ENAUITests_09_TraceLocations\/test_screenshots_of_traceLocation_print_flow()",
         "ENAUITests_10_CheckIns\/test_screenshot_WHEN_scan_QRCode_THEN_checkin_and_checkout()",
-        "ENAUITests_13_CreateHealthCertificate\/test_CompleteVaccinationProtectionWithTestCertificate()",
-        "ENAUITests_13_CreateHealthCertificate\/test_CreateAntigenTestProfileWithFirstCertificate()",
-        "ENAUITests_13_CreateHealthCertificate\/test_CreateAntigenTestProfileWithLastCertificate()",
-        "ENAUITests_13_CreateHealthCertificate\/test_ShowCertificate()",
-        "ENAUITests_13_CreateHealthCertificate\/test_TestCertificate()",
-        "ENAUITests_13_CreateHealthCertificate\/test_shownConsentScreenAndDisclaimer()"
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CompleteVaccinationProtectionWithTestCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithFirstCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithLastCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_ShowCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_TestCertificate()",
+        "ENAUITests_13_CreateHealthCertificate\/test_screenshot_shownConsentScreenAndDisclaimer()"
       ],
       "target" : {
         "containerPath" : "container:ENA.xcodeproj",


### PR DESCRIPTION
## Description
Adding a screenshot for the new certificates tab to show on the App Store.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7805

## Screenshots
![Simulator Screen Shot - Clone 1 of iPhone 11 - 2021-06-11 at 14 05 16](https://user-images.githubusercontent.com/1157991/121684410-ef297280-cabe-11eb-9475-2b9e6f2a103a.png)
![simulator_screenshot_A3B9778D-0A96-45ED-8E3C-3DE42C3CF65F](https://user-images.githubusercontent.com/1157991/121684428-f6e91700-cabe-11eb-86eb-15c856b75210.png)

