### PR TITLE
Fix/#7828 tan is not registered as pcr in contact journal

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -186,7 +186,7 @@ class CoronaTestService {
 					// testType: Always PCR
 					// testResult: teleTan is always positive
 					
-					let stringDate = DateFormatter.packagesDayDateFormatter.string(from: _pcrTest.registrationDate)
+					let stringDate = ISO8601DateFormatter.justLocalDateFormatter.string(from: _pcrTest.registrationDate)
 					self?.diaryStore.addCoronaTest(
 						testDate: stringDate,
 						testType: CoronaTestType.pcr.rawValue,

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -180,7 +180,20 @@ class CoronaTestService {
 					Analytics.collect(.testResultMetadata(.registerNewTestMetadata(Date(), registrationToken, .pcr)))
 					Analytics.collect(.testResultMetadata(.updateTestResult(.positive, registrationToken, .pcr)))
 					Analytics.collect(.keySubmissionMetadata(.submittedWithTeletan(true, .pcr)))
-
+					
+					// Because every test registered per teleTAN is positive, we can add this PCR test as positive in the contact diary.
+					// testDate: For PCR -> registration date
+					// testType: Always PCR
+					// testResult: teleTan is always positive
+					
+					let stringDate = DateFormatter.packagesDayDateFormatter.string(from: _pcrTest.registrationDate)
+					self?.diaryStore.addCoronaTest(
+						testDate: stringDate,
+						testType: CoronaTestType.pcr.rawValue,
+						testResult: TestResult.positive.rawValue
+					)
+					self?.pcrTest?.journalEntryCreated = true
+					
 					completion(.success(()))
 				case .failure(let error):
 					Log.error("[CoronaTestService] PCR test registration failed: \(error.localizedDescription)", log: .api)

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -804,12 +804,13 @@ class CoronaTestServiceTests: CWATestCase {
 		}
 
 		let appConfiguration = CachedAppConfigurationMock()
+		let diaryStore = MockDiaryStore()
 
 		let service = CoronaTestService(
 			client: client,
 			store: store,
 			eventStore: eventStore,
-			diaryStore: MockDiaryStore(),
+			diaryStore: diaryStore,
 			appConfiguration: appConfiguration,
 			healthCertificateService: HealthCertificateService(
 				store: store,
@@ -863,7 +864,8 @@ class CoronaTestServiceTests: CWATestCase {
 		XCTAssertFalse(pcrTest.isSubmissionConsentGiven)
 		XCTAssertNil(pcrTest.submissionTAN)
 		XCTAssertFalse(pcrTest.keysSubmitted)
-		XCTAssertFalse(pcrTest.journalEntryCreated)
+		XCTAssertTrue(pcrTest.journalEntryCreated)
+		XCTAssertFalse(diaryStore.coronaTests.isEmpty)
 		XCTAssertEqual(store.pcrKeySubmissionMetadata?.submittedWithCheckIns, true)
 	}
 
@@ -880,12 +882,13 @@ class CoronaTestServiceTests: CWATestCase {
 		}
 
 		let appConfiguration = CachedAppConfigurationMock()
+		let diaryStore = MockDiaryStore()
 
 		let service = CoronaTestService(
 			client: client,
 			store: store,
 			eventStore: MockEventStore(),
-			diaryStore: MockDiaryStore(),
+			diaryStore: diaryStore,
 			appConfiguration: appConfiguration,
 			healthCertificateService: HealthCertificateService(
 				store: store,
@@ -933,7 +936,8 @@ class CoronaTestServiceTests: CWATestCase {
 		XCTAssertTrue(pcrTest.isSubmissionConsentGiven)
 		XCTAssertNil(pcrTest.submissionTAN)
 		XCTAssertFalse(pcrTest.keysSubmitted)
-		XCTAssertFalse(pcrTest.journalEntryCreated)
+		XCTAssertTrue(pcrTest.journalEntryCreated)
+		XCTAssertFalse(diaryStore.coronaTests.isEmpty)
 	}
 
 	func testRegisterPCRTestWithTeleTAN_RegistrationFails() {
@@ -949,12 +953,12 @@ class CoronaTestServiceTests: CWATestCase {
 		}
 
 		let appConfiguration = CachedAppConfigurationMock()
-
+		let diaryStore = MockDiaryStore()
 		let service = CoronaTestService(
 			client: client,
 			store: store,
 			eventStore: MockEventStore(),
-			diaryStore: MockDiaryStore(),
+			diaryStore: diaryStore,
 			appConfiguration: appConfiguration,
 			healthCertificateService: HealthCertificateService(
 				store: store,
@@ -983,6 +987,7 @@ class CoronaTestServiceTests: CWATestCase {
 
 		XCTAssertNil(service.pcrTest)
 		XCTAssertNil(store.pcrTestResultMetadata)
+		XCTAssertTrue(diaryStore.coronaTests.isEmpty)
 	}
 
 	func testRegisterAntigenTestAndGetResult_successWithoutSubmissionConsentGivenWithTestedPerson() {


### PR DESCRIPTION
## Description
Adds automatically one per teleTAN added test as a contact journal entry.
Also extended the existing unit tests for teleTAN PCR tests to ensure the creation/non-creation of this test.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7828

## Screenshots
![Bildschirmfoto 2021-06-14 um 15 00 46](https://user-images.githubusercontent.com/75615785/121896671-da004e00-cd21-11eb-97d9-4431857ad035.png)

