### PR TITLE
Chore/8990 mock en manager

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		35F929B02682176B006115BB /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = 35F929AF2682176B006115BB /* style.css */; };
 		4026C2DC24852B7600926FB4 /* AppInformationViewController+LegalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4026C2DB24852B7600926FB4 /* AppInformationViewController+LegalModel.swift */; };
 		4026C2E424854C8D00926FB4 /* AppInformationLegalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4026C2E324854C8D00926FB4 /* AppInformationLegalCell.swift */; };
+		4B54B35226D52B8F00A49EB9 /* MockENManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B54B35126D52B8F00A49EB9 /* MockENManager.swift */; };
 		4B577C5F26C1D90500641667 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B577C5E26C1D90500641667 /* LoggingTests.swift */; };
 		4BAB48F426C9B4FB00CC4C11 /* RateLimitLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAB48F326C9B4FB00CC4C11 /* RateLimitLogger.swift */; };
 		4BAB490426C9B70A00CC4C11 /* RateLimitLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAB490326C9B70900CC4C11 /* RateLimitLoggerTests.swift */; };
@@ -1866,6 +1867,7 @@
 		35F929AF2682176B006115BB /* style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
 		4026C2DB24852B7600926FB4 /* AppInformationViewController+LegalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppInformationViewController+LegalModel.swift"; sourceTree = "<group>"; };
 		4026C2E324854C8D00926FB4 /* AppInformationLegalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInformationLegalCell.swift; sourceTree = "<group>"; };
+		4B54B35126D52B8F00A49EB9 /* MockENManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockENManager.swift; sourceTree = "<group>"; };
 		4B577C5E26C1D90500641667 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
 		4BAB48F326C9B4FB00CC4C11 /* RateLimitLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RateLimitLogger.swift; sourceTree = "<group>"; };
 		4BAB490326C9B70900CC4C11 /* RateLimitLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RateLimitLoggerTests.swift; sourceTree = "<group>"; };
@@ -4795,6 +4797,7 @@
 				941ADDB12518C3FB00E421D9 /* ENSettingEuTracingViewModel.swift */,
 				514E81332461B97700636861 /* ExposureManager.swift */,
 				CD678F6A246C43E200B6A0F8 /* MockExposureManager.swift */,
+				4B54B35126D52B8F00A49EB9 /* MockENManager.swift */,
 				518A69FA24687D5800444E66 /* RiskLevel.swift */,
 				01D307892562B03B00ADB67B /* RiskState.swift */,
 				94427A4F25502B8900C36BE6 /* WarnOthersNotificationsTimeInterval.swift */,
@@ -8564,6 +8567,7 @@
 				BA6C8AB9254D64D3008344F5 /* MinutesAtAttenuationWeight.swift in Sources */,
 				7154EB4C247E862100A467FF /* ExposureDetectionLoadingCell.swift in Sources */,
 				01164CE626C57BB5007F9C3E /* OnBehalfTraceLocationSelectionEmptyStateViewModel.swift in Sources */,
