### PR TITLE
fix/#8326-missing-permission-screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
@@ -82,6 +82,8 @@ class HealthCertificateOverviewViewController: UITableViewController {
 		navigationController?.navigationBar.sizeToFit()
 
 		viewModel.resetBadgeCount()
+		tableView.reloadData()
+		updateEmptyState()
 	}
 
 	// MARK: - Protocol UITableViewDataSource


### PR DESCRIPTION
## Description
The bug was about that the missing permission cell was not shown right after the system permission alert was denied inside the QR code scanner. After returning to the overview, the view was not refreshed. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8326

## Screenshots
Fixed:

https://user-images.githubusercontent.com/75615785/125075481-f85a2f00-e0be-11eb-86d0-aec245a2605e.mp4

