### PR TITLE
reuse textWithLinks cell, removed and move text assets

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2917,8 +2917,6 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_Validation_Bullet4" = "Ob die im Zertifikat eingetragenen Daten richtig sind, wird in der Corona-Warn-App nicht geprüft.";
 
-"HealthCertificate_Validation_Body3" = "Mehr Informationen finden Sie in den FAQ und unter https://reopen.europa.eu/de.";
-
 "HealthCertificate_Validation_Legal_Title" = "Datenschutz und Datensicherheit";
 
 "HealthCertificate_Validation_Legal_Description" = "Die aktuellen Einreiseregeln werden von den Servern des RKI heruntergeladen. Hierfür ist eine Verbindung zum Internet erforderlich und es werden Zugriffsdaten an das RKI übermittelt.";

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/HealthCertificateValidationViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/HealthCertificateValidationViewModel.swift
@@ -71,10 +71,15 @@ final class HealthCertificateValidationViewModel {
 					.bulletPoint(text: AppStrings.HealthCertificate.Validation.bullet2, spacing: .large),
 					.bulletPoint(text: AppStrings.HealthCertificate.Validation.bullet3, spacing: .large),
 					.bulletPoint(text: AppStrings.HealthCertificate.Validation.bullet4, spacing: .large),
-					.body(
-						text: AppStrings.HealthCertificate.Validation.body3,
-						style: .textView(.link),
-						accessibilityIdentifier: ""
+					.textWithLinks(
+						text: String(
+							format: AppStrings.HealthCertificate.Validation.moreInformation,
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
+						links: [
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
+							AppStrings.Links.healthCertificateValidationEU: AppStrings.Links.healthCertificateValidationEU
+						],
+						linksColor: .enaColor(for: .textTint)
 					),
 					.legal(title: NSAttributedString(string: AppStrings.HealthCertificate.Validation.legalTitle), description: NSAttributedString(string: AppStrings.HealthCertificate.Validation.legalDescription), textBlocks: []),
 					.space(height: 16)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateTechnicalValidationFailedViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateTechnicalValidationFailedViewModel.swift
@@ -40,10 +40,10 @@ struct HealthCertificateTechnicalValidationFailedViewModel: HealthCertificateVal
 					.technicalFailedRulesCell(),
 					.textWithLinks(
 						text: String(
-							format: AppStrings.HealthCertificate.Validation.Result.moreInformation,
-							AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
+							format: AppStrings.HealthCertificate.Validation.moreInformation,
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
 						links: [
-							AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
 							AppStrings.Links.healthCertificateValidationEU: AppStrings.Links.healthCertificateValidationEU
 						],
 						linksColor: .enaColor(for: .textTint)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationFailedViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationFailedViewModel.swift
@@ -100,10 +100,10 @@ struct HealthCertificateValidationFailedViewModel: HealthCertificateValidationRe
 		cells.append(
 			.textWithLinks(
 				text: String(
-					format: AppStrings.HealthCertificate.Validation.Result.moreInformation,
-					AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
+					format: AppStrings.HealthCertificate.Validation.moreInformation,
+					AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
 				links: [
-					AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
+					AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
 					AppStrings.Links.healthCertificateValidationEU: AppStrings.Links.healthCertificateValidationEU
 				],
 				linksColor: .enaColor(for: .textTint)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationOpenViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationOpenViewModel.swift
@@ -70,10 +70,10 @@ struct HealthCertificateValidationOpenViewModel: HealthCertificateValidationResu
 		cells.append(
 			.textWithLinks(
 				text: String(
-					format: AppStrings.HealthCertificate.Validation.Result.moreInformation,
-					AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
+					format: AppStrings.HealthCertificate.Validation.moreInformation,
+					AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
 				links: [
-					AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
+					AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
 					AppStrings.Links.healthCertificateValidationEU: AppStrings.Links.healthCertificateValidationEU
 				],
 				linksColor: .enaColor(for: .textTint)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationPassedViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Validation/Result/HealthCertificateValidationPassedViewModel.swift
@@ -56,10 +56,10 @@ struct HealthCertificateValidationPassedViewModel: HealthCertificateValidationRe
 					.bulletPoint(text: AppStrings.HealthCertificate.Validation.Result.Passed.hint4, spacing: .large),
 					.textWithLinks(
 						text: String(
-							format: AppStrings.HealthCertificate.Validation.Result.moreInformation,
-							AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
+							format: AppStrings.HealthCertificate.Validation.moreInformation,
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ, AppStrings.Links.healthCertificateValidationEU),
 						links: [
-							AppStrings.HealthCertificate.Validation.Result.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
+							AppStrings.HealthCertificate.Validation.moreInformationPlaceholderFAQ: AppStrings.Links.healthCertificateValidationFAQ,
 							AppStrings.Links.healthCertificateValidationEU: AppStrings.Links.healthCertificateValidationEU
 						],
 						linksColor: .enaColor(for: .textTint)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2115,11 +2115,12 @@ enum AppStrings {
 			static let bullet2 = NSLocalizedString("HealthCertificate_Validation_Bullet2", comment: "")
 			static let bullet3 = NSLocalizedString("HealthCertificate_Validation_Bullet3", comment: "")
 			static let bullet4 = NSLocalizedString("HealthCertificate_Validation_Bullet4", comment: "")
-			static let body3 = NSLocalizedString("HealthCertificate_Validation_Body3", comment: "")
 			static let legalTitle = NSLocalizedString("HealthCertificate_Validation_Legal_Title", comment: "")
 			static let legalDescription = NSLocalizedString("HealthCertificate_Validation_Legal_Description", comment: "")
 			static let body4 = NSLocalizedString("HealthCertificate_Validation_Body4", comment: "")
 			static let buttonTitle = NSLocalizedString("HealthCertificate_Validation_ButtonTitle", comment: "")
+			static let moreInformation = NSLocalizedString("HealthCertificate_Validation_Result_moreInformation", comment: "")
+			static let moreInformationPlaceholderFAQ = NSLocalizedString("HealthCertificate_Validation_Result_moreInformation_placeholder_FAQ", comment: "")
 
 			enum Info {
 				static let imageDescription = NSLocalizedString("HealthCertificate_Validation_Info_imageDescription", comment: "")
@@ -2138,8 +2139,6 @@ enum AppStrings {
 				static let validationParameters = NSLocalizedString("HealthCertificate_Validation_Result_validationParameters", comment: "")
 				static let acceptanceRule = NSLocalizedString("HealthCertificate_Validation_Result_acceptanceRule", comment: "")
 				static let invalidationRule = NSLocalizedString("HealthCertificate_Validation_Result_invalidationRule", comment: "")
-				static let moreInformation = NSLocalizedString("HealthCertificate_Validation_Result_moreInformation", comment: "")
-				static let moreInformationPlaceholderFAQ = NSLocalizedString("HealthCertificate_Validation_Result_moreInformation_placeholder_FAQ", comment: "")
 
 				enum Passed {
 					static let title = NSLocalizedString("HealthCertificate_Validation_Passed_title", comment: "")


### PR DESCRIPTION
## Description
Add Link to FAQ in validation screen - reuse textWithLinks cell with same text and links.
Moved text in AppStrings to another section.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8689

## Screenshots
https://user-images.githubusercontent.com/2675578/127137105-bcdb6fe5-ec66-481b-ad73-d0c3d89ef12b.mp4