+				4B54B35226D52B8F00A49EB9 /* MockENManager.swift in Sources */,
 				94EAF87925B6CAA300BE1F40 /* DeltaOnboardingNewVersionFeaturesViewModel.swift in Sources */,
 				01A4DD4325935D1F007D5794 /* HomeRiskCellModel.swift in Sources */,
 				2EB7D68B2680790D00633D30 /* CoronaTestResultOperation.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -411,9 +411,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		otpService: otpService
 	)
 
-	#if targetEnvironment(simulator) || COMMUNITY
+	#if COMMUNITY
 	// Enable third party contributors that do not have the required
 	// entitlements to also use the app
+	lazy var exposureManager: ExposureManager = {
+		let keys = [ENTemporaryExposureKey()]
+		let mock = MockENManager(enError: nil, diagnosisKeysResult: (keys, nil))
+		return ENAExposureManager(manager: mock)
+	}()
+	#elseif targetEnvironment(simulator)
 	lazy var exposureManager: ExposureManager = {
 		let keys = [ENTemporaryExposureKey()]
 		return MockExposureManager(exposureNotificationError: nil, diagnosisKeysResult: (keys, nil))

--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockENManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockENManager.swift
@@ -1,0 +1,148 @@
+////
+// 🦠 Corona-Warn-App
+//
+
+import ExposureNotification
+
+final class MockENManager: NSObject {
+	typealias MockDiagnosisKeysResult = ([ENTemporaryExposureKey]?, Error?)
+
+	// MARK: Creating a Mocked ENManager
+
+	init(
+		enError: ENError?,
+		diagnosisKeysResult: MockDiagnosisKeysResult?
+	) {
+		self.enError = enError
+		self.diagnosisKeysResult = diagnosisKeysResult
+
+		#if RELEASE
+		// This whole class would/should be wrapped in a DEBUG block. However, there were some
+		// issues with the handling of community and debug builds so we chose this way to prevent
+		// malicious usage
+		preconditionFailure("Don't use this mock in production!")
+		#endif
+	}
+	
+	// MARK: - Activating
+
+	func activate(completionHandler: @escaping ENErrorHandler) {
+		DispatchQueue.main.async {
+			completionHandler(nil)
+		}
+	}
+
+	func setExposureNotificationEnabled(_ enabled: Bool, completionHandler: @escaping ENErrorHandler) {
+		self.enabled = enabled
+		DispatchQueue.main.async {
+			completionHandler(nil)
+		}
+	}
+
+	// MARK: - Obtaining Exposure Information
+
+	func detectExposures(configuration: ENExposureConfiguration, diagnosisKeyURLs: [URL], completionHandler: @escaping ENDetectExposuresHandler) -> Progress {
+		let error = enError
+		let now = Date()
+		dispatchQueue.async {
+			if error == nil {
+				// assuming successfull execution and no exposures
+				guard !self.wasCalledTooOftenTill(now) else {
+					completionHandler(nil, ENError(.rateLimited))
+					return
+				}
+				completionHandler(ENExposureDetectionSummary(), error)
+			} else {
+				// error case
+				completionHandler(nil, error)
+			}
+		}
+		return Progress()
+	}
+
+	func getExposureWindows(from summary: ENExposureDetectionSummary, completionHandler: @escaping ENGetExposureWindowsHandler) -> Progress {
+		dispatchQueue.async {
+			// assuming successfull execution and empty list of exposure windows
+			completionHandler([], nil)
+		}
+		return Progress()
+	}
+
+	// MARK: - Obtaining Exposure Keys
+
+	func getDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) {
+		dispatchQueue.async {
+			// swiftlint:disable:next force_unwrapping
+			completionHandler(self.diagnosisKeysResult!.0, self.diagnosisKeysResult!.1)
+		}
+	}
+
+	func getTestDiagnosisKeys(completionHandler: @escaping ENGetDiagnosisKeysHandler) {
+		dispatchQueue.async {
+			// swiftlint:disable:next force_unwrapping
+			completionHandler(self.diagnosisKeysResult!.0, self.diagnosisKeysResult!.1)
+		}
+	}
+
+	// MARK: - Configuring the Manager
+
+	var exposureNotificationStatus: ENStatus {
+		if enabled {
+			return ENStatus.active
+		} else {
+			return ENStatus.disabled
+		}
+	}
+
+	var exposureNotificationEnabled: Bool {
+		return enabled
+	}
+
+	static var authorizationStatus: ENAuthorizationStatus {
+		return ENAuthorizationStatus.authorized
+	}
+
+	var dispatchQueue = DispatchQueue.main
+
+	// MARK: - Preauthorizing Exposure Keys
+
+	@available(iOS 14.4, *)
+	func preAuthorizeKeys(completion: @escaping  ENErrorHandler) {
+		dispatchQueue.async {
+			completion(nil)
+		}
+	}
+
+	// MARK: - Invalidating the Manager
+
+	func invalidate() {
+		if let handler = invalidationHandler {
+			dispatchQueue.async {
+				handler()
+			}
+		}
+	}
+	var invalidationHandler: (() -> Void)?
+
+	// MARK: - Private
+
+	private let enError: ENError?
+	private let diagnosisKeysResult: MockDiagnosisKeysResult?
+	private let minDistanceBetweenCalls: TimeInterval = 4 * 3600
+	private var enabled: Bool = true
+	private var lastCall: Date?
+
+	private func wasCalledTooOftenTill(_ now: Date) -> Bool {
+		var tooOften = false
+		if let last = lastCall {
+			if now.timeIntervalSince(last) < minDistanceBetweenCalls {
+				tooOften = true
+			}
+		}
+		lastCall = now
+		return tooOften
+	}
+}
+
+extension MockENManager: Manager {
+}


### PR DESCRIPTION
## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR implements a mock ENManager for the community build, as proposed at https://github.com/corona-warn-app/cwa-app-ios/issues/3283.
I have not implemented the complete interface of the Apple API, but focussed basically on what cwa actually uses today (protocol Manager).

## Link to Jira
<!-- Please add the link to the related Jira issue -->
Internal Tracking-ID: EXPOSUREAPP-8990

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
