### PR TITLE
Feature/#8384 export certificates/#9062 action sheet

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2927,6 +2927,12 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "RecoveryCertificate_Alert_message" = "Wenn Sie das Genesenenzertifikat entfernen, können Sie es nicht mehr als Nachweis in der App verwenden.";
 
+/* Health Certificate Print PDF */
+
+"HealthCertificate_PrintPdf_showPrintableVersion" = "Druckversion anzeigen";
+
+"HealthCertificate_PrintPdf_cancelActionSheet" = "Abbrechen";
+
 /* Health Certificate Errors */
 
 "HealthCertificate_Error_Title" = "Fehler";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2876,6 +2876,8 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_Details_expirationDateDetails" = "Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
 
+"HealthCertificate_Details_moreButtonTitle" = "Mehr";
+
 
 /* Vaccination Certificate Details */
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
@@ -15,11 +15,11 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 		vaccinationValueSetsProvider: VaccinationValueSetsProviding,
 		dismiss: @escaping () -> Void,
 		didTapValidationButton: @escaping () -> Void,
-		didTapDeleteButton: @escaping () -> Void
+		didTapActionSheet: @escaping () -> Void
 	) {
 		self.dismiss = dismiss
 		self.didTapValidationButton = didTapValidationButton
-		self.didTapDeleteButton = didTapDeleteButton
+		self.didTapActionSheet = didTapActionSheet
 		self.viewModel = HealthCertificateViewModel(
 			healthCertifiedPerson: healthCertifiedPerson,
 			healthCertificate: healthCertificate,
@@ -62,7 +62,7 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 		case .primary:
 			didTapValidationButton()
 		case .secondary:
-			didTapDeleteButton()
+			didTapActionSheet()
 		}
 	}
 
@@ -134,7 +134,7 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 
 	private let dismiss: () -> Void
 	private let didTapValidationButton: () -> Void
-	private let didTapDeleteButton: () -> Void
+	private let didTapActionSheet: () -> Void
 
 	private let viewModel: HealthCertificateViewModel
 	private let backgroundView = GradientBackgroundView(type: .solidGrey(withStars: true))

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
@@ -15,11 +15,11 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 		vaccinationValueSetsProvider: VaccinationValueSetsProviding,
 		dismiss: @escaping () -> Void,
 		didTapValidationButton: @escaping () -> Void,
-		didTapActionSheet: @escaping () -> Void
+		didTapMoreButton: @escaping () -> Void
 	) {
 		self.dismiss = dismiss
 		self.didTapValidationButton = didTapValidationButton
-		self.didTapActionSheet = didTapActionSheet
+		self.didTapMoreButton = didTapMoreButton
 		self.viewModel = HealthCertificateViewModel(
 			healthCertifiedPerson: healthCertifiedPerson,
 			healthCertificate: healthCertificate,
@@ -62,7 +62,7 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 		case .primary:
 			didTapValidationButton()
 		case .secondary:
-			didTapActionSheet()
+			didTapMoreButton()
 		}
 	}
 
@@ -134,7 +134,7 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 
 	private let dismiss: () -> Void
 	private let didTapValidationButton: () -> Void
-	private let didTapActionSheet: () -> Void
+	private let didTapMoreButton: () -> Void
 
 	private let viewModel: HealthCertificateViewModel
 	private let backgroundView = GradientBackgroundView(type: .solidGrey(withStars: true))

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -256,26 +256,15 @@ final class HealthCertificatesCoordinator {
 		healthCertificate: HealthCertificate,
 		shouldPushOnModalNavigationController: Bool
 	) {
-		let deleteButtonTitle: String
-		switch healthCertificate.type {
-		case .vaccination:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.deleteButtonTitle
-		case .test:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.TestCertificate.primaryButton
-		case .recovery:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.RecoveryCertificate.primaryButton
-		}
-
 		let footerViewModel = FooterViewModel(
 			primaryButtonName: AppStrings.HealthCertificate.Details.validationButtonTitle,
-			secondaryButtonName: deleteButtonTitle,
+			secondaryButtonName: AppStrings.HealthCertificate.Details.moreButtonTitle,
 			isPrimaryButtonEnabled: true,
 			isSecondaryButtonEnabled: true,
 			isSecondaryButtonHidden: false,
 			primaryButtonInverted: false,
 			secondaryButtonInverted: true,
-			backgroundColor: .enaColor(for: .cellBackground),
-			secondaryTextColor: .systemRed
+			backgroundColor: .enaColor(for: .cellBackground)
 		)
 
 		let footerViewController = FooterViewController(footerViewModel)
@@ -309,29 +298,8 @@ final class HealthCertificatesCoordinator {
 					}
 				}
 			},
-			didTapDeleteButton: { [weak self] in
-				self?.showDeleteAlert(
-					certificateType: healthCertificate.type,
-					submitAction: UIAlertAction(
-						title: AppStrings.HealthCertificate.Alert.deleteButton,
-						style: .destructive,
-						handler: { _ in
-							guard let self = self else {
-								Log.error("Could not create strong self")
-								return
-							}
-							self.healthCertificateService.removeHealthCertificate(healthCertificate)
-							let isPersonStillExistent = self.healthCertificateService.healthCertifiedPersons.value.contains(healthCertifiedPerson)
-
-							// Only pop to root if we did not removed the last certificate of a person (because this removes the person, too). A pop would trigger a reload of content which was removed before. If so, dismiss to go back to certificate overview.
-							if shouldPushOnModalNavigationController && isPersonStillExistent {
-								self.modalNavigationController.popToRootViewController(animated: true)
-							} else {
-								self.modalNavigationController.dismiss(animated: true)
-							}
-						}
-					)
-				)
+			didTapActionSheet: { [weak self] in
+				self?.showActionSheet(healthCertificate: healthCertificate)
 			}
 		)
 		
