### PR TITLE
Update validity state on didBecomeActive notification

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -643,6 +643,7 @@ class HealthCertificateService {
 				self?.testCertificateRequests.value.forEach {
 					self?.executeTestCertificateRequest($0, retryIfCertificateIsPending: false)
 				}
+				self?.updateValidityStatesAndNotifications()
 			}
 			.store(in: &subscriptions)
 	}


### PR DESCRIPTION
## Description
Updates the validity state on didBecomeActive notification so it is up-to-date if the app is not in foreground when the expiring soon or expiration date is reached.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8878