### PR TITLE
Fix/certificate header optionality

### DIFF
--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
@@ -154,6 +154,7 @@ public struct DigitalCovidCertificateAccess: DigitalCovidCertificateAccessProtoc
         }
 
         // 'iat' (issuedAt) should not be nil, so we assign it a default 0 here to void optionality.
+        // We are not returning an error here, because of backwards compatibility, due to a change from optional to non-optional.
         var issuedAt: UInt64 = 0
         // 6: Issued at (UNIX timestamp in seconds)
         if let issuedAtElement = cborWebToken[6],

--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
@@ -153,7 +153,8 @@ public struct DigitalCovidCertificateAccess: DigitalCovidCertificateAccessProtoc
             return .failure(.HC_CBORWEBTOKEN_NO_EXPIRATIONTIME)
         }
 
-        var issuedAt: UInt64?
+        // 'iat' (issuedAt) should not be nil, so we assign it a default 0 here to void optionality.
+        var issuedAt: UInt64 = 0
         // 6: Issued at (UNIX timestamp in seconds)
         if let issuedAtElement = cborWebToken[6],
            case let .unsignedInt(_issuedAt) = issuedAtElement {

--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateAccess.swift
@@ -153,7 +153,7 @@ public struct DigitalCovidCertificateAccess: DigitalCovidCertificateAccessProtoc
             return .failure(.HC_CBORWEBTOKEN_NO_EXPIRATIONTIME)
         }
 
-        // 'iat' (issuedAt) should not be nil, so we assign it a default 0 here to void optionality.
+        // 'iat' (issuedAt) should not be nil, so we assign it a default 0 here to avoid optionality.
         // We are not returning an error here, because of backwards compatibility, due to a change from optional to non-optional.
         var issuedAt: UInt64 = 0
         // 6: Issued at (UNIX timestamp in seconds)

--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateFake.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/DigitalCovidCertificateFake.swift
@@ -26,10 +26,7 @@ public enum DigitalCovidCertificateFake {
         cborWebTokenPayload[-260] = wrappedCertificate
         cborWebTokenPayload[1] = CBOR.utf8String(header.issuer)
         cborWebTokenPayload[4] = CBOR.unsignedInt(header.expirationTime)
-
-        if let issuedAt = header.issuedAt {
-            cborWebTokenPayload[6] = CBOR.unsignedInt(issuedAt)
-        }
+        cborWebTokenPayload[6] = CBOR.unsignedInt(header.issuedAt)
 
         let cborWebTokenPayloadBytes = cborWebTokenPayload.encode()
 
@@ -81,10 +78,7 @@ public enum DigitalCovidCertificateFake {
         var cborWebTokenPayload = CBOR.map([CBOR: CBOR]())
         cborWebTokenPayload[-260] = wrappedCertificate
         cborWebTokenPayload[4] = CBOR.unsignedInt(header.expirationTime)
-
-        if let issuedAt = header.issuedAt {
-            cborWebTokenPayload[6] = CBOR.unsignedInt(issuedAt)
-        }
+        cborWebTokenPayload[6] = CBOR.unsignedInt(header.issuedAt)
 
         let cborWebTokenPayloadBytes = cborWebTokenPayload.encode()
 

--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/Model/CBORWebTokenHeader.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/CertificateAccess/Model/CBORWebTokenHeader.swift
@@ -17,12 +17,12 @@ public struct CBORWebTokenHeader: Codable, Equatable {
     // MARK: - Internal
 
     public let issuer: String
-    public let issuedAt: UInt64?
+    public let issuedAt: UInt64
     public let expirationTime: UInt64
 
     public static func fake(
         issuer: String = "issuer",
-        issuedAt: UInt64? = nil,
+        issuedAt: UInt64 = UInt64(Date().timeIntervalSince1970),
         expirationTime: UInt64 = 0
     ) -> CBORWebTokenHeader {
         CBORWebTokenHeader(


### PR DESCRIPTION
## Description
'iat' does not need to be optional, because it cant be nil.
Changed it from optional to non-optional.
