### PR TITLE
Fix Certificate printing in iOS 12

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/CGPDFDocument+EmbedImage.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/CGPDFDocument+EmbedImage.swift
@@ -128,7 +128,7 @@ extension CGPDFDocument {
 		// End the PDF context, essentially closing the PDF document context.
 		UIGraphicsEndPDFContext()
 		
-		// Somehow iOS 12 does not like initialising 'PDFDocument' directly from data so we have to safe the data to disk just to read it again into PDFDocument
+		// Somehow iOS 12 does not like initialising 'PDFDocument' directly from data so we have to save the data to disk just to read it again into a PDFDocument
 		let temporaryDirectoryURL = URL(
 			fileURLWithPath: NSTemporaryDirectory(),
 			isDirectory: true

--- a/src/xcode/ENA/ENA/Source/Extensions/CGPDFDocument+EmbedImage.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/CGPDFDocument+EmbedImage.swift
@@ -127,12 +127,29 @@ extension CGPDFDocument {
 
 		// End the PDF context, essentially closing the PDF document context.
 		UIGraphicsEndPDFContext()
-
-		guard let pdfDocument = PDFDocument(data: Data(data)) else {
+		
+		// Somehow iOS 12 does not like initialising 'PDFDocument' directly from data so we have to safe the data to disk just to read it again into PDFDocument
+		let temporaryDirectoryURL = URL(
+			fileURLWithPath: NSTemporaryDirectory(),
+			isDirectory: true
+		)
+		let temporaryFilename = ProcessInfo().globallyUniqueString
+		let temporaryFileURL = temporaryDirectoryURL.appendingPathComponent(temporaryFilename)
+		
+		do {
+			try data.write(to: temporaryFileURL)
+		} catch {
 			throw PDFEmbeddingError.pdfDocumentCreationFailed
 		}
-
-	   return pdfDocument
+				
+		guard let pdfDocument = PDFDocument(url: temporaryFileURL) else {
+			throw PDFEmbeddingError.pdfDocumentCreationFailed
+		}
+		
+		// Even though we save to a temp folder its nicer to remove the document explicitly
+		try FileManager.default.removeItem(at: temporaryFileURL)
+		
+		return pdfDocument
 	}
 
 }


### PR DESCRIPTION
## Description
Somehow iOS 12 does not like initialising 'PDFDocument' directly from data so we have to safe the data to disk just to read it again into a PDFDocument.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9493

