### PR TITLE
Wrong texts used

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2718,7 +2718,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_Info_imageDescription" = "Eine geschützte Person schaut auf ein Smartphone";
 
-"HealthCertificate_Info_description" = "Fügen Sie Ihre digitalen COVID-Zertifikate der EU in der App hinzu, um mit der App den Impfschutz, ein negatives Testergebnis oder eine überstandene Infektion nachweisen zu können.";
+"HealthCertificate_Info_description" = "Fügen Sie digitale COVID-Zertifikate der EU in der App hinzu, um mit der App den Impfschutz, ein negatives Testergebnis oder eine überstandene Infektion nachweisen zu können.";
 
 "HealthCertificate_Info_section01" = "Sie können digitale COVID-Impfzertifikate, COVID-Testzertifikate und COVID-Genesenenzertifikate der EU in der App hinzufügen.";
 


### PR DESCRIPTION
Please take over the correct texts as mentioned in Figma: https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.5?node-id=20219%3A0
As we now also offer certificates for family members, it's not only "Ihre" Zertifikate anymore. Thanks
