### PR TITLE
Feature/8449 Use the country code as fallback if there is no localized name.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
@@ -36,13 +36,8 @@ struct Country: Equatable, Codable {
 	///
 	/// - Parameter countryCode: An [ISO 3166 (Alpha-2)](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) country two-digit code. Examples: "DE", "FR"
 	init(withCountryCodeFallback countryCode: ID) {
-		if let name = Locale.current.regionName(forCountryCode: countryCode) {
-			id = countryCode
-			localizedName = name
-		} else {
-			id = countryCode
-			localizedName = countryCode
-		}
+		id = countryCode
+		localizedName = Locale.current.regionName(forCountryCode: countryCode) ?? countryCode
 	}
 
 	static func defaultCountry() -> Country {

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/Country.swift
@@ -21,7 +21,7 @@ struct Country: Equatable, Codable {
 		UIImage(named: "flag.\(id.lowercased())")
 	}
 
-	/// Initialize a country with a given. If no valid `countryCode` is given the initalizer returns `nil`.
+	/// Initialize a country with a given `countryCode`. If no valid `countryCode` is given the initalizer returns `nil`.
 	///
 	/// - Parameter countryCode: An [ISO 3166 (Alpha-2)](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) country two-digit code. Examples: "DE", "FR"
 	init?(countryCode: ID) {
@@ -30,6 +30,19 @@ struct Country: Equatable, Codable {
 
 		id = countryCode
 		localizedName = name
+	}
+
+	/// Initialize a country with a given `countryCode`. If `countryCode` cannot be localized, the localizedName will contain the `countryCode`.
+	///
+	/// - Parameter countryCode: An [ISO 3166 (Alpha-2)](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) country two-digit code. Examples: "DE", "FR"
+	init(withCountryCodeFallback countryCode: ID) {
+		if let name = Locale.current.regionName(forCountryCode: countryCode) {
+			id = countryCode
+			localizedName = name
+		} else {
+			id = countryCode
+			localizedName = countryCode
+		}
 	}
 
 	static func defaultCountry() -> Country {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/HealthCertificateValidationOnboardedCountriesProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/HealthCertificateValidationOnboardedCountriesProvider.swift
@@ -156,7 +156,7 @@ final class HealthCertificateValidationOnboardedCountriesProvider: HealthCertifi
 		switch extractOnboardedCountryCodesResult {
 		case let .success(countryCodes):
 			let countries = countryCodes.compactMap {
-				Country(countryCode: $0)
+				Country(withCountryCodeFallback: $0)
 			}
 			completion(.success(countries))
 		case let .failure(error):


### PR DESCRIPTION
## Description
Add a fallback to Country implementation if country code cannot be localized.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8449
