### PR TITLE
remove LaunchArgument for statistics

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
@@ -173,7 +173,7 @@ class HomeCoordinator: RequiresAppDependencies {
 
 	private lazy var statisticsProvider: StatisticsProvider = {
 			#if DEBUG
-			if isUITesting, LaunchArguments.statistics.useMockDataForStatistics.boolValue {
+			if isUITesting {
 				return StatisticsProvider(
 					client: CachingHTTPClientMock(),
 					store: store

--- a/src/xcode/ENA/ENAUITests/AppStore/ENAUITests.swift
+++ b/src/xcode/ENA/ENAUITests/AppStore/ENAUITests.swift
@@ -108,7 +108,6 @@ class ENAUITests: CWATestCase {
 		app.setPreferredContentSizeCategory(accessibility: .normal, size: .M)
 		app.setLaunchArgument(LaunchArguments.onboarding.isOnboarded, to: true)
 		app.setLaunchArgument(LaunchArguments.common.ENStatus, to: ENStatus.active.stringValue)
-		app.setLaunchArgument(LaunchArguments.statistics.useMockDataForStatistics, to: true) // prevent failing tests for 1.11; use "NO" for 1.12
 		app.launch()
 
 		app.swipeUp(velocity: .slow)

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITests-Statistics.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITests-Statistics.swift
@@ -16,8 +16,6 @@ class ENAUITests_01b_Statistics: CWATestCase {
 		app.setLaunchArgument(LaunchArguments.onboarding.isOnboarded, to: true)
 		app.setLaunchArgument(LaunchArguments.onboarding.setCurrentOnboardingVersion, to: true)
 		app.setLaunchArgument(LaunchArguments.infoScreen.userNeedsToBeInformedAboutHowRiskDetectionWorks, to: false)
-		app.setLaunchArgument(LaunchArguments.statistics.useMockDataForStatistics, to: true)
-
 	}
 	
 	func test_StatisticsCardTitles() throws {


### PR DESCRIPTION
## Description
Remove **LaunchArguments.statistics.useMockDataForStatistics** from UITests since we already have a condition **isUITesting** in the HomeCoordinator

I checked all placed that used the argument still works in the UITests