### PR TITLE
Add webhook to the general teams channel

### DIFF
--- a/scripts/announce_screenshots.sh
+++ b/scripts/announce_screenshots.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCREENSHOT_URL=$1
 
 if curl --output /dev/null --silent --head --fail "$SCREENSHOT_URL"; then
-  curl --output /dev/null --silent $SAP_TEAMS_WEBHOOK \
+  curl --output /dev/null --silent $SAP_TEAMS_SCREENSHOTS_WEBHOOK \
   -H 'Content-Type: application/json' \
   --data-binary @- << EOF
 {


### PR DESCRIPTION
## Description
Add a new Webhook to publish the screenshots directly to the general channel.
A new env variable was added into the CI environment variables to hold the webhook URL