### PR TITLE
Incorrect display of text on statistic tiles 5 and 6

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1982,11 +1982,11 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "Statistics_Card_AtLeastOneVaccinated_Date" = "Bis %@";
 
-"Statistics_Card_AtLeastOneVaccinated_SecondaryLabelTitle" = "der Gesamtbevölkerung";
+"Statistics_Card_AtLeastOneVaccinated_SecondaryLabelTitle" = "der Gesamt\U00ADbevölkerung";
 
 "Statistics_Card_AtLeastOneVaccinated_TertiaryLabelTitle" = "Gesamt";
 
-"Statistics_Card_AtLeastOneVaccinated_SecondarySubtitleLabel" = "der Gesamtbevölkerung";
+"Statistics_Card_AtLeastOneVaccinated_SecondarySubtitleLabel" = "der Gesamt\U00ADbevölkerung";
 
 
 
@@ -2000,11 +2000,11 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "Statistics_Card_FullyVaccinated_Date" = "Bis %@";
 
-"Statistics_Card_FullyVaccinated_SecondaryLabelTitle" = "der Gesamtbevölkerung";
+"Statistics_Card_FullyVaccinated_SecondaryLabelTitle" = "der Gesamt\U00ADbevölkerung";
 
 "Statistics_Card_FullyVaccinated_TertiaryLabelTitle" = "Gesamt";
 
-"Statistics_Card_FullyVaccinated_SecondarySubtitleLabel" = "der Gesamtbevölkerung";
+"Statistics_Card_FullyVaccinated_SecondarySubtitleLabel" = "der Gesamt\U00ADbevölkerung";
 
 /* - Applied vaccination dose rates card */
 


### PR DESCRIPTION
## Description

Add soft hyphens to German translation for better line breaking on the statistics card

## Link to Jira

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8181

## Screenshots

![IMG_3146](https://user-images.githubusercontent.com/3601228/124468329-3ee71b00-dd99-11eb-961c-85d02527e5c1.PNG)
