### PR TITLE
Use launch arguments only in UI tests

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -696,30 +696,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	#if DEBUG
 	private func setupOnboardingForTesting() {
-		// Only disable onboarding if it was explicitly set to "NO"
-		if let isOnboarded = LaunchArguments.onboarding.isOnboarded.stringValue {
-			store.isOnboarded = isOnboarded != "NO"
-		}
+		if isUITesting {
+			// Only disable onboarding if it was explicitly set to "NO"
+			if let isOnboarded = LaunchArguments.onboarding.isOnboarded.stringValue {
+				store.isOnboarded = isOnboarded != "NO"
+			}
 
-		if let onboardingVersion = LaunchArguments.onboarding.onboardingVersion.stringValue {
-			store.onboardingVersion = onboardingVersion
-		}
+			if let onboardingVersion = LaunchArguments.onboarding.onboardingVersion.stringValue {
+				store.onboardingVersion = onboardingVersion
+			}
 
-		if LaunchArguments.onboarding.resetFinishedDeltaOnboardings.boolValue {
-			store.finishedDeltaOnboardings = [:]
-		}
+			if LaunchArguments.onboarding.resetFinishedDeltaOnboardings.boolValue {
+				store.finishedDeltaOnboardings = [:]
+			}
 
-		if LaunchArguments.onboarding.setCurrentOnboardingVersion.boolValue {
-			store.onboardingVersion = Bundle.main.appVersion
+			if LaunchArguments.onboarding.setCurrentOnboardingVersion.boolValue {
+				store.onboardingVersion = Bundle.main.appVersion
+			}
 		}
 	}
 
 	private func setupDatadonationForTesting() {
-		store.isPrivacyPreservingAnalyticsConsentGiven = LaunchArguments.consent.isDatadonationConsentGiven.boolValue
+		if isUITesting {
+			store.isPrivacyPreservingAnalyticsConsentGiven = LaunchArguments.consent.isDatadonationConsentGiven.boolValue
+		}
 	}
 
 	private func setupInstallationDateForTesting() {
-		if let installationDaysString = LaunchArguments.common.appInstallationDays.stringValue {
+		if isUITesting, let installationDaysString = LaunchArguments.common.appInstallationDays.stringValue {
 			let installationDays = Int(installationDaysString) ?? 0
 			let date = Calendar.current.date(byAdding: .day, value: -installationDays, to: Date())
 			store.appInstallationDate = date
@@ -727,9 +731,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	}
 
 	private func setupAntigenTestProfileForTesting() {
-		store.antigenTestProfileInfoScreenShown = LaunchArguments.infoScreen.antigenTestProfileInfoScreenShown.boolValue
-		if LaunchArguments.test.antigen.removeAntigenTestProfile.boolValue {
-			store.antigenTestProfile = nil
+		if isUITesting {
+			store.antigenTestProfileInfoScreenShown = LaunchArguments.infoScreen.antigenTestProfileInfoScreenShown.boolValue
+			if LaunchArguments.test.antigen.removeAntigenTestProfile.boolValue {
+				store.antigenTestProfile = nil
+			}
 		}
 	}
 	


### PR DESCRIPTION
## Description
Fixes launch arguments that were applied outside of UI tests. Lead to data donation being deactivated on every app start if the launch argument was not set.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8521
