### PR TITLE
Typo in Check-in

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -182,7 +182,7 @@
 
 "ExposureSubmission_Antigen_Profile_Legal_Text03" = "In der Teststelle können Sie den QR-Code Ihres Schnelltest-Profils scannen lassen, um der Teststelle Ihre Daten schnell und sicher bereitzustellen. Die Teststelle benötigt Ihre Daten zur Durchführung des Tests. Sie können die Daten aber auch ohne die App bereitstellen. Sie entscheiden selbst, welche Daten im QR-Code enthalten sind und welche Sie der Teststelle auf andere Weise mitteilen.";
 
-"ExposureSubmission_Antigen_Profile_Legal_Text04" = "Auf Ihr persönliches Schnelltest-Profil haben zunächst nur Sie Zugriff. Nur wenn Sie den QR-Code des Schnelltest-Profils anderen Personen zeigen, können diese Zugriff auf die persönlichen Daten Ihres Schnelltest-Profils erhalten. Ein Zugriff auf andere Daten aus der App erfolgt dabei nicht (z.\U00A0B. Ihre Check-Ins oder Angaben im Kontakt-Tagebuch).";
+"ExposureSubmission_Antigen_Profile_Legal_Text04" = "Auf Ihr persönliches Schnelltest-Profil haben zunächst nur Sie Zugriff. Nur wenn Sie den QR-Code des Schnelltest-Profils anderen Personen zeigen, können diese Zugriff auf die persönlichen Daten Ihres Schnelltest-Profils erhalten. Ein Zugriff auf andere Daten aus der App erfolgt dabei nicht (z.\U00A0B. Ihre Check-ins oder Angaben im Kontakt-Tagebuch).";
 
 "ExposureSubmission_Antigen_Profile_Legal_Text05" = "Sie haben jederzeit die Möglichkeit, Ihr Schnelltest-Profil wieder zu entfernen. Bis dahin bleibt es in der App auf Ihrem Smartphone gespeichert.";
 


### PR DESCRIPTION
spell Check-in with sentence-case "i"