### PR TITLE
Feature/#8382 value set change

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/HealthCertificateValidationService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/HealthCertificateValidationService.swift
@@ -98,7 +98,7 @@ final class HealthCertificateValidationService: HealthCertificateValidationProvi
 		completion: @escaping (Result<HealthCertificateValidationReport, HealthCertificateValidationError>) -> Void
 	) {
 		// 2. update/ download value sets
-		vaccinationValueSetsProvider.latestVaccinationCertificateValueSets()
+		vaccinationValueSetsProvider.fetchVaccinationCertificateValueSets()
 			.sink(
 				receiveCompletion: { result in
 					switch result {

--- a/src/xcode/ENA/ENA/Source/Services/VaccinationValueSets/VaccinationValueSetsProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/VaccinationValueSets/VaccinationValueSetsProviding.swift
@@ -6,7 +6,10 @@ import Foundation
 import OpenCombine
 
 protocol VaccinationValueSetsProviding {
+	/// Proofs before fetching if we have cached something and returns this. Otherwise, it fetches from server. If the server returns 304 (not modified), we take again the cached value sets and return them.
 	func latestVaccinationCertificateValueSets() -> AnyPublisher<SAP_Internal_Dgc_ValueSets, Error>
+	/// Fetches every time from server regardless of something cached. If the server returns 304 (not modified), we take again the cached value sets and return them.
+	func fetchVaccinationCertificateValueSets() -> AnyPublisher<SAP_Internal_Dgc_ValueSets, Error>
 }
 
 protocol VaccinationValueSetsFetching {


### PR DESCRIPTION
## Description
For the DCC validation the behavior of fetching the value sets is different: We only return something cached for .notModified case. Otherwise we fail the download because we need for the validation always very fresh value sets.
So i added a second function to the protocol which ignores cached value sets and also the "timeout" when to fetch new value sets.
See also here: https://github.com/corona-warn-app/cwa-app-ios/pull/3122#discussion_r667888205

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8382

## Screenshots
x
