### PR TITLE
Fix/9442 scale factor fixing

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/TraceLocation+GenerateQRCode.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/TraceLocation+GenerateQRCode.swift
@@ -8,12 +8,20 @@ extension TraceLocation {
 
 	// MARK: - Internal
 	
-	func qrCode(size: CGSize = CGSize(width: 400, height: 400), qrCodeErrorCorrectionLevel: MappedErrorCorrectionType = .medium) -> UIImage? {
+	func qrCode(
+		size: CGSize = CGSize(width: 400, height: 400),
+		scale: CGFloat = UIScreen.main.scale,
+		qrCodeErrorCorrectionLevel: MappedErrorCorrectionType = .medium
+	) -> UIImage? {
 		guard let qrCodeURL = qrCodeURL else {
 			return nil
 		}
 
-		return UIImage.qrCode(with: qrCodeURL, size: size, qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel)
+		return UIImage.qrCode(with: qrCodeURL,
+							  size: size,
+							  scale: scale,
+							  qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel
+		)
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/TraceLocation+GenerateQRCode.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/TraceLocation+GenerateQRCode.swift
@@ -17,11 +17,11 @@ extension TraceLocation {
 			return nil
 		}
 
-		return UIImage.qrCode(with: qrCodeURL,
-							  size: size,
-							  scale: scale,
-							  qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel
+		return UIImage.qrCode(
+			with: qrCodeURL,
+			size: size,
+			scale: scale,
+			qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel
 		)
 	}
-
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Details/TraceLocationDetailsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Details/TraceLocationDetailsViewController.swift
@@ -198,7 +198,10 @@ class TraceLocationDetailsViewController: UIViewController, UITableViewDataSourc
 		let pdfDocument = PDFDocument(data: templateData.template)
 
 		let qrSideLength = CGFloat(templateData.qrCodeSideLength)
-		guard let qrCodeImage = viewModel.qrCode(size: CGSize(width: qrSideLength, height: qrSideLength)) else { return pdfView }
+		guard let qrCodeImage = viewModel.qrCode(
+			size: CGSize(width: qrSideLength, height: qrSideLength),
+			scale: 1
+		) else { return pdfView }
 		let descriptionTextDetails = templateData.descriptionTextBox
 		let addressTextDetails = templateData.addressTextBox
 		

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Details/TraceLocationDetailsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Details/TraceLocationDetailsViewModel.swift
@@ -59,8 +59,15 @@ class TraceLocationDetailsViewModel {
 		return 1
 	}
 
-	func qrCode(size: CGSize = CGSize(width: 300, height: 300)) -> UIImage? {
-		guard let qrCodeImage = traceLocation.qrCode(size: size, qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel) else { return nil }
+	func qrCode(
+		size: CGSize = CGSize(width: 300, height: 300),
+		scale: CGFloat = UIScreen.main.scale
+	) -> UIImage? {
+		guard let qrCodeImage = traceLocation.qrCode(
+			size: size,
+			scale: scale,
+			qrCodeErrorCorrectionLevel: qrCodeErrorCorrectionLevel
+		) else { return nil }
 		return qrCodeImage
 	}
 


### PR DESCRIPTION
## Description
After removing the scaling of our qrImage function in this PR #3517, we must pass for the checkin print QR code a scale factor of 1 to our functions that generates the qrImage, so that the printable version of the QR code is scaled correctly. If not, the QR code would scale to nonsense size.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9442