### PR TITLE
Make expiring(soon) notifications more friendly

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1506,11 +1506,11 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "local_notifications_expiringSoon_title" = "Corona-Warn-App";
 
-"local_notifications_expiringSoon_body" = "Überprüfen Sie die Gültigkeit Ihrer Zertifikate.";
+"local_notifications_expiringSoon_body" = "Überprüfen Sie bite die Gültigkeit Ihrer Zertifikate.";
 
 "local_notifications_expired_title" = "Corona-Warn-App";
 
-"local_notifications_expired_body" = "Überprüfen Sie die Gültigkeit Ihrer Zertifikate.";
+"local_notifications_expired_body" = "Überprüfen Sie die bitte Gültigkeit Ihrer Zertifikate.";
 
 /* Risk Legend */
 "RiskLegend_Title" = "Überblick";


### PR DESCRIPTION
## Description
This PR adds a "bitte" to the notifications which inform the user about soon expiring or already expired COVID certificates.

## Link to Jira
n/a

## Screenshots
Not possible since I can't import any certificates on my Emulator (see #2907).
