### PR TITLE
Use fork to include 12-hour override fix

### DIFF
--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -57,11 +57,11 @@
       },
       {
         "package": "JSONSchema",
-        "repositoryURL": "https://github.com/eu-digital-green-certificates/JSONSchema.swift",
+        "repositoryURL": "https://github.com/corona-warn-app/JSONSchema.swift",
         "state": {
           "branch": null,
-          "revision": "c21d82683c426097700afc90dfe63fe06ed5127c",
-          "version": "0.6.0"
+          "revision": "4a46b92510fb85ac5e84dbe95d88c6f5d1736341",
+          "version": null
         }
       },
       {

--- a/src/xcode/ENA/ENA/Source/Extensions/Dateformatter+vCard.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/Dateformatter+vCard.swift
@@ -12,13 +12,15 @@ extension DateFormatter {
 			let dateFormatter = DateFormatter()
 			dateFormatter.dateFormat = "yyyyMMdd"
 			dateFormatter.timeZone = .utcTimeZone
+			dateFormatter.locale = Locale(identifier: "en_US_POSIX")
 			return dateFormatter
 		}
 
 		static var revDate: DateFormatter {
 			let dateFormatter = DateFormatter()
-			dateFormatter.dateFormat = "yyyyMMdd'T'hhmmss'Z'"
+			dateFormatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
 			dateFormatter.timeZone = .utcTimeZone
+			dateFormatter.locale = Locale(identifier: "en_US_POSIX")
 			return dateFormatter
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/TestEntry+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/TestEntry+Extension.swift
@@ -80,7 +80,8 @@ extension TestEntry {
 			let customDateFormatter = DateFormatter()
 			customDateFormatter.dateFormat = "yyyy-MM-dd HH:mm 'UTC' x"
 			// Dates for certificates are formatted in Gregorian calendar, even if the user setting is different
-			customDateFormatter.calendar = .gregorian()
+			customDateFormatter.calendar = .gregorian(with: Locale(identifier: "en_US_POSIX"))
+			customDateFormatter.locale = Locale(identifier: "en_US_POSIX")
 			return sampleCollectionDate.flatMap {
 				customDateFormatter.string(from: $0)
 			} ?? dateTimeOfSampleCollection

--- a/src/xcode/ENA/HealthCertificateToolkit/Package.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR", .upToNextMajor(from: "0.4.3")),
         .package(url: "https://github.com/corona-warn-app/base45-swift", .branch("distribution/swiftpackage")),
-        .package(name: "JSONSchema", url: "https://github.com/eu-digital-green-certificates/JSONSchema.swift", .upToNextMajor(from: "0.6.0")),
+        .package(name: "JSONSchema", url: "https://github.com/corona-warn-app/JSONSchema.swift", .revision("4a46b92510fb85ac5e84dbe95d88c6f5d1736341")),
         .package(url: "https://github.com/tsolomko/SWCompression.git", .upToNextMajor(from: "4.5.0")),
         .package(name: "CertLogic", url: "https://github.com/eu-digital-green-certificates/dgc-certlogic-ios", .revision("8f07a22ec2adc2335b4a4cb75b408c8c93d86208")),
         .package(url: "https://github.com/filom/ASN1Decoder", .upToNextMajor(from: "1.8.0")),


### PR DESCRIPTION
## Description
I made a fork of JSONSchema.swift and fixed the locale of the date formatter. This PR switches CWA to that fork.

In parallel I opened a PR to fix the issue in the original fork: https://github.com/eu-digital-green-certificates/JSONSchema.swift/pull/1. As soon as it is merged, we can go back to it and delete our own fork.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9234
