### PR TITLE
set errorCorrectionLevel to .medium in QRCodes for HealthCertificates

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -18,7 +18,7 @@ struct HealthCertificateQRCodeCellViewModel {
 			with: healthCertificate.base45,
 			encoding: .utf8,
 			size: CGSize(width: qrCodeSize, height: qrCodeSize),
-			qrCodeErrorCorrectionLevel: .quartile
+			qrCodeErrorCorrectionLevel: .medium
 		) ?? UIImage()
 
 		self.accessibilityText = accessibilityText


### PR DESCRIPTION
## Description
Use .medium so our Android friends , you know those with the bad cameras ;), have it easier to scan HealthCertificates
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8072

