### PR TITLE
Fix/fallback to countrycode on result

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/Cells/ValidationResultCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/Cells/ValidationResultCellModel.swift
@@ -67,7 +67,7 @@ final class ValidationResultCellModel {
 	var ruleTypeDescription: String? {
 		switch validationResult.rule?.ruleType {
 		case .acceptence:
-			let arrivalCountry = (validationResult.rule?.countryCode).flatMap { Country(countryCode: $0) }
+			let arrivalCountry = (validationResult.rule?.countryCode).flatMap { Country(withCountryCodeFallback: $0) }
 
 			return String(
 				format: AppStrings.HealthCertificate.Validation.Result.acceptanceRule,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
@@ -252,7 +252,7 @@ class ValidationResultCellModelTests: XCTestCase {
 		// GIVEN
 		let expectedResult = String(
 			format: AppStrings.HealthCertificate.Validation.Result.acceptanceRule,
-			""
+			"Fake"
 		)
 		let expectedAcceptanceOpenValidationResult = ValidationResult.fake(
 			rule: Rule.fake(

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
@@ -193,6 +193,36 @@ class ValidationResultCellModelTests: XCTestCase {
 		// THEN
 		XCTAssertEqual(ruleTypeDescription, expectedResult)
 	}
+
+	func testGIVEN_AcceptanceRule_WHEN_RuleTypeDescriptionWithNonexistantCountry_THEN_DescriptionIsReturned() throws {
+		// GIVEN
+		let countryCode = "XX"
+		let expectedResult = String(
+			format: AppStrings.HealthCertificate.Validation.Result.acceptanceRule,
+			countryCode
+		)
+		let expectedAcceptanceOpenValidationResult = ValidationResult.fake(
+			rule: Rule.fake(
+				type: "Acceptance",
+				countryCode: countryCode
+			),
+			result: .open)
+
+		let healthCertificate = HealthCertificate.mock()
+		let vaccinationValueSets = VaccinationValueSetsProvider(client: CachingHTTPClientMock(), store: MockTestStore())
+
+		let model = ValidationResultCellModel(
+			validationResult: expectedAcceptanceOpenValidationResult,
+			healthCertificate: healthCertificate,
+			vaccinationValueSetsProvider: vaccinationValueSets
+		)
+
+		// WHEN
+		let ruleTypeDescription = model.ruleTypeDescription
+
+		// THEN
+		XCTAssertEqual(ruleTypeDescription, expectedResult)
+	}
 	
 	func testGIVEN_InvalidationRule_WHEN_RuleTypeDescription_THEN_DescriptionIsReturned() throws {
 		// GIVEN

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/__tests__/ValidationResultCellModelTests.swift
@@ -194,7 +194,7 @@ class ValidationResultCellModelTests: XCTestCase {
 		XCTAssertEqual(ruleTypeDescription, expectedResult)
 	}
 
-	func testGIVEN_AcceptanceRule_WHEN_RuleTypeDescriptionWithNonexistantCountry_THEN_DescriptionIsReturned() throws {
+	func testGIVEN_AcceptanceRule_WHEN_RuleTypeDescriptionWithNonexistentCountry_THEN_DescriptionIsReturned() throws {
 		// GIVEN
 		let countryCode = "XX"
 		let expectedResult = String(


### PR DESCRIPTION
## Description
Falls back to the country code on the result cell as well, so we show "Dies ist eine Regel des Reiselandes XX." instead of "Dies ist eine Regel des Reiselandes ." for our test countries.
