### PR TITLE
Feature/#8384 export certificates/#9063 error alert

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
@@ -43,3 +43,5 @@
 "HealthCertificate_InvalidSignature_FAQLink" = "https://www.coronawarn.app/en/faq/#hc_signature_invalid";
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/";
+
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/en/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
@@ -43,3 +43,5 @@
 "HealthCertificate_InvalidSignature_FAQLink" = "https://www.coronawarn.app/de/faq/#hc_signature_invalid";
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/de/blog/2021-08-05-statistictiles/";
+
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/de/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2933,6 +2933,16 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_PrintPdf_cancelActionSheet" = "Abbrechen";
 
+/* Health Certificate Print PDF Error Alert */
+
+"HealthCertificate_PrintPdf_ErrorAlert_Title" = "Druckversion anzeigen nicht möglich";
+
+"HealthCertificate_PrintPdf_ErrorAlert_Message" = "Die Druckversion des Zertifikats kann nicht angezeigt werden, da das Zertifikat nicht in Deutschland ausgestellt wurde.";
+
+"HealthCertificate_PrintPdf_ErrorAlert_FAQ" = "FAQ zur Druckversion";
+
+"HealthCertificate_PrintPdf_ErrorAlert_OK" = "OK";
+
 /* Health Certificate Errors */
 
 "HealthCertificate_Error_Title" = "Fehler";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
@@ -44,3 +44,4 @@
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/";
 
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/en/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
@@ -43,3 +43,5 @@
 "HealthCertificate_InvalidSignature_FAQLink" = "https://www.coronawarn.app/en/faq/#hc_signature_invalid";
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/";
+
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/en/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
@@ -43,3 +43,5 @@
 "HealthCertificate_InvalidSignature_FAQLink" = "https://www.coronawarn.app/en/faq/#hc_signature_invalid";
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/";
+
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/en/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
@@ -43,3 +43,5 @@
 "HealthCertificate_InvalidSignature_FAQLink" = "https://www.coronawarn.app/en/faq/#hc_signature_invalid";
 
 "Statistics_Info_Blog_Link" = "https://www.coronawarn.app/en/blog/2021-08-05-statistictiles/";
+
+"HealthCertificate_Print_FAQ_Link" = "https://www.coronawarn.app/en/faq/#eu_dcc_export";

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -374,6 +374,11 @@ final class HealthCertificatesCoordinator {
 			title: AppStrings.HealthCertificate.PrintPDF.showVersion,
 			style: .default,
 			handler: { [weak self] _ in
+				// Check first if the certificate is obtained in DE. If not, show error alert.
+				guard healthCertificate.cborWebTokenHeader.issuer == "DE" else {
+					self?.showPdfPrintErrorAlert()
+					return
+				}
 				self?.showPdfGenerationInfo(
 					healthCertificate: healthCertificate
 				)
@@ -481,6 +486,35 @@ final class HealthCertificatesCoordinator {
 
 		let okayAction = UIAlertAction(
 			title: AppStrings.Common.alertActionOk,
+			style: .cancel,
+			handler: { _ in
+				alert.dismiss(animated: true)
+			}
+		)
+		alert.addAction(okayAction)
+
+		modalNavigationController.present(alert, animated: true, completion: nil)
+	}
+	
+	private func showPdfPrintErrorAlert() {
+		let alert = UIAlertController(
+			title: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.title,
+			message: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.message,
+			preferredStyle: .alert
+		)
+		
+		let faqAction = UIAlertAction(
+			title: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.faq,
+			style: .default,
+			handler: { _ in
+				// TODO
+				LinkHelper.open(urlString: AppStrings.Links.appFaq)
+			}
+		)
+		alert.addAction(faqAction)
+		
+		let okayAction = UIAlertAction(
+			title: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.ok,
 			style: .cancel,
 			handler: { _ in
 				alert.dismiss(animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -507,8 +507,7 @@ final class HealthCertificatesCoordinator {
 			title: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.faq,
 			style: .default,
 			handler: { _ in
-				// TODO
-				LinkHelper.open(urlString: AppStrings.Links.appFaq)
+				LinkHelper.open(urlString: AppStrings.Links.healthCertificatePrintFAQ)
 			}
 		)
 		alert.addAction(faqAction)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2117,6 +2117,12 @@ enum AppStrings {
 		enum PrintPDF {
 			static let showVersion = NSLocalizedString("HealthCertificate_PrintPdf_showPrintableVersion", comment: "")
 			static let cancel = NSLocalizedString("HealthCertificate_PrintPdf_cancelActionSheet", comment: "")
+			enum ErrorAlert {
+				static let title = NSLocalizedString("HealthCertificate_PrintPdf_ErrorAlert_Title", comment: "")
+				static let message = NSLocalizedString("HealthCertificate_PrintPdf_ErrorAlert_Message", comment: "")
+				static let faq = NSLocalizedString("HealthCertificate_PrintPdf_ErrorAlert_FAQ", comment: "")
+				static let ok = NSLocalizedString("HealthCertificate_PrintPdf_ErrorAlert_OK", comment: "")
+			}
 		}
 
 		enum ValidityState {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -49,6 +49,7 @@ enum AppStrings {
 		static let healthCertificateValidationEU = NSLocalizedString("HealthCertificate_Info_validation_EULink", tableName: "Localizable.links", comment: "")
 		static let invalidSignatureFAQ = NSLocalizedString("HealthCertificate_InvalidSignature_FAQLink", tableName: "Localizable.links", comment: "")
 		static let statisticsInfoBlog = NSLocalizedString("Statistics_Info_Blog_Link", tableName: "Localizable.links", comment: "")
+		static let healthCertificatePrintFAQ = NSLocalizedString("HealthCertificate_Print_FAQ_Link", tableName: "Localizable.links", comment: "")
 	}
 
 	enum QuickActions {


### PR DESCRIPTION
## Description
Shows an error alert to the print action sheet which appears when you tap on "printable pdf version" but your certificate was not obtained in DE.

## Link to Jira
Main story: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8384
Subtask: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9063

## Screenshots
![9063-alert](https://user-images.githubusercontent.com/75615785/130210317-7404cf77-409d-4d9b-9b0d-62965bf34cea.PNG)
![9063-alert-dark](https://user-images.githubusercontent.com/75615785/130210326-6751c4f2-2095-46a2-8fe5-117ebcda7631.PNG)

