### PR TITLE
Pin date formatter on certificate screen to Gregorian calendar

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewModel.swift
@@ -341,6 +341,8 @@ final class HealthCertificateViewModel {
 
 		let customDateFormatter = DateFormatter()
 		customDateFormatter.dateFormat = "yyyy-MM-dd HH:mm 'UTC' x"
+		// Dates on this screen are formatted in Gregorian calendar, even if the user setting is different
+		customDateFormatter.calendar = .gregorian()
 		var dateTimeOfSampleCollectionCellViewModel: HealthCertificateKeyValueCellViewModel?
 		if let sampleCollectionDate = testEntry.sampleCollectionDate {
 			dateTimeOfSampleCollectionCellViewModel = HealthCertificateKeyValueCellViewModel(


### PR DESCRIPTION
## Description
Sets the date formatter on certificate screen to Gregorian calendar to make sure all dates on this screen are formatted in the same calendar.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8205
