### PR TITLE
fix/9434-crash-when-export

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/UIImage+QRCode.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UIImage+QRCode.swift
@@ -10,7 +10,7 @@ extension UIImage {
 		with string: String,
 		encoding: String.Encoding = .shiftJIS,
 		size: CGSize = CGSize(width: 400, height: 400),
-		scale: CGFloat = UIScreen.main.scale,
+		scale: CGFloat,
 		qrCodeErrorCorrectionLevel: MappedErrorCorrectionType = .medium
 	) -> UIImage? {
 		/// Create data from string which will be feed into the CoreImage Filter

--- a/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/QRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/QRCodeCellViewModel.swift
@@ -30,7 +30,7 @@ struct QRCodeCellViewModel {
 			with: vCardV4(revDate: revDate),
 			encoding: .utf8,
 			size: CGSize(width: 280.0, height: 280.0),
-			scale: 1,
+			scale: UIScreen.main.scale,
 			qrCodeErrorCorrectionLevel: .medium
 		)
 		else {

--- a/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/QRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/QRCodeCellViewModel.swift
@@ -30,6 +30,7 @@ struct QRCodeCellViewModel {
 			with: vCardV4(revDate: revDate),
 			encoding: .utf8,
 			size: CGSize(width: 280.0, height: 280.0),
+			scale: 1,
 			qrCodeErrorCorrectionLevel: .medium
 		)
 		else {

--- a/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/__tests__/QRCodeCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/Cells/__tests__/QRCodeCellViewModelTests.swift
@@ -31,6 +31,7 @@ class QRCodeCellViewModelTests: CWATestCase {
 			with: viewModel.vCardV4(revDate: revDate),
 			encoding: .utf8,
 			size: CGSize(width: 280.0, height: 280.0),
+			scale: UIScreen.main.scale,
 			qrCodeErrorCorrectionLevel: .medium
 		))
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
@@ -45,6 +45,7 @@ struct HealthCertificateQRCodeViewModel {
 			with: qrCodeString,
 			encoding: .utf8,
 			size: CGSize(width: qrCodeSize, height: qrCodeSize),
+			scale: UIScreen.main.scale,
 			qrCodeErrorCorrectionLevel: .medium
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -522,7 +522,10 @@ final class HealthCertificatesCoordinator {
 			onTapPrintPdf: printPdf,
 			onTapExportPdf: exportPdf
 		)
-		printNavigationController.pushViewController(healthCertificatePDFVersionViewController, animated: true)
+		// The call of showPdfGenerationResult is made possibly in the background while generating the pdfDocument
+		DispatchQueue.main.async { [weak self] in
+			self?.printNavigationController.pushViewController(healthCertificatePDFVersionViewController, animated: true)
+		}
 	}
 	
 	private func printPdf(

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
@@ -32,7 +32,8 @@ class HealthCertificatePDFVersionViewController: DynamicTableViewController, UIA
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		
-		let pdfView = PDFView()
+		// Avoid assertion when init with non-zero scale.
+		let pdfView = PDFView(frame: .init(x: 0, y: 0, width: 1, height: 1))
 
 		pdfView.document = viewModel.pdfDocument
 		pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/HealthCertificate+PDF/HealthCertificate+PDF.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/HealthCertificate+PDF/HealthCertificate+PDF.swift
@@ -25,6 +25,7 @@ extension HealthCertificate {
 			with: base45,
 			encoding: .utf8,
 			size: CGSize(width: 150, height: 150),
+			scale: 1,
 			qrCodeErrorCorrectionLevel: .medium
 		) else {
 			throw PDFGenerationError.qrCodeCreationFailed


### PR DESCRIPTION
## Description
When traversing between the consent and the generated certificate screens, there may occur in some cases a crash. This happens because we generate the pdf async and push the view controller when we receive the result. This leads to non-UIThread-call and the app crashes.

I also noticed a console assert that we init the PDFView with nothing, we should avoid this.

I also removed after discussion of #3526 the default value of the scale factor in our function to generate the qrImage so that every dev has to think about the property he is passing into.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9434
