### PR TITLE
noResponse error will get handled as noConnection now

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/HealthCertificateValidationOnboardedCountriesProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/HealthCertificateValidationOnboardedCountriesProvider.swift
@@ -130,6 +130,9 @@ final class HealthCertificateValidationOnboardedCountriesProvider: HealthCertifi
 		case .noNetworkConnection:
 			Log.error("Could not download onboarded countries due to no network.", log: .vaccination, error: error)
 			completion(.failure(.ONBOARDED_COUNTRIES_NO_NETWORK))
+		case .noResponse:
+			Log.error("Could not download onboarded countries due to no response.", log: .vaccination, error: error)
+			completion(.failure(.ONBOARDED_COUNTRIES_NO_NETWORK))
 		case let .serverError(statusCode):
 			switch statusCode {
 			case 400...409:

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/__tests__/HealthCertificateValidationOnboardedCountriesProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/__tests__/HealthCertificateValidationOnboardedCountriesProviderTests.swift
@@ -274,37 +274,6 @@ class HealthCertificateValidationOnboardedCountriesProviderTests: XCTestCase {
 		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_NO_NETWORK)
 	}
 
-	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_NoResponse_THEN_ONBOARDED_COUNTRIES_NO_NETWORKIsReturned() {
-		// GIVEN
-		let client = ClientMock()
-		client.onValidationOnboardedCountries = { _, completion in
-			completion(.failure(.noResponse))
-		}
-		let store = MockTestStore()
-		let provider = HealthCertificateValidationOnboardedCountriesProvider(
-			store: store,
-			client: client,
-			signatureVerifier: MockVerifier()
-		)
-		let expectation = self.expectation(description: "Test should fail ONBOARDED_COUNTRIES_NO_NETWORK")
-		var receivedError: HealthCertificateValidationOnboardedCountriesError?
-
-		// WHEN
-		provider.onboardedCountries(completion: { result in
-			switch result {
-			case .success:
-				XCTFail("Test should not succeed.")
-			case let .failure(error):
-				receivedError = error
-				expectation.fulfill()
-			}
-		})
-
-		// THEN
-		waitForExpectations(timeout: .short)
-		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_NO_NETWORK)
-	}
-
 	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_NotModified_THEN_ONBOARDED_COUNTRIES_MISSING_CACHEIsReturned() {
 		// GIVEN
 		let client = ClientMock()
@@ -398,8 +367,8 @@ class HealthCertificateValidationOnboardedCountriesProviderTests: XCTestCase {
 		waitForExpectations(timeout: .short)
 		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_SERVER_ERROR)
 	}
-	
-	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_DefaultHTTPError_THEN_ONBOARDED_COUNTRIES_SERVER_ERRORIsReturned() {
+
+	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_NoResponse_THEN_ONBOARDED_COUNTRIES_NO_NETWORKIsReturned() {
 		// GIVEN
 		let client = ClientMock()
 		client.onValidationOnboardedCountries = { _, completion in
@@ -411,9 +380,9 @@ class HealthCertificateValidationOnboardedCountriesProviderTests: XCTestCase {
 			client: client,
 			signatureVerifier: MockVerifier()
 		)
-		let expectation = self.expectation(description: "Test should fail ONBOARDED_COUNTRIES_SERVER_ERROR")
+		let expectation = self.expectation(description: "Test should fail ONBOARDED_COUNTRIES_NO_NETWORK")
 		var receivedError: HealthCertificateValidationOnboardedCountriesError?
-	
+
 		// WHEN
 		provider.onboardedCountries(completion: { result in
 			switch result {
@@ -424,12 +393,12 @@ class HealthCertificateValidationOnboardedCountriesProviderTests: XCTestCase {
 				expectation.fulfill()
 			}
 		})
-	
+
 		// THEN
 		waitForExpectations(timeout: .short)
-		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_SERVER_ERROR)
+		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_NO_NETWORK)
 	}
-			
+
 	private lazy var dummyOnboardedCountriesResponse: PackageDownloadResponse = {
 		let fakeData = onboardedCountriesCBORDataFake
 				

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/__tests__/HealthCertificateValidationOnboardedCountriesProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidationOnboardedCountries/__tests__/HealthCertificateValidationOnboardedCountriesProviderTests.swift
@@ -273,7 +273,38 @@ class HealthCertificateValidationOnboardedCountriesProviderTests: XCTestCase {
 		waitForExpectations(timeout: .short)
 		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_NO_NETWORK)
 	}
-	
+
+	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_NoResponse_THEN_ONBOARDED_COUNTRIES_NO_NETWORKIsReturned() {
+		// GIVEN
+		let client = ClientMock()
+		client.onValidationOnboardedCountries = { _, completion in
+			completion(.failure(.noResponse))
+		}
+		let store = MockTestStore()
+		let provider = HealthCertificateValidationOnboardedCountriesProvider(
+			store: store,
+			client: client,
+			signatureVerifier: MockVerifier()
+		)
+		let expectation = self.expectation(description: "Test should fail ONBOARDED_COUNTRIES_NO_NETWORK")
+		var receivedError: HealthCertificateValidationOnboardedCountriesError?
+
+		// WHEN
+		provider.onboardedCountries(completion: { result in
+			switch result {
+			case .success:
+				XCTFail("Test should not succeed.")
+			case let .failure(error):
+				receivedError = error
+				expectation.fulfill()
+			}
+		})
+
+		// THEN
+		waitForExpectations(timeout: .short)
+		XCTAssertEqual(receivedError, .ONBOARDED_COUNTRIES_NO_NETWORK)
+	}
+
 	func testGIVEN_ValidationService_GetOnboardedCountries_WHEN_NotModified_THEN_ONBOARDED_COUNTRIES_MISSING_CACHEIsReturned() {
 		// GIVEN
 		let client = ClientMock()


### PR DESCRIPTION
## Description
If fetching onboarded countries gets a noResponse error it will result in a NoConnection error now,
instead of the default handling. Added a unit test too.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8545