@@ -368,7 +336,44 @@ final class HealthCertificatesCoordinator {
 		healthCertificate: HealthCertificate
 	) {
 		
-	
+		
+		/*
+		
+		
+		let deleteButtonTitle: String
+		switch healthCertificate.type {
+		case .vaccination:
+			deleteButtonTitle = AppStrings.HealthCertificate.Details.deleteButtonTitle
+		case .test:
+			deleteButtonTitle = AppStrings.HealthCertificate.Details.TestCertificate.primaryButton
+		case .recovery:
+			deleteButtonTitle = AppStrings.HealthCertificate.Details.RecoveryCertificate.primaryButton
+		}
+		
+		// action for delete
+		self.showDeleteAlert(
+			certificateType: healthCertificate.type,
+			submitAction: UIAlertAction(
+				title: AppStrings.HealthCertificate.Alert.deleteButton,
+				style: .destructive,
+				handler: { _ in
+					guard let self = self else {
+						Log.error("Could not create strong self")
+						return
+					}
+					self.healthCertificateService.removeHealthCertificate(healthCertificate)
+					let isPersonStillExistent = self.healthCertificateService.healthCertifiedPersons.value.contains(healthCertifiedPerson)
+
+					// Only pop to root if we did not removed the last certificate of a person (because this removes the person, too). A pop would trigger a reload of content which was removed before. If so, dismiss to go back to certificate overview.
+					if shouldPushOnModalNavigationController && isPersonStillExistent {
+						self.modalNavigationController.popToRootViewController(animated: true)
+					} else {
+						self.modalNavigationController.dismiss(animated: true)
+					}
+				}
+			)
+		)
+	*/
 	}
 	
 	private func showDeleteAlert(

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -5,6 +5,7 @@
 import UIKit
 import OpenCombine
 
+// swiftlint:disable type_body_length
 final class HealthCertificatesCoordinator {
 	
 	// MARK: - Init

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -299,7 +299,7 @@ final class HealthCertificatesCoordinator {
 					}
 				}
 			},
-			didTapActionSheet: { [weak self] in
+			didTapMoreButton: { [weak self] in
 				self?.showActionSheet(
 					healthCertificate: healthCertificate,
 					removeAction: { [weak self] in

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -373,7 +373,9 @@ final class HealthCertificatesCoordinator {
 			title: AppStrings.HealthCertificate.PrintPDF.showVersion,
 			style: .default,
 			handler: { [weak self] _ in
-//				self?.onInfoButtonTap()
+				self?.showPdfGenerationInfo(
+					healthCertificate: healthCertificate
+				)
 			}
 		)
 		actionSheet.addAction(printAction)
@@ -404,15 +406,6 @@ final class HealthCertificatesCoordinator {
 		)
 		actionSheet.addAction(cancelAction)
 		modalNavigationController.present(actionSheet, animated: true, completion: nil)
-
-		/*
-		
-		
-		
-		
-		// action for delete
-		
-	*/
 	}
 	
 	private func showDeleteAlert(

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2095,7 +2095,8 @@ enum AppStrings {
 			static let expirationDateTitle = NSLocalizedString("HealthCertificate_Details_expirationDateTitle", comment: "")
 			static let expirationDatePlaceholder = NSLocalizedString("HealthCertificate_Details_expirationDatePlaceholder", comment: "")
 			static let expirationDateDetails = NSLocalizedString("HealthCertificate_Details_expirationDateDetails", comment: "")
-
+			static let moreButtonTitle = NSLocalizedString("HealthCertificate_Details_moreButtonTitle", comment: "")
+			
 			enum VaccinationCertificate {
 				static let oneOfOneHint = NSLocalizedString("VaccinationCertificate_Details_OneOfOneHint", comment: "")
 			}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2113,6 +2113,11 @@ enum AppStrings {
 				static let primaryButton = NSLocalizedString("RecoveryCertificate_Details_primaryButton", comment: "")
 			}
 		}
+		
+		enum PrintPDF {
+			static let showVersion = NSLocalizedString("HealthCertificate_PrintPdf_showPrintableVersion", comment: "")
+			static let cancel = NSLocalizedString("HealthCertificate_PrintPdf_cancelActionSheet", comment: "")
+		}
 
 		enum ValidityState {
 			static let expiringSoon = NSLocalizedString("HealthCertificate_ValidityState_ExpiringSoon", comment: "")


### PR DESCRIPTION
## Description
In a HealthCertificate details, this replaces the "remove" button by a "more" button. Tapping this will open an action sheet with the possibility to remove the certificate, show a printable version or to cancel the action sheet.

This PR adds the action sheet and moves the remove certificate functionality to the action sheets button. The remaining functionality comes in the next PR.

## Link to Jira
Main Story: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8384
Subtask: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9062

## Screenshots
![9062-more](https://user-images.githubusercontent.com/75615785/130086551-f2dedbf0-db61-4580-aa3f-d396608da720.PNG)
![9062-more-dark](https://user-images.githubusercontent.com/75615785/130086558-6239c101-a68e-4680-acb3-97ae51d27245.PNG)
![9062-actionsheet](https://user-images.githubusercontent.com/75615785/130086563-112dd6d4-e940-4caa-ada3-f77f5d060ef8.PNG)
![9062-actionsheet-dark](https://user-images.githubusercontent.com/75615785/130086570-e77e71f0-2859-4e46-b030-06ad72fb113b.PNG)

