### PR TITLE
Add year and copyright holder to MIT license (Fixes #2413) (COMMUNITY)

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) 2020-2021 SAP SE or an SAP affiliate company
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description
This PR adds missing information to the MIT license file.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6343

---

**Closes #2413**