### PR TITLE
Fix/4348 ns progress again

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -36,14 +36,15 @@ final class ExposureDetection {
 
 	private func writeKeyPackagesToFileSystem(completion: (WrittenPackages) -> Void) {
 		if let writtenPackages = self.delegate?.exposureDetectionWriteDownloadedPackages(country: country) {
-			completion(WrittenPackages(urls: writtenPackages.urls))
+			completion(writtenPackages)
 		} else {
 			endPrematurely(reason: .unableToWriteDiagnosisKeys)
 		}
 	}
 
 	private func detectExposureWindows(writtenPackages: WrittenPackages, exposureConfiguration: ENExposureConfiguration) {
-		self.progress = self.delegate?.detectExposureWindows(
+		progress?.cancel()
+		progress = delegate?.detectExposureWindows(
 			self,
 			detectSummaryWithConfiguration: exposureConfiguration,
 			writtenPackages: writtenPackages
@@ -69,7 +70,7 @@ final class ExposureDetection {
 
         Log.info("ExposureDetection: Start writing packages to file system.", log: .riskDetection)
 
-        self.writeKeyPackagesToFileSystem { [weak self] writtenPackages in
+        writeKeyPackagesToFileSystem { [weak self] writtenPackages in
             guard let self = self else { return }
 
             Log.info("ExposureDetection: Completed writing packages to file system.", log: .riskDetection)
@@ -96,9 +97,9 @@ final class ExposureDetection {
 			"Tried to end a detection prematurely is only possible if a detection is currently running."
 		)
 
-		DispatchQueue.main.async {
-			self.completion?(.failure(reason))
-			self.completion = nil
+		DispatchQueue.main.async { [weak self] in
+			self?.completion?(.failure(reason))
+			self?.completion = nil
 		}
 	}
 
@@ -111,9 +112,9 @@ final class ExposureDetection {
 			"Tried report exposure windows but no completion handler is set."
 		)
 		
-		DispatchQueue.main.async {
-			self.completion?(.success(exposureWindows))
-			self.completion = nil
+		DispatchQueue.main.async { [weak self] in
+			self?.completion?(.success(exposureWindows))
+			self?.completion = nil
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -44,7 +44,7 @@ final class ExposureDetection {
 
 	private func detectExposureWindows(writtenPackages: WrittenPackages, exposureConfiguration: ENExposureConfiguration) {
 		if progress != nil {
-			Log.error("previous running process found, will try to cancel", log: .riskDetection)
+			Log.error("previous running progress found, will try to cancel", log: .riskDetection)
 			progress?.cancel()
 		}
 		progress = delegate?.detectExposureWindows(

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -97,9 +97,9 @@ final class ExposureDetection {
 			"Tried to end a detection prematurely is only possible if a detection is currently running."
 		)
 
-		DispatchQueue.main.async { [weak self] in
-			self?.completion?(.failure(reason))
-			self?.completion = nil
+		DispatchQueue.main.async {
+			self.completion?(.failure(reason))
+			self.completion = nil
 		}
 	}
 
@@ -112,9 +112,9 @@ final class ExposureDetection {
 			"Tried report exposure windows but no completion handler is set."
 		)
 		
-		DispatchQueue.main.async { [weak self] in
-			self?.completion?(.success(exposureWindows))
-			self?.completion = nil
+		DispatchQueue.main.async {
+			self.completion?(.success(exposureWindows))
+			self.completion = nil
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -43,7 +43,10 @@ final class ExposureDetection {
 	}
 
 	private func detectExposureWindows(writtenPackages: WrittenPackages, exposureConfiguration: ENExposureConfiguration) {
-		progress?.cancel()
+		if progress != nil {
+			Log.error("previous running process found, will try to cancel", log: .riskDetection)
+			progress?.cancel()
+		}
 		progress = delegate?.detectExposureWindows(
 			self,
 			detectSummaryWithConfiguration: exposureConfiguration,

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -82,7 +82,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 						completion(.failure(error))
 					}
 				}
-				Log.info("2nd child added to process", log: .riskDetection)
+				Log.info("2nd child added to progress", log: .riskDetection)
 				progress.addChild(exposureWindowsProgress, withPendingUnitCount: 1)
 			} else if let error = error {
 				self.clearCacheOnErrorBadParameter(error: error)
@@ -90,7 +90,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 			}
 		}
 
-		Log.info("1st child added to process", log: .riskDetection)
+		Log.info("1st child added to progress", log: .riskDetection)
 		progress.addChild(detectExposuresProgress, withPendingUnitCount: 1)
 
 		return progress

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -82,7 +82,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 						completion(.failure(error))
 					}
 				}
-
+				Log.info("2nd child added to process", log: .riskDetection)
 				progress.addChild(exposureWindowsProgress, withPendingUnitCount: 1)
 			} else if let error = error {
 				self.clearCacheOnErrorBadParameter(error: error)
@@ -90,6 +90,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 			}
 		}
 
+		Log.info("1st child added to process", log: .riskDetection)
 		progress.addChild(detectExposuresProgress, withPendingUnitCount: 1)
 
 		return progress

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -65,7 +65,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 		writtenPackages: WrittenPackages,
 		completion: @escaping (Result<[ENExposureWindow], Error>) -> Void
 	) -> Progress {
-		let progress = Progress()
+		let progress = Progress(totalUnitCount: 2)
 
 		let detectExposuresProgress = exposureDetector.detectExposures(
 			configuration: configuration,


### PR DESCRIPTION
## Description
We still see some crashes appear when adding children to the progress.
Set progress totalUnitCount to 2 and make sure  old progress gets canceled before setting a new one.

It still is uncertain if this will solve the issue - keep fingers crossed.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4368?filter=58336

