### PR TITLE
Add keyboard subscriptions only to screens with textfields

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
@@ -43,12 +43,10 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 	
 	init(
 		topController: TopViewController,
-		bottomController: BottomViewController,
-		isWithKeyBoardHandling: Bool = false
+		bottomController: BottomViewController
 	) {
 		self.topViewController = topController
 		self.bottomViewController = bottomController
-		self.isWithKeyBoardHandling = isWithKeyBoardHandling
 		
 		// if the the bottom view controller is FooterViewController we use it's viewModel here as well
 		self.footerViewModel = (bottomViewController as? FooterViewController)?.viewModel
@@ -102,10 +100,8 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 				bottomViewHeightAnchorConstraint
 			]
 		)
+		subscribeToKeyboardNotifications()
 		
-		if isWithKeyBoardHandling {
-			subscribeToKeyboardNotifications()
-		}
 		// if the the bottom view controller is FooterViewController we use it's viewModel here as well
 		if let viewModel = (bottomViewController as? FooterViewController)?.viewModel {
 			UIView.performWithoutAnimation {
@@ -178,7 +174,6 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 
 	private let topViewController: TopViewController
 	private let bottomViewController: BottomViewController
-	private let isWithKeyBoardHandling: Bool
 
 	private var subscriptions: [AnyCancellable] = []
 	private var keyboardSubscriptions: [AnyCancellable] = []
@@ -224,6 +219,7 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 			.store(in: &keyboardSubscriptions)
 		
 		NotificationCenter.default.ocombine.publisher(for: UIApplication.keyboardWillHideNotification)
+			.dropFirst()
 			.sink { [weak self] notification in
 				
 				guard let self = self,

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -339,8 +339,7 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 		
 		let topBottomContainerViewController = TopBottomContainerViewController(
 			topController: vc,
-			bottomController: footerViewController,
-			isWithKeyBoardHandling: triggeredFromTeletan
+			bottomController: footerViewController
 		)
 		
 		return topBottomContainerViewController

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -339,7 +339,8 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 		
 		let topBottomContainerViewController = TopBottomContainerViewController(
 			topController: vc,
-			bottomController: footerViewController
+			bottomController: footerViewController,
+			isWithKeyBoardHandling: triggeredFromTeletan
 		)
 		
 		return topBottomContainerViewController


### PR DESCRIPTION
## Description
We needed to add keyboard subscription for handling a previous bug 
https://github.com/corona-warn-app/cwa-app-ios/pull/2946/files
The Problem is even screens without textfields and keyboard also call the sink block of the keyboard subscription and this creates the layout glitches.

The proposed solution is to only subscribe to the keyboard notifications if the TopBottomVC contains textfields so I added a flag for that and subscribe to notifications only for screens that have keyboard like: TAN, Antigen Profile, etc

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8285

## Videos

BEFORE:
https://user-images.githubusercontent.com/15270737/124764568-62df6380-df35-11eb-96e5-2fb07984ab5e.MP4

AFTER:
https://user-images.githubusercontent.com/15270737/124764670-7ee30500-df35-11eb-8734-9663ef845090.MP4

