### PR TITLE
Fix/9349 submission timeintervall change

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
@@ -16,7 +16,7 @@ enum PPASError: Error {
 	case ppacError(PPACError)
 	case appResetError
 	case onboardingError
-	case submission23hoursError
+	case submissionAmountUndercutError
 	case probibilityError
 	case userConsentError
 }

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/Model/PPASError.swift
@@ -16,7 +16,7 @@ enum PPASError: Error {
 	case ppacError(PPACError)
 	case appResetError
 	case onboardingError
-	case submissionAmountUndercutError
+	case submissionTimeAmountUndercutError
 	case probibilityError
 	case userConsentError
 }

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -107,7 +107,7 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			if strongSelf.submissionWithinLast23HoursAnd55Minutes {
 				Log.warning("Analytics submission abort due to submission last 23 hours", log: .ppa)
 				strongSelf.submissionState = .readyForSubmission
-				completion?(.failure(.submissionAmountUndercutError))
+				completion?(.failure(.submissionTimeAmountUndercutError))
 				return
 			}
 			

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/PPAnalyticsSubmitter.swift
@@ -104,10 +104,10 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 			}
 			
 			// Last submission check
-			if strongSelf.submissionWithinLast23Hours {
+			if strongSelf.submissionWithinLast23HoursAnd55Minutes {
 				Log.warning("Analytics submission abort due to submission last 23 hours", log: .ppa)
 				strongSelf.submissionState = .readyForSubmission
-				completion?(.failure(.submission23hoursError))
+				completion?(.failure(.submissionAmountUndercutError))
 				return
 			}
 			
@@ -189,13 +189,14 @@ final class PPAnalyticsSubmitter: PPAnalyticsSubmitting {
 		return !store.isPrivacyPreservingAnalyticsConsentGiven
 	}
 	
-	private var submissionWithinLast23Hours: Bool {
+	private var submissionWithinLast23HoursAnd55Minutes: Bool {
 		guard let lastSubmission = store.lastSubmissionAnalytics,
-			  let twentyThreeHoursAgo = Calendar.current.date(byAdding: .hour, value: -23, to: Date()) else {
+			  let twentyThreeHoursAgo = Calendar.current.date(byAdding: .hour, value: -23, to: Date()),
+			  let twentyThreeHoursAndFiftyFiveMinutesAgo = Calendar.current.date(byAdding: .minute, value: -55, to: twentyThreeHoursAgo) else {
 			return false
 		}
-		let lastTwentyThreeHours = twentyThreeHoursAgo...Date()
-		return lastTwentyThreeHours.contains(lastSubmission)
+		let lastTwentyThreeHoursAndFiftyMinutes = twentyThreeHoursAndFiftyFiveMinutesAgo...Date()
+		return lastTwentyThreeHoursAndFiftyMinutes.contains(lastSubmission)
 	}
 	
 	private var onboardingCompletedWithinLast24Hours: Bool {

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -276,7 +276,7 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 		XCTAssertEqual(ppasError, .probibilityError)
 	}
 
-	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas2HoursAgo_THEN_SubmissionAmountUndercutErrorIsReturned() {
+	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas2HoursAgo_THEN_SubmissionTimeAmountUndercutErrorIsReturned() {
 		// GIVEN
 		let store = MockTestStore()
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
@@ -330,10 +330,10 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(ppasError, .submissionAmountUndercutError)
+		XCTAssertEqual(ppasError, .submissionTimeAmountUndercutError)
 	}
 	
-	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas23Hours53MinutesAgo_THEN_SubmissionAmountUndercutErrorIsReturned() throws {
+	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas23Hours53MinutesAgo_THEN_SubmissionTimeAmountUndercutErrorIsReturned() throws {
 		// GIVEN
 		let store = MockTestStore()
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
@@ -390,7 +390,7 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(ppasError, .submissionAmountUndercutError)
+		XCTAssertEqual(ppasError, .submissionTimeAmountUndercutError)
 	}
 
 	func testGIVEN_SubmissionIsTriggered_WHEN_OnboardingWas2HoursAgo_THEN_OnboardingErrorIsReturned() throws {

--- a/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAnalyticsSubmitter/__tests__/PPAnalyticsSubmitterTests.swift
@@ -330,10 +330,10 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(ppasError, .submission23Hours50MinutesError)
+		XCTAssertEqual(ppasError, .submissionAmountUndercutError)
 	}
 	
-	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas23Hours53MinutesAgo_THEN_SubmissionAmountUndercutErrorIsReturned() {
+	func testGIVEN_SubmissionIsTriggered_WHEN_SubmissionWas23Hours53MinutesAgo_THEN_SubmissionAmountUndercutErrorIsReturned() throws {
 		// GIVEN
 		let store = MockTestStore()
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
@@ -361,7 +361,10 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 					dccSignatureVerifier: DCCSignatureVerifyingStub(),
 					dscListProvider: MockDSCListProvider(),
 					client: client,
-					appConfiguration: appConfigurationProvider
+					appConfiguration: appConfigurationProvider,
+					boosterNotificationsService: BoosterNotificationsService(
+						rulesDownloadService: RulesDownloadService(store: store, client: client)
+					)
 				)
 			),
 			ppacService: PPACService(store: store, deviceCheck: deviceCheck)
@@ -369,9 +372,9 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		let expectation = self.expectation(description: "completion handler is called with an error")
 		// Test edge case when 2 minutes remain to submit again.
-		let twentyThreeHoursAgo = Calendar.current.date(byAdding: .hour, value: -23, to: Date())
-		let twentyThreeHoursFiftyThreeMinutesAgo = Calendar.current.date(byAdding: .minutes, value: -53, to: twentyThreeHoursAgo)
-		store.lastSubmissionAnalytics = twentyThreeHoursFortyEightMinutesAgo
+		let twentyThreeHoursAgo = try XCTUnwrap(Calendar.current.date(byAdding: .hour, value: -23, to: Date()))
+		let twentyThreeHoursFiftyThreeMinutesAgo = Calendar.current.date(byAdding: .minute, value: -53, to: twentyThreeHoursAgo)
+		store.lastSubmissionAnalytics = twentyThreeHoursFiftyThreeMinutesAgo
 
 		// WHEN
 		var ppasError: PPASError?
@@ -387,10 +390,10 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		// THEN
 		waitForExpectations(timeout: .medium)
-		XCTAssertEqual(ppasError, .submission23Hours50MinutesError)
+		XCTAssertEqual(ppasError, .submissionAmountUndercutError)
 	}
 
-	func testGIVEN_SubmissionIsTriggered_WHEN_OnboardingWas2HoursAgo_THEN_OnboardingErrorIsReturned() {
+	func testGIVEN_SubmissionIsTriggered_WHEN_OnboardingWas2HoursAgo_THEN_OnboardingErrorIsReturned() throws {
 		// GIVEN
 		let store = MockTestStore()
 		store.isPrivacyPreservingAnalyticsConsentGiven = true
@@ -429,8 +432,8 @@ class PPAnalyticsSubmitterTests: CWATestCase {
 
 		let expectation = self.expectation(description: "completion handler is called with an error")
 		// Test edge case when we can submit since 2 minutes.
-		let twentyThreeHoursAgo = Calendar.current.date(byAdding: .hour, value: -23, to: Date())
-		let twentyThreeHoursFiftySevenMinutesAgo = Calendar.current.date(byAdding: .minutes, value: -57, to: twentyThreeHoursAgo)
+		let twentyThreeHoursAgo = try XCTUnwrap(Calendar.current.date(byAdding: .hour, value: -23, to: Date()))
+		let twentyThreeHoursFiftySevenMinutesAgo = Calendar.current.date(byAdding: .minute, value: -57, to: twentyThreeHoursAgo)
 		
 		store.lastSubmissionAnalytics = twentyThreeHoursFiftySevenMinutesAgo
 		store.dateOfAcceptedPrivacyNotice = Calendar.current.date(byAdding: .hour, value: -2, to: Date())


### PR DESCRIPTION
## Description
Changes the time when a PPA submission can be done again from 23h to 23h55m.
Renamed the vars, funcs and error code.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9349
