### PR TITLE
Feature/#8384 export certificates/#9177 adoptchanges to testresult opening

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -693,26 +693,15 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 		healthCertifiedPerson: HealthCertifiedPerson,
 		healthCertificate: HealthCertificate
 	) {
-		let deleteButtonTitle: String
-		switch healthCertificate.type {
-		case .vaccination:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.deleteButtonTitle
-		case .test:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.TestCertificate.primaryButton
-		case .recovery:
-			deleteButtonTitle = AppStrings.HealthCertificate.Details.RecoveryCertificate.primaryButton
-		}
-
 		let footerViewModel = FooterViewModel(
 			primaryButtonName: AppStrings.HealthCertificate.Details.validationButtonTitle,
-			secondaryButtonName: deleteButtonTitle,
+			secondaryButtonName: AppStrings.HealthCertificate.Details.moreButtonTitle,
 			isPrimaryButtonEnabled: true,
 			isSecondaryButtonEnabled: true,
 			isSecondaryButtonHidden: false,
 			primaryButtonInverted: false,
 			secondaryButtonInverted: true,
-			backgroundColor: .enaColor(for: .cellBackground),
-			secondaryTextColor: .systemRed
+			backgroundColor: .enaColor(for: .cellBackground)
 		)
 
 		let footerViewController = FooterViewController(footerViewModel)


### PR DESCRIPTION
## Description
Adopts the changes made for export functionality to the `SubmissionCoordiniator` because we can open from here the certificates details now, too.

## Link to Jira
Subtask: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9177
Mainstory: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8384

## Screenshots
x
