### PR TITLE
Removed word

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1967,7 +1967,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "Statistics_Info_Title" = "Kennzahlen";
 
-"Statistics_Info_Subtitle" = "Erklärung der bundesweiten Statistiken";
+"Statistics_Info_Subtitle" = "Erklärung der Statistiken";
 
 "Statistics_Info_Infections_Title" = "Bestätigte Neuinfektionen";
 


### PR DESCRIPTION
Removed the unnecessary word "bundesweiten", which in Android had already been the case. Now, both stings are the same. Figma is up to date.