### PR TITLE
Fix/9638 alert crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesCoordinator.swift
@@ -212,21 +212,24 @@ final class HealthCertificatesCoordinator {
 				self?.viewController.dismiss(animated: true)
 			},
 			didTapValidationButton: { [weak self] healthCertificate, setLoadingState in
+				guard let self = self else { return }
+
 				setLoadingState(true)
 
-				self?.healthCertificateValidationOnboardedCountriesProvider.onboardedCountries { result in
+				self.healthCertificateValidationOnboardedCountriesProvider.onboardedCountries { result in
 					setLoadingState(false)
 
 					switch result {
 					case .success(let countries):
-						self?.showValidationFlow(
+						self.showValidationFlow(
 							healthCertificate: healthCertificate,
 							countries: countries
 						)
 					case .failure(let error):
-						self?.showErrorAlert(
+						self.showErrorAlert(
 							title: AppStrings.HealthCertificate.Validation.Error.title,
-							error: error
+							error: error,
+							from: self.modalNavigationController
 						)
 					}
 				}
@@ -291,23 +294,26 @@ final class HealthCertificatesCoordinator {
 				self?.viewController.dismiss(animated: true)
 			},
 			didTapValidationButton: { [weak self] in
+				guard let self = self else { return }
+
 				footerViewModel.setLoadingIndicator(true, disable: true, button: .primary)
 				footerViewModel.setLoadingIndicator(false, disable: true, button: .secondary)
 
-				self?.healthCertificateValidationOnboardedCountriesProvider.onboardedCountries { result in
+				self.healthCertificateValidationOnboardedCountriesProvider.onboardedCountries { result in
 					footerViewModel.setLoadingIndicator(false, disable: false, button: .primary)
 					footerViewModel.setLoadingIndicator(false, disable: false, button: .secondary)
 
 					switch result {
 					case .success(let countries):
-						self?.showValidationFlow(
+						self.showValidationFlow(
 							healthCertificate: healthCertificate,
 							countries: countries
 						)
 					case .failure(let error):
-						self?.showErrorAlert(
+						self.showErrorAlert(
 							title: AppStrings.HealthCertificate.Validation.Error.title,
-							error: error
+							error: error,
+							from: self.modalNavigationController
 						)
 					}
 				}
@@ -478,9 +484,12 @@ final class HealthCertificatesCoordinator {
 				self?.modalNavigationController.dismiss(animated: true)
 			},
 			showErrorAlert: { [weak self] error in
-				self?.showErrorAlert(
+				guard let self = self else { return }
+
+				self.showErrorAlert(
 					title: AppStrings.HealthCertificate.PrintPDF.ErrorAlert.fetchValueSets.title,
-					error: error
+					error: error,
+					from: self.printNavigationController
 				)
 			}
 		)
@@ -545,7 +554,8 @@ final class HealthCertificatesCoordinator {
 
 	private func showErrorAlert(
 		title: String,
-		error: Error
+		error: Error,
+		from presentingViewController: UIViewController
 	) {
 		let alert = UIAlertController(
 			title: title,
@@ -561,16 +571,8 @@ final class HealthCertificatesCoordinator {
 			}
 		)
 		alert.addAction(okayAction)
-		DispatchQueue.main.async { [weak self] in
-			guard let self = self else {
-				fatalError("Could not create strong self")
-			}
-			
-			if self.modalNavigationController.isBeingPresented {
-				self.modalNavigationController.present(alert, animated: true, completion: nil)
-			} else {
-				self.printNavigationController.present(alert, animated: true, completion: nil)
-			}
+		DispatchQueue.main.async {
+			presentingViewController.present(alert, animated: true)
 		}
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFGenerationInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFGenerationInfoViewController.swift
@@ -70,18 +70,19 @@ class HealthCertificatePDFGenerationInfoViewController: DynamicTableViewControll
 
 	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		if type == .primary {
-			self.footerView?.setLoadingIndicator(true, disable: true, button: .primary)
-			
-			DispatchQueue.main.async { [weak self] in
-				self?.viewModel.generatePDFData(completion: { result in
+			footerView?.setLoadingIndicator(true, disable: true, button: .primary)
+
+			viewModel.generatePDFData { result in
+				DispatchQueue.main.async { [weak self] in
 					self?.footerView?.setLoadingIndicator(false, disable: false, button: .primary)
+
 					switch result {
 					case let .success(pdfDocument):
 						self?.onTapContinue(pdfDocument)
 					case let .failure(error):
 						self?.showErrorAlert(error)
 					}
-				})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Fixes a crash that occurred if the validity of a certificate was checked while the device is offline. The alert was attempted to be presented on the wrong view controller. Fixed it by explicitly injecting the correct one.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9638

## Screenshots
![IMG_EBC80B637DC4-1](https://user-images.githubusercontent.com/1157991/134657562-7ee1b782-31b4-49d3-a152-ca8c63b34541.jpeg)