### PR TITLE
Use decorator to take the debug menu entry into account.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -181,12 +181,18 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 			// Check if we did not discover in the same hour before.
 			if shouldStartPackageDownload(for: country) {
 				countriesDG.enter()
-				
+
+				var unencryptedCheckinsEnabled = false
+
+				#if !RELEASE
 				let appFeatureProvider = AppFeatureUnencryptedEventsDecorator(
 					AppFeatureProvider(appConfig: appConfig),
 					store: store
 				)
-				let unencryptedCheckinsEnabled = appFeatureProvider.value(for: .unencryptedCheckinsEnabled)
+				unencryptedCheckinsEnabled = appFeatureProvider.value(for: .unencryptedCheckinsEnabled)
+				#else
+				unencryptedCheckinsEnabled = AppFeatureProvider(appConfig: appConfig).value(for: .unencryptedCheckinsEnabled)
+				#endif
 
 				// Go now for the real download
 				downloadTraceWarningPackages(

--- a/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TraceWarningDownload/TraceWarningPackageDownload.swift
@@ -181,12 +181,18 @@ class TraceWarningPackageDownload: TraceWarningPackageDownloading {
 			// Check if we did not discover in the same hour before.
 			if shouldStartPackageDownload(for: country) {
 				countriesDG.enter()
+				
+				let appFeatureProvider = AppFeatureUnencryptedEventsDecorator(
+					AppFeatureProvider(appConfig: appConfig),
+					store: store
+				)
+				let unencryptedCheckinsEnabled = appFeatureProvider.value(for: .unencryptedCheckinsEnabled)
 
 				// Go now for the real download
 				downloadTraceWarningPackages(
 					with: appConfig,
 					for: country,
-					unencrypted: AppFeatureProvider(appConfig: appConfig).value(for: .unencryptedCheckinsEnabled),
+					unencrypted: unencryptedCheckinsEnabled,
 					completion: { result in
 						switch result {
 						case let .success(success):


### PR DESCRIPTION
## Description
With this change, the debug menu setting for `unencryptedCheckinsEnabled` will be taken into account during download.
