### PR TITLE
Fix/8498 cannot continue feature screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -714,15 +714,22 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			}
 			#endif
 
-			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-				let onboardings: [DeltaOnboarding] = [
-					DeltaOnboardingV15(store: self.viewModel.store, supportedCountries: supportedCountries),
-					DeltaOnboardingDataDonation(store: self.viewModel.store),
-					DeltaOnboardingNewVersionFeatures(store: self.viewModel.store)
-				]
-				Log.debug("Delta Onboarding list size: \(onboardings.count)")
+			let onboardings: [DeltaOnboarding] = [
+				DeltaOnboardingV15(store: self.viewModel.store, supportedCountries: supportedCountries),
+				DeltaOnboardingDataDonation(store: self.viewModel.store),
+				DeltaOnboardingNewVersionFeatures(store: self.viewModel.store)
+			]
 
-				self.deltaOnboardingCoordinator = DeltaOnboardingCoordinator(rootViewController: self, onboardings: onboardings)
+			Log.debug("Delta Onboarding list size: \(onboardings.count)")
+
+			self.deltaOnboardingCoordinator = DeltaOnboardingCoordinator(rootViewController: self, onboardings: onboardings)
+
+			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+				guard self.presentedViewController == nil else {
+					Log.debug("Don't show onboarding this time, because another view controller is currently presented.")
+					return
+				}
+
 				self.deltaOnboardingCoordinator?.finished = { [weak self] in
 					self?.deltaOnboardingCoordinator = nil
 					completion()

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -697,7 +697,10 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func showDeltaOnboardingIfNeeded(completion: @escaping () -> Void = {}) {
-		guard deltaOnboardingCoordinator == nil else { return }
+		guard deltaOnboardingCoordinator == nil else {
+			completion()
+			return
+		}
 
 		appConfigurationProvider.appConfiguration().sink { [weak self] configuration in
 			guard let self = self else { return }
@@ -727,6 +730,8 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 				guard self.presentedViewController == nil else {
 					Log.debug("Don't show onboarding this time, because another view controller is currently presented.")
+					self.deltaOnboardingCoordinator = nil
+					completion()
 					return
 				}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -336,6 +336,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	private var onDismissDistrict: (Bool) -> Void
 
 	private var deltaOnboardingCoordinator: DeltaOnboardingCoordinator?
+	private var onboardingIsRunning = false
 	private var riskCell: UITableViewCell?
 	private var pcrTestResultCell: UITableViewCell?
 	private var pcrTestShownPositiveResultCell: UITableViewCell?
@@ -697,11 +698,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func showDeltaOnboardingIfNeeded(completion: @escaping () -> Void = {}) {
-		guard deltaOnboardingCoordinator == nil else {
+		guard !onboardingIsRunning else {
 			Log.debug("Skip onboarding call, because onboarding is already running.")
 			completion()
 			return
 		}
+		self.onboardingIsRunning = true
 
 		appConfigurationProvider.appConfiguration().sink { [weak self] configuration in
 			guard let self = self else {
@@ -713,12 +715,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			let supportedCountries = configuration.supportedCountries.compactMap({ Country(countryCode: $0) })
 
 			/// As per feature requirement, the delta onboarding should appear with a slight delay of 0.5
-			var delay = 0.5
+			var delay = 10.5
 
 			#if DEBUG
 			if isUITesting {
 				/// In UI Testing we need to increase the delay slightly again. Otherwise UI Tests fail.
-				delay = 1.5
+				delay = 11.5
 			}
 			#endif
 
@@ -735,14 +737,14 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 				guard self.presentedViewController == nil else {
 					Log.debug("Don't show onboarding this time, because another view controller is currently presented.")
-					self.deltaOnboardingCoordinator = nil
+					self.onboardingIsRunning = false
 					completion()
 					return
 				}
 
 				self.deltaOnboardingCoordinator?.finished = { [weak self] in
 					Log.debug("Onboarding finished.")
-					self?.deltaOnboardingCoordinator = nil
+					self?.onboardingIsRunning = false
 					completion()
 				}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -336,7 +336,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	private var onDismissDistrict: (Bool) -> Void
 
 	private var deltaOnboardingCoordinator: DeltaOnboardingCoordinator?
-	private var onboardingIsRunning = false
+	private var deltaOnboardingIsRunning = false
 	private var riskCell: UITableViewCell?
 	private var pcrTestResultCell: UITableViewCell?
 	private var pcrTestShownPositiveResultCell: UITableViewCell?
@@ -698,12 +698,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func showDeltaOnboardingIfNeeded(completion: @escaping () -> Void = {}) {
-		guard !onboardingIsRunning else {
+		guard !deltaOnboardingIsRunning else {
 			Log.debug("Skip onboarding call, because onboarding is already running.")
 			completion()
 			return
 		}
-		self.onboardingIsRunning = true
+		self.deltaOnboardingIsRunning = true
 
 		appConfigurationProvider.appConfiguration().sink { [weak self] configuration in
 			guard let self = self else {
@@ -737,14 +737,14 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
 				guard self.presentedViewController == nil else {
 					Log.debug("Don't show onboarding this time, because another view controller is currently presented.")
-					self.onboardingIsRunning = false
+					self.deltaOnboardingIsRunning = false
 					completion()
 					return
 				}
 
 				self.deltaOnboardingCoordinator?.finished = { [weak self] in
 					Log.debug("Onboarding finished.")
-					self?.onboardingIsRunning = false
+					self?.deltaOnboardingIsRunning = false
 					completion()
 				}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -715,12 +715,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			let supportedCountries = configuration.supportedCountries.compactMap({ Country(countryCode: $0) })
 
 			/// As per feature requirement, the delta onboarding should appear with a slight delay of 0.5
-			var delay = 10.5
+			var delay = 0.5
 
 			#if DEBUG
 			if isUITesting {
 				/// In UI Testing we need to increase the delay slightly again. Otherwise UI Tests fail.
-				delay = 11.5
+				delay = 1.5
 			}
 			#endif
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -698,12 +698,17 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 
 	private func showDeltaOnboardingIfNeeded(completion: @escaping () -> Void = {}) {
 		guard deltaOnboardingCoordinator == nil else {
+			Log.debug("Skip onboarding call, because onboarding is already running.")
 			completion()
 			return
 		}
 
 		appConfigurationProvider.appConfiguration().sink { [weak self] configuration in
-			guard let self = self else { return }
+			guard let self = self else {
+				Log.debug("Skip onboarding call, because HomeTableViewController was deallocated.")
+				completion()
+				return
+			}
 
 			let supportedCountries = configuration.supportedCountries.compactMap({ Country(countryCode: $0) })
 
@@ -736,10 +741,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 				}
 
 				self.deltaOnboardingCoordinator?.finished = { [weak self] in
+					Log.debug("Onboarding finished.")
 					self?.deltaOnboardingCoordinator = nil
 					completion()
 				}
 
+				Log.debug("Start onboarding.")
 				self.deltaOnboardingCoordinator?.startOnboarding()
 			}
 		}.store(in: &subscriptions)


### PR DESCRIPTION
## Description
This PR fixes 2 problems.

1) The availability of `deltaOnboardingCoordinator` was a gatekeeper to make sure, that the onboarding is not started twice. The problem was, that `deltaOnboardingCoordinator` was initialized after app config fetch and after a timeout. So the gate was open for some time, depending on the app config fetch. Now we have a property as the gatekeeper which is set directly before the fetch. This way the gate is closed directly.

2) There could be the case, that a view controller is already presented. In this case, we return now and don't start the onboarding. This way, the onboarding can be triggered the next time. Before that change the onboarding was triggered, but never showed up. The gate (`deltaOnboardingCoordinator`) was closed for subsequent onboarding calls.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8498
