### PR TITLE
Fix/always update all statistics cards

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsCellModel.swift
@@ -22,15 +22,6 @@ class HomeStatisticsCellModel {
 					}
 			}
 			.store(in: &subscriptions)
-
-		homeState.$localStatistics
-			.sink { [weak self] localStatistics in
-				self?.localAdministrativeUnitStatistics = localStatistics.administrativeUnitData
-				self?.localFederalStateStatistics = localStatistics.federalStateData
-				Log.debug("HomeState did update \(private: "\(self?.localAdministrativeUnitStatistics.count ?? -1) administrativeUnits.")", log: .localStatistics)
-				Log.debug("HomeState did update \(private: "\(self?.localFederalStateStatistics.count ?? -1) localFederalStates.")", log: .localStatistics)
-			}
-			.store(in: &subscriptions)
 		
 		homeState.$selectedLocalStatistics
 			.sink { [weak self] selectedLocalStatistics in
@@ -42,15 +33,14 @@ class HomeStatisticsCellModel {
 
 	// MARK: - Internal
 
+	let homeState: HomeState
+
 	/// The default set of 'global' statistics for every user
-	@OpenCombine.Published private(set) var keyFigureCards = [SAP_Internal_Stats_KeyFigureCard]()
-	@OpenCombine.Published private(set) var localAdministrativeUnitStatistics = [SAP_Internal_Stats_AdministrativeUnitData]()
-	@OpenCombine.Published private(set) var localFederalStateStatistics = [SAP_Internal_Stats_FederalStateData]()
-	@OpenCombine.Published private(set) var selectedLocalStatistics = [SelectedLocalStatisticsTuple]()
+	@DidSetPublished private(set) var keyFigureCards = [SAP_Internal_Stats_KeyFigureCard]()
+	@DidSetPublished private(set) var selectedLocalStatistics = [SelectedLocalStatisticsTuple]()
 
 	// MARK: - Private
 
-	private let homeState: HomeState
 	private var subscriptions = Set<AnyCancellable>()
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
@@ -30,9 +30,13 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 
 	override func layoutSubviews() {
 		super.layoutSubviews()
-		
-		// prevent glitches with stackviews not sized properly.
-		self.scrollView.bounds.origin.x = self.scrollView.frame.size.width
+
+		// Scroll to first statistics card initially and when entering/leaving edit mode
+		if scrollView.bounds.origin.x == 0, let firstStatisticsCard = stackView.arrangedSubviews[safe: 1] {
+			DispatchQueue.main.async {
+				self.scrollView.scrollRectToVisible(firstStatisticsCard.frame, animated: true)
+			}
+		}
 	}
 
 	override func setEditing(_ editing: Bool, animated: Bool) {
@@ -47,18 +51,15 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 	}
 
 	// MARK: - Internal
-	// swiftlint:disable:next function_parameter_count function_body_length
+	// swiftlint:disable:next function_parameter_count
 	func configure(
 		with keyFigureCellModel: HomeStatisticsCellModel,
 		store: Store,
 		onInfoButtonTap: @escaping () -> Void,
 		onAddLocalStatisticsButtonTap: @escaping (SelectValueTableViewController) -> Void,
 		onAddDistrict: @escaping (SelectValueTableViewController) -> Void,
-		onDeleteLocalStatistic: @escaping (RegionStatisticsData, LocalStatisticsRegion) -> Void,
 		onDismissState: @escaping () -> Void,
 		onDismissDistrict: @escaping (Bool) -> Void,
-		onFetchGroupData: @escaping (LocalStatisticsRegion) -> Void,
-		onToggleEditMode: @escaping (_ enabled: Bool) -> Void,
 		onAccessibilityFocus: @escaping () -> Void,
 		onUpdate: @escaping () -> Void
 	) {
@@ -66,165 +67,150 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 		
 		keyFigureCellModel.$keyFigureCards
 			.receive(on: DispatchQueue.OCombine(.main))
-			.sink { [weak self] in
-				self?.clearStackView()
-				self?.configureLocalStatisticsCell(
+			.sink { [weak self] _ in
+				self?.configureStatisticsCards(
+					with: keyFigureCellModel,
 					store: store,
+					onInfoButtonTap: onInfoButtonTap,
 					onAddLocalStatisticsButtonTap: onAddLocalStatisticsButtonTap,
 					onAddDistrict: onAddDistrict,
-					onDeleteLocalStatistic: onDeleteLocalStatistic,
 					onDismissState: onDismissState,
 					onDismissDistrict: onDismissDistrict,
-					onFetchGroupData: onFetchGroupData,
-					onToggleEditMode: onToggleEditMode,
-					onAccessibilityFocus: onAccessibilityFocus
-				)
-				self?.configureKeyFigureCells(
-					for: $0,
-					onInfoButtonTap: onInfoButtonTap,
-					onAccessibilityFocus: onAccessibilityFocus
-				)
-				onUpdate()
-			}
-			.store(in: &subscriptions)
-		// Retaining cell model so it gets updated
-		self.cellModel = keyFigureCellModel
-		
-		keyFigureCellModel.$localAdministrativeUnitStatistics
-			.receive(on: DispatchQueue.OCombine(.main))
-			.sink { [weak self] administrativeUnitsData in
-				Log.debug("update with \(keyFigureCellModel.localAdministrativeUnitStatistics.count) administrative local stats", log: .localStatistics)
-								
-				let administrativeUnit = administrativeUnitsData.first {
-					$0.administrativeUnitShortID == UInt32(self?.localStatisticsRegion?.id ?? "0")
-				}
-				// needed for UI updates
-				self?.localStatisticsCache = store
-				
-				guard let adminUnit = administrativeUnit, let districtName = self?.localStatisticsRegion?.name else {
-					Log.error("Could not assign administrative unit or district name", log: .localStatistics)
-					return
-				}
-				let regionStatistics = RegionStatisticsData(
-					regionName: districtName,
-					id: Int(adminUnit.administrativeUnitShortID),
-					updatedAt: adminUnit.updatedAt,
-					sevenDayIncidence: adminUnit.sevenDayIncidence
-				)
-				
-				self?.insertLocalStatistics(
-					store: store,
-					regionData: regionStatistics,
-					onInfoButtonTap: onInfoButtonTap,
 					onAccessibilityFocus: onAccessibilityFocus,
-					onDeleteStatistic: onDeleteLocalStatistic
+					onUpdate: onUpdate
 				)
-				onUpdate()
-			}
-			.store(in: &subscriptions)
-		
-		keyFigureCellModel.$localFederalStateStatistics
-			.receive(on: DispatchQueue.OCombine(.main))
-			.sink { [weak self] localFederalStates in
-				Log.debug("update with \(keyFigureCellModel.localFederalStateStatistics.count) federal local stats", log: .localStatistics)
-				
-				let localFederalState = localFederalStates.first {
-					$0.federalState.rawValue == Int(self?.localStatisticsRegion?.id ?? "0")
-				}
-				// needed for UI updates
-				self?.localStatisticsCache = store
-				
-				guard let federalState = localFederalState, let federalStateName = self?.localStatisticsRegion?.name else {
-					Log.error("Could not assign localFederalState or localFederalState name", log: .localStatistics)
-					return
-				}
-				let regionStatistics = RegionStatisticsData(
-					regionName: federalStateName,
-					id: federalState.federalState.rawValue,
-					updatedAt: federalState.updatedAt,
-					sevenDayIncidence: federalState.sevenDayIncidence
-				)
-				
-				self?.insertLocalStatistics(
-					store: store,
-					regionData: regionStatistics,
-					onInfoButtonTap: onInfoButtonTap,
-					onAccessibilityFocus: onAccessibilityFocus,
-					onDeleteStatistic: onDeleteLocalStatistic
-				)
-				onUpdate()
 			}
 			.store(in: &subscriptions)
 		
 		keyFigureCellModel.$selectedLocalStatistics
 			.receive(on: DispatchQueue.OCombine(.main))
-			.sink { [weak self] selectedLocalStatistics in
-				Log.debug("update with \(keyFigureCellModel.selectedLocalStatistics.count) local stats", log: .localStatistics)
-				
-				self?.removeLocalStatisticsCards()
-				
-				for singleSelectedLocalStatistics in selectedLocalStatistics {
-					
-					self?.localStatisticsRegion = singleSelectedLocalStatistics.localStatisticsRegion
-					let regionName = singleSelectedLocalStatistics.localStatisticsRegion.name
-					let regionStatistics: RegionStatisticsData
-					guard let region = self?.localStatisticsRegion else {
-						Log.error("Could not assign localFederalState or localFederalState name", log: .localStatistics)
-						return
-					}
-					
-					switch region.regionType {
-					case .federalState:
-						let localFederalState = singleSelectedLocalStatistics.federalStateAndDistrictsData.federalStateData.first {
-							$0.federalState.rawValue == Int(self?.localStatisticsRegion?.id ?? "0")
-						}
-						guard let federalState = localFederalState else {
-							Log.error("Could not assign localFederalState or localFederalState name", log: .localStatistics)
-							return
-						}
-						regionStatistics = RegionStatisticsData(
-							regionName: regionName,
-							id: federalState.federalState.rawValue,
-							updatedAt: federalState.updatedAt,
-							sevenDayIncidence: federalState.sevenDayIncidence
-						)
-						
-					case .administrativeUnit:
-						let administrativeUnit = singleSelectedLocalStatistics.federalStateAndDistrictsData.administrativeUnitData.first {
-							$0.administrativeUnitShortID == UInt32(self?.localStatisticsRegion?.id ?? "0")
-						}
-						guard let adminUnit = administrativeUnit else {
-							Log.error("Could not assign administrative unit or district name", log: .localStatistics)
-							return
-						}
-						
-						regionStatistics = RegionStatisticsData(
-							regionName: regionName,
-							id: Int(adminUnit.administrativeUnitShortID),
-							updatedAt: adminUnit.updatedAt,
-							sevenDayIncidence: adminUnit.sevenDayIncidence
-						)
-					}
-					
-					self?.insertLocalStatistics(
-						store: store,
-						regionData: regionStatistics,
-						onInfoButtonTap: onInfoButtonTap,
-						onAccessibilityFocus: onAccessibilityFocus,
-						onDeleteStatistic: onDeleteLocalStatistic
-					)
-					onUpdate()
-				}
+			.sink { [weak self] _ in
+				self?.configureStatisticsCards(
+					with: keyFigureCellModel,
+					store: store,
+					onInfoButtonTap: onInfoButtonTap,
+					onAddLocalStatisticsButtonTap: onAddLocalStatisticsButtonTap,
+					onAddDistrict: onAddDistrict,
+					onDismissState: onDismissState,
+					onDismissDistrict: onDismissDistrict,
+					onAccessibilityFocus: onAccessibilityFocus,
+					onUpdate: onUpdate
+				)
 			}
 			.store(in: &subscriptions)
+
+		// Retaining cell model so it gets updated
+		self.cellModel = keyFigureCellModel
+	}
+
+	// swiftlint:disable:next function_parameter_count
+	func configureStatisticsCards(
+		with keyFigureCellModel: HomeStatisticsCellModel,
+		store: Store,
+		onInfoButtonTap: @escaping () -> Void,
+		onAddLocalStatisticsButtonTap: @escaping (SelectValueTableViewController) -> Void,
+		onAddDistrict: @escaping (SelectValueTableViewController) -> Void,
+		onDismissState: @escaping () -> Void,
+		onDismissDistrict: @escaping (Bool) -> Void,
+		onAccessibilityFocus: @escaping () -> Void,
+		onUpdate: @escaping () -> Void
+	) {
+		clearStackView()
+
+		configureManageLocalStatisticsCell(
+			store: store,
+			onAddLocalStatisticsButtonTap: onAddLocalStatisticsButtonTap,
+			onAddDistrict: onAddDistrict,
+			onDismissState: onDismissState,
+			onDismissDistrict: onDismissDistrict,
+			onAccessibilityFocus: onAccessibilityFocus
+		)
+		configureLocalStatisticsCards(
+			store: store,
+			onInfoButtonTap: onInfoButtonTap,
+			onAccessibilityFocus: onAccessibilityFocus,
+			onUpdate: onUpdate
+		)
+		configureKeyFigureCells(
+			for: keyFigureCellModel.keyFigureCards,
+			onInfoButtonTap: onInfoButtonTap,
+			onAccessibilityFocus: onAccessibilityFocus
+		)
+
+		onUpdate()
+	}
+
+	func configureLocalStatisticsCards(
+		store: Store,
+		onInfoButtonTap:  @escaping () -> Void,
+		onAccessibilityFocus: @escaping () -> Void,
+		onUpdate: @escaping () -> Void
+	) {
+		guard let cellModel = cellModel else {
+			return
+		}
+
+		Log.debug("update with \(cellModel.selectedLocalStatistics.count) local stats", log: .localStatistics)
+
+		removeLocalStatisticsCards()
+
+		for singleSelectedLocalStatistics in cellModel.selectedLocalStatistics {
+			localStatisticsRegion = singleSelectedLocalStatistics.localStatisticsRegion
+			let regionName = singleSelectedLocalStatistics.localStatisticsRegion.name
+			let regionStatistics: RegionStatisticsData
+			guard let region = localStatisticsRegion else {
+				Log.error("Could not assign localFederalState or localFederalState name", log: .localStatistics)
+				return
+			}
+
+			switch region.regionType {
+			case .federalState:
+				let localFederalState = singleSelectedLocalStatistics.federalStateAndDistrictsData.federalStateData.first {
+					$0.federalState.rawValue == Int(localStatisticsRegion?.id ?? "0")
+				}
+				guard let federalState = localFederalState else {
+					Log.error("Could not assign localFederalState or localFederalState name", log: .localStatistics)
+					return
+				}
+				regionStatistics = RegionStatisticsData(
+					regionName: regionName,
+					id: federalState.federalState.rawValue,
+					updatedAt: federalState.updatedAt,
+					sevenDayIncidence: federalState.sevenDayIncidence
+				)
+
+			case .administrativeUnit:
+				let administrativeUnit = singleSelectedLocalStatistics.federalStateAndDistrictsData.administrativeUnitData.first {
+					$0.administrativeUnitShortID == UInt32(localStatisticsRegion?.id ?? "0")
+				}
+				guard let adminUnit = administrativeUnit else {
+					Log.error("Could not assign administrative unit or district name", log: .localStatistics)
+					return
+				}
+
+				regionStatistics = RegionStatisticsData(
+					regionName: regionName,
+					id: Int(adminUnit.administrativeUnitShortID),
+					updatedAt: adminUnit.updatedAt,
+					sevenDayIncidence: adminUnit.sevenDayIncidence
+				)
+			}
+
+			insertLocalStatistics(
+				store: store,
+				regionData: regionStatistics,
+				onInfoButtonTap: onInfoButtonTap,
+				onAccessibilityFocus: onAccessibilityFocus
+			)
+			onUpdate()
+		}
 	}
 	
 	func insertLocalStatistics(
 		store: Store,
 		regionData: RegionStatisticsData,
 		onInfoButtonTap:  @escaping () -> Void,
-		onAccessibilityFocus: @escaping () -> Void,
-		onDeleteStatistic: @escaping (RegionStatisticsData, LocalStatisticsRegion) -> Void
+		onAccessibilityFocus: @escaping () -> Void
 	) {
 		let nibName = String(describing: HomeStatisticsCardView.self)
 		let nib = UINib(nibName: nibName, bundle: .main)
@@ -250,17 +236,23 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 							return
 						}
 						Log.info("removing \(private: regionData.id, public: "administrative unit") @ \(private: region.name, public: "district id")", log: .ui)
-						onDeleteStatistic(regionData, region)
+
 						DispatchQueue.main.async { [weak self] in
 							self?.stackView.removeArrangedSubview(statisticsCardView)
 							statisticsCardView.removeFromSuperview()
-
-							// update management 'cell' state
-							self?.updateManagementCellState()
 						}
+
+						// removing the district from the store
+						store.selectedLocalStatisticsRegions = store.selectedLocalStatisticsRegions.filter { $0.id != String(regionData.id) }
+						if let cellModel = self?.cellModel {
+							cellModel.homeState.selectedLocalStatistics = cellModel.homeState.selectedLocalStatistics.filter { $0.localStatisticsRegion.id != String(regionData.id) }
+						}
+
+						self?.updateManagementCellState()
 					}
 				)
 				statisticsCardView.accessibilityIdentifier = AccessibilityIdentifiers.LocalStatistics.localStatisticsCard
+				statisticsCardView.setEditMode(Self.editingStatistics, animated: false)
 
 				configureBaselines(statisticsCardView: statisticsCardView)
 			}
@@ -282,16 +274,17 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 
 	/// Keeping `editingStatistics` locally would reset it on reloading of this cell.
 	/// Terrible design but simpler to handle than states passed through n layers of models, view controllers and views…
-	private static var editingStatistics: Bool = false
+	static var editingStatistics: Bool = false {
+		didSet {
+			()
+		}
+	}
 
 	private func clearStackView() {
 		stackView.arrangedSubviews.forEach {
 			stackView.removeArrangedSubview($0)
 			$0.removeFromSuperview()
 		}
-
-		// reset state
-		setEditing(false, animated: true)
 	}
 	
 	private func removeLocalStatisticsCards() {
@@ -304,16 +297,12 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 		stackView.layoutIfNeeded()
 	}
 	
-	// swiftlint:disable:next function_parameter_count
-	private func configureLocalStatisticsCell(
+	private func configureManageLocalStatisticsCell(
 		store: Store,
 		onAddLocalStatisticsButtonTap: @escaping (SelectValueTableViewController) -> Void,
 		onAddDistrict: @escaping (SelectValueTableViewController) -> Void,
-		onDeleteLocalStatistic: @escaping (RegionStatisticsData, LocalStatisticsRegion) -> Void,
 		onDismissState: @escaping () -> Void,
 		onDismissDistrict: @escaping (Bool) -> Void,
-		onFetchGroupData: @escaping (LocalStatisticsRegion) -> Void,
-		onToggleEditMode: @escaping (_ enabled: Bool) -> Void,
 		onAccessibilityFocus: @escaping () -> Void
 	) {
 		let localStatisticsModel = LocalStatisticsModel()
@@ -340,11 +329,11 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 					onDismissDistrict(dismissToRoot)
 				}, onFetchGroupData: { region in
 					self.localStatisticsRegion = region
-					onFetchGroupData(region)
+					self.cellModel?.homeState.fetchLocalStatistics(region: region)
 				}, onEditButtonTap: {
-					self.setEditing(!Self.editingStatistics, animated: true)
-					// Pass the current state to the tableViewController
-					onToggleEditMode(Self.editingStatistics)
+					DispatchQueue.main.async {
+						self.setEditing(!Self.editingStatistics, animated: true)
+					}
 				}, onAccessibilityFocus: { [weak self] in
 					self?.scrollView.scrollRectToVisible(manageLocalStatisticsCardView.frame, animated: true)
 					onAccessibilityFocus()

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
@@ -277,11 +277,7 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 
 	/// Keeping `editingStatistics` locally would reset it on reloading of this cell.
 	/// Terrible design but simpler to handle than states passed through n layers of models, view controllers and views…
-	static var editingStatistics: Bool = false {
-		didSet {
-			()
-		}
-	}
+	static var editingStatistics: Bool = false
 
 	private func clearStackView() {
 		stackView.arrangedSubviews.forEach {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
@@ -34,7 +34,8 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 		// Scroll to first statistics card initially and when entering/leaving edit mode
 		if scrollView.bounds.origin.x == 0, let firstStatisticsCard = stackView.arrangedSubviews[safe: 1] {
 			DispatchQueue.main.async {
-				self.scrollView.scrollRectToVisible(firstStatisticsCard.frame, animated: true)
+				self.scrollView.scrollRectToVisible(firstStatisticsCard.frame, animated: self.wasAlreadyShown)
+				self.wasAlreadyShown = true
 			}
 		}
 	}
@@ -271,6 +272,8 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 	private var subscriptions = Set<AnyCancellable>()
 	private var localStatisticsRegion: LocalStatisticsRegion?
 	private var localStatisticsCache: LocalStatisticsCaching?
+
+	private var wasAlreadyShown = false
 
 	/// Keeping `editingStatistics` locally would reset it on reloading of this cell.
 	/// Terrible design but simpler to handle than states passed through n layers of models, view controllers and views…

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/__tests__/HomeStatisticsCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/__tests__/HomeStatisticsCellModelTests.swift
@@ -55,66 +55,6 @@ class HomeStatisticsCellModelTests: CWATestCase {
 
 		subscription.cancel()
 	}
-	
-	func testForwardingLocalStatistics() throws {
-		let store = MockTestStore()
-
-		let homeState = HomeState(
-			store: store,
-			riskProvider: MockRiskProvider(),
-			exposureManagerState: ExposureManagerState(authorized: true, enabled: true, status: .active),
-			enState: .enabled,
-			statisticsProvider: StatisticsProvider(
-				client: CachingHTTPClientMock(),
-				store: store
-			), localStatisticsProvider: LocalStatisticsProvider(
-				client: CachingHTTPClientMock(),
-				store: store
-			)
-		)
-		homeState.localStatistics.administrativeUnitData = []
-
-		let cellModel = HomeStatisticsCellModel(
-			homeState: homeState
-		)
-
-		let sinkExpectation = expectation(description: "keyFigureCards received")
-		sinkExpectation.expectedFulfillmentCount = 2
-
-		var receivedValues = [[SAP_Internal_Stats_AdministrativeUnitData]]()
-		let subscription = cellModel.$localAdministrativeUnitStatistics.sink {
-			receivedValues.append($0)
-			sinkExpectation.fulfill()
-		}
-
-		var loadedStatistics = SAP_Internal_Stats_LocalStatistics()
-
-		loadedStatistics.administrativeUnitData = [
-			administrativeUnitData(administrativeUnitShortID: 12005),
-			administrativeUnitData(administrativeUnitShortID: 12006),
-			administrativeUnitData(administrativeUnitShortID: 12007),
-			administrativeUnitData(administrativeUnitShortID: 12008)
-		]
-
-		homeState.localStatistics = loadedStatistics
-
-		waitForExpectations(timeout: .short)
-
-		XCTAssertEqual(
-			receivedValues,
-			[
-				[],
-				[
-					administrativeUnitData(administrativeUnitShortID: 12005),
-					administrativeUnitData(administrativeUnitShortID: 12006),
-					administrativeUnitData(administrativeUnitShortID: 12007),
-					administrativeUnitData(administrativeUnitShortID: 12008)
-				]
-			]
-		)
-
-		subscription.cancel()
-	}
 
 	// MARK: - Private
 	private func keyFigureCard(

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeState.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeState.swift
@@ -72,7 +72,6 @@ class HomeState: ENStateHandlerUpdating {
 	@OpenCombine.Published var enState: ENStateHandler.State
 
 	@OpenCombine.Published var statistics: SAP_Internal_Stats_Statistics
-	@OpenCombine.Published var localStatistics: SAP_Internal_Stats_LocalStatistics = SAP_Internal_Stats_LocalStatistics()
 	@OpenCombine.Published var selectedLocalStatistics: [SelectedLocalStatisticsTuple]
 	@OpenCombine.Published var statisticsLoadingError: StatisticsLoadingError?
 
@@ -162,10 +161,10 @@ class HomeState: ENStateHandlerUpdating {
 	func updateLocalStatistics(selectedLocalStatisticsRegion: LocalStatisticsRegion) {
 		localStatisticsProvider.latestLocalStatistics(groupID: String(selectedLocalStatisticsRegion.federalState.groupID), eTag: nil, completion: { [weak self] result in
 			switch result {
-			case .success(let localStatistics):
+			case .success:
 				// persist the Region to the list of selected Regions
 				self?.store.selectedLocalStatisticsRegions.append(selectedLocalStatisticsRegion)
-				self?.localStatistics = localStatistics
+				self?.updateSelectedLocalStatistics(self?.store.selectedLocalStatisticsRegions)
 			case .failure(let error):
 				// Propagate signature verification error to the user
 				if case CachingHTTPClient.CacheError.dataVerificationError = error {
@@ -177,7 +176,7 @@ class HomeState: ENStateHandlerUpdating {
 	}
 	
 	func updateSelectedLocalStatistics(_ selection: [LocalStatisticsRegion]?) {
-		localStatisticsProvider.latestSelectedLocalStatistics(selectedlocalStatisticsRegions: selection ?? [], completion: { selectedLocalStatistics in
+		localStatisticsProvider.latestSelectedLocalStatistics(selectedLocalStatisticsRegions: selection ?? [], completion: { selectedLocalStatistics in
 			self.selectedLocalStatistics = selectedLocalStatistics
 			Log.debug("fetched selected local statistics: \(private: selectedLocalStatistics) entities", log: .localStatistics)
 		})

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -609,33 +609,11 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 				self?.onAddDistrict(selectValueViewController)
 				self?.statisticsCell?.updateManagementCellState()
 			},
-			onDeleteLocalStatistic: { [weak self] administrativeUnit, region in
-				Log.debug("Delete \(private: region.regionType) \(private: administrativeUnit.id), \(private: region.name)", log: .localStatistics)
-				
-				// removing the district from the store
-				guard let selectedLocalStatisticsDistricts = self?.viewModel.store.selectedLocalStatisticsRegions else {
-					Log.error("Could not assign selected local statistics districts", log: .localStatistics)
-					return
-				}
-				self?.viewModel.store.selectedLocalStatisticsRegions = selectedLocalStatisticsDistricts.filter { $0.id != String(administrativeUnit.id) }
-				
-				self?.statisticsCell?.updateManagementCellState()
-				self?.statisticsCell?.layoutIfNeeded()
-			},
 			onDismissState: { [weak self] in
 				self?.onDismissState()
 			},
 			onDismissDistrict: { [weak self] dismissToRoot in
 				self?.onDismissDistrict(dismissToRoot)
-			},
-			onFetchGroupData: { [weak self] region in
-				self?.viewModel.state.fetchLocalStatistics(region: region)
-			},
-			onToggleEditMode: { enabled in
-				Log.debug("Edit mode on: \(enabled)", log: .localStatistics)
-				DispatchQueue.main.async {
-					cell.setEditing(enabled, animated: true)
-				}
 			},
 			onAccessibilityFocus: { [weak self] in
 				self?.tableView.contentOffset.x = 0
@@ -643,7 +621,9 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			},
 			onUpdate: { [weak self] in
 				DispatchQueue.main.async { [weak self] in
+					let isEditing = HomeStatisticsTableViewCell.editingStatistics
 					self?.tableView.reloadSections([HomeTableViewModel.Section.statistics.rawValue], with: .none)
+					self?.statisticsCell?.setEditing(isEditing, animated: false)
 					self?.statisticsCell?.updateManagementCellState()
 				}
 			}

--- a/src/xcode/ENA/ENA/Source/Services/LocalStatistics/LocalStatisticsProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/LocalStatistics/LocalStatisticsProvider.swift
@@ -59,8 +59,45 @@ class LocalStatisticsProvider: LocalStatisticsProviding {
 	// function to get local statistics for N saved districts which are passed as an array
 	// returns an array of type SelectedLocalStatisticsTuple which contains the data for a particular group
 	// and the district information which will be then used for filtering.
-	func latestSelectedLocalStatistics(selectedlocalStatisticsRegions: [LocalStatisticsRegion], completion: @escaping ([SelectedLocalStatisticsTuple]) -> Void) {
-		return fetchSelectedLocalStatistics(selectedLocalStatisticsDistricts: selectedlocalStatisticsRegions, completion: completion)
+	func latestSelectedLocalStatistics(selectedLocalStatisticsRegions: [LocalStatisticsRegion], completion: @escaping ([SelectedLocalStatisticsTuple]) -> Void) {
+		self.selectedLocalStatisticsTuples = []
+
+		// We need to fetch local statistics for N saved districts, so we use dispatch group
+		// to make sure we get the data for N saved districts
+		let localStatisticsGroup = DispatchGroup()
+
+		for localStatisticsRegion in selectedLocalStatisticsRegions {
+			localStatisticsGroup.enter()
+			DispatchQueue.global().async { [weak self] in
+				let localStatistics = self?.store.localStatistics.first(where: {
+					$0.groupID == String(localStatisticsRegion.federalState.groupID)
+				})
+
+				self?.latestLocalStatistics(groupID: String(localStatisticsRegion.federalState.groupID), eTag: localStatistics?.lastLocalStatisticsETag, completion: { result in
+					switch result {
+					case .success(let localStatistics):
+						self?.selectedLocalStatisticsTuples.append(SelectedLocalStatisticsTuple(federalStateAndDistrictsData: localStatistics, localStatisticsRegion: localStatisticsRegion))
+						localStatisticsGroup.leave()
+					case .failure(let error):
+						Log.error("[LocalStatisticsProvider] Could not fetch saved local statistics for district: \(localStatisticsRegion.name): \(error)", log: .api)
+					}
+				})
+			}
+		}
+
+		localStatisticsGroup.notify(queue: .main) { [weak self] in
+			var arrangedSelectedLocalStatisticsTuples: [SelectedLocalStatisticsTuple] = []
+			for localStatisticsRegion in selectedLocalStatisticsRegions {
+				guard let localStatisticsTuple = self?.selectedLocalStatisticsTuples.first(where: {
+					$0.localStatisticsRegion.id == localStatisticsRegion.id
+				}) else {
+					continue
+				}
+
+				arrangedSelectedLocalStatisticsTuples.append(localStatisticsTuple)
+			}
+			completion(arrangedSelectedLocalStatisticsTuples)
+		}
 	}
 
 	// MARK: - Private
@@ -68,48 +105,6 @@ class LocalStatisticsProvider: LocalStatisticsProviding {
 	private let client: LocalStatisticsFetching
 	private let store: LocalStatisticsCaching
 	private var selectedLocalStatisticsTuples: [SelectedLocalStatisticsTuple]
-
-	private func fetchSelectedLocalStatistics(selectedLocalStatisticsDistricts: [LocalStatisticsRegion], completion: @escaping ([SelectedLocalStatisticsTuple]) -> Void) {
-		
-		self.selectedLocalStatisticsTuples = []
-
-		// We need to fetch local statistics for N saved districts, so we use dispatch group
-		// to make sure we get the data for N saved districts
-		let localStatisticsGroup = DispatchGroup()
-		
-		for localStatisticsDistrict in selectedLocalStatisticsDistricts {
-			localStatisticsGroup.enter()
-			DispatchQueue.global().async { [weak self] in
-				let localStatistics = self?.store.localStatistics.first(where: {
-					$0.groupID == String(localStatisticsDistrict.federalState.groupID)
-				})
-				
-				self?.latestLocalStatistics(groupID: String(localStatisticsDistrict.federalState.groupID), eTag: localStatistics?.lastLocalStatisticsETag, completion: { result in
-					switch result {
-					case .success(let localStatistics):
-						self?.selectedLocalStatisticsTuples.append(SelectedLocalStatisticsTuple(federalStateAndDistrictsData: localStatistics, localStatisticsRegion: localStatisticsDistrict))
-						localStatisticsGroup.leave()
-					case .failure(let error):
-						Log.error("[LocalStatisticsProvider] Could not fetch saved local statistics for district: \(localStatisticsDistrict.name): \(error)", log: .api)
-					}
-				})
-			}
-		}
-		
-		localStatisticsGroup.notify(queue: .main) { [weak self] in
-			var arrangedSelectedLocalStatisticsTuples: [SelectedLocalStatisticsTuple] = []
-			for localStatisticsDistrict in selectedLocalStatisticsDistricts {
-				guard let localStatisticsTuple = self?.selectedLocalStatisticsTuples.first(where: {
-					$0.localStatisticsRegion.id == localStatisticsDistrict.id
-				}) else {
-					continue
-				}
-				
-				arrangedSelectedLocalStatisticsTuples.append(localStatisticsTuple)
-			}
-			completion(arrangedSelectedLocalStatisticsTuples)
-		}
-	}
 
 	private func fetchLocalStatistics(groupID: StatisticsGroupIdentifier, eTag: String? = nil, completion: @escaping
 		(Result<SAP_Internal_Stats_LocalStatistics, Error>) -> Void) {

--- a/src/xcode/ENA/ENA/Source/Services/LocalStatistics/LocalStatisticsProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/LocalStatistics/LocalStatisticsProviding.swift
@@ -8,7 +8,7 @@ protocol LocalStatisticsProviding {
 	var cachedSelectedLocalStatisticsTuples: [SelectedLocalStatisticsTuple] { get }
 
 	func latestLocalStatistics(groupID: StatisticsGroupIdentifier, eTag: String?, completion: @escaping (Result<SAP_Internal_Stats_LocalStatistics, Error>) -> Void)
-	func latestSelectedLocalStatistics(selectedlocalStatisticsRegions: [LocalStatisticsRegion], completion: @escaping ([SelectedLocalStatisticsTuple]) -> Void)
+	func latestSelectedLocalStatistics(selectedLocalStatisticsRegions: [LocalStatisticsRegion], completion: @escaping ([SelectedLocalStatisticsTuple]) -> Void)
 }
 
 protocol LocalStatisticsFetching {


### PR DESCRIPTION
## Description
Redraws the whole statistics card stack view on every update to make sure no cards are missing. Also simplifies the data model to reduce the number of publishers and keep the models in sync at all times.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8762
