### PR TITLE
Fix/9656 crash on second test registration

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -210,8 +210,6 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 		self.navigationController?.popViewController(animated: true)
 	}
 
-	private var subscriptions = [AnyCancellable]()
-
 	// MARK: Start
 
 	private func start(with initialViewController: UIViewController) {

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
@@ -188,21 +188,6 @@ class HomeCoordinator: RequiresAppDependencies {
 	private var subscriptions = Set<AnyCancellable>()
 
 	private weak var delegate: CoordinatorDelegate?
-	
-	private (set) lazy var exposureSubmissionCoordinator: ExposureSubmissionCoordinator = {
-		ExposureSubmissionCoordinator(
-			parentViewController: rootViewController,
-			exposureSubmissionService: exposureSubmissionService,
-			coronaTestService: coronaTestService,
-			healthCertificateService: healthCertificateService,
-			healthCertificateValidationService: healthCertificateValidationService,
-			eventProvider: eventStore,
-			antigenTestProfileStore: store,
-			vaccinationValueSetsProvider: vaccinationValueSetsProvider,
-			healthCertificateValidationOnboardedCountriesProvider: healthCertificateValidationOnboardedCountriesProvider,
-			qrScannerCoordinator: qrScannerCoordinator
-		)
-	}()
 	   
 	private lazy var statisticsProvider: StatisticsProvider = {
 			#if DEBUG
@@ -326,7 +311,19 @@ class HomeCoordinator: RequiresAppDependencies {
 		// A strong reference to the coordinator is passed to the exposure submission navigation controller
 		// when .start() is called. The coordinator is then bound to the lifecycle of this navigation controller
 		// which is managed by UIKit.
-		let coordinator = exposureSubmissionCoordinator
+		let coordinator = ExposureSubmissionCoordinator(
+			parentViewController: rootViewController,
+			exposureSubmissionService: exposureSubmissionService,
+			coronaTestService: coronaTestService,
+			healthCertificateService: healthCertificateService,
+			healthCertificateValidationService: healthCertificateValidationService,
+			eventProvider: eventStore,
+			antigenTestProfileStore: store,
+			vaccinationValueSetsProvider: vaccinationValueSetsProvider,
+			healthCertificateValidationOnboardedCountriesProvider: healthCertificateValidationOnboardedCountriesProvider,
+			qrScannerCoordinator: qrScannerCoordinator
+		)
+
 		if let testInformationResult = testInformationResult {
 			coordinator.start(with: testInformationResult)
 		} else {

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
@@ -79,7 +79,7 @@ class QRScannerCoordinator {
 	private let coronaTestService: CoronaTestService
 	
 	private var presenter: QRScannerPresenter!
-	private var parentViewController: UIViewController!
+	private weak var parentViewController: UIViewController?
 	private var healthCertificateCoordinator: HealthCertificateCoordinator?
 	private var traceLocationCheckinCoordinator: TraceLocationCheckinCoordinator?
 	private var exposureSubmissionCoordinator: ExposureSubmissionCoordinator?
@@ -96,7 +96,7 @@ class QRScannerCoordinator {
 			markCertificateAsNew: markCertificateAsNew,
 			markCoronaTestAsNew: markCoronaTestAsNew,
 			didScan: { [weak self] qrCodeResult in
-				self?.parentViewController.dismiss(animated: true, completion: {
+				self?.parentViewController?.dismiss(animated: true, completion: {
 					switch qrCodeResult {
 					case let .coronaTest(testRegistrationInformation):
 						self?.showScannedTestResult(testRegistrationInformation)
@@ -108,7 +108,7 @@ class QRScannerCoordinator {
 				})
 			},
 			dismiss: { [weak self] in
-				self?.parentViewController.dismiss(animated: true)
+				self?.parentViewController?.dismiss(animated: true)
 				didDismiss()
 			}
 		)
@@ -118,6 +118,10 @@ class QRScannerCoordinator {
 	private func showScannedTestResult(
 		_ testRegistrationInformation: CoronaTestRegistrationInformation
 	) {
+		guard let parentViewController = parentViewController else {
+			return
+		}
+
 		switch presenter {
 		case .submissionFlow:
 			didScanCoronaTestInSubmissionFlow?(testRegistrationInformation)
@@ -128,7 +132,7 @@ class QRScannerCoordinator {
 				self.parentViewController = parentPresentingViewController
 
 				self.exposureSubmissionCoordinator = ExposureSubmissionCoordinator(
-					parentViewController: self.parentViewController,
+					parentViewController: parentViewController,
 					exposureSubmissionService: self.exposureSubmissionService,
 					coronaTestService: self.coronaTestService,
 					healthCertificateService: self.healthCertificateService,
@@ -166,6 +170,10 @@ class QRScannerCoordinator {
 		for person: HealthCertifiedPerson,
 		with certificate: HealthCertificate
 	) {
+		guard let parentViewController = parentViewController else {
+			return
+		}
+
 		switch presenter {
 		case .submissionFlow, .onBehalfFlow:
 			let parentPresentingViewController = parentViewController.presentingViewController
@@ -174,7 +182,7 @@ class QRScannerCoordinator {
 				self.parentViewController = parentPresentingViewController
 
 				self.healthCertificateCoordinator = HealthCertificateCoordinator(
-					parentingViewController: .present(self.parentViewController),
+					parentingViewController: .present(parentViewController),
 					healthCertifiedPerson: person,
 					healthCertificate: certificate,
 					store: self.store,
@@ -209,6 +217,10 @@ class QRScannerCoordinator {
 	private func showScannedCheckin(
 		_ traceLocation: TraceLocation
 	) {
+		guard let parentViewController = parentViewController else {
+			return
+		}
+
 		switch presenter {
 		case .onBehalfFlow:
 			didScanTraceLocationInOnBehalfFlow?(traceLocation)
@@ -219,7 +231,7 @@ class QRScannerCoordinator {
 				self.parentViewController = parentPresentingViewController
 
 				self.traceLocationCheckinCoordinator = TraceLocationCheckinCoordinator(
-					parentViewController: self.parentViewController,
+					parentViewController: parentViewController,
 					traceLocation: traceLocation,
 					store: self.store,
 					eventStore: self.eventStore,

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
@@ -82,7 +82,6 @@ class QRScannerCoordinator {
 	private weak var parentViewController: UIViewController?
 	private var healthCertificateCoordinator: HealthCertificateCoordinator?
 	private var traceLocationCheckinCoordinator: TraceLocationCheckinCoordinator?
-	private var exposureSubmissionCoordinator: ExposureSubmissionCoordinator?
 	private var onBehalfCheckinCoordinator: OnBehalfCheckinSubmissionCoordinator?
 	
 	private func qrScannerViewController(
@@ -131,7 +130,7 @@ class QRScannerCoordinator {
 			parentViewController.dismiss(animated: true) {
 				self.parentViewController = parentPresentingViewController
 
-				self.exposureSubmissionCoordinator = ExposureSubmissionCoordinator(
+				let exposureSubmissionCoordinator = ExposureSubmissionCoordinator(
 					parentViewController: parentViewController,
 					exposureSubmissionService: self.exposureSubmissionService,
 					coronaTestService: self.coronaTestService,
@@ -144,10 +143,10 @@ class QRScannerCoordinator {
 					qrScannerCoordinator: self
 				)
 
-				self.exposureSubmissionCoordinator?.start(with: .success(testRegistrationInformation), markNewlyAddedCoronaTestAsUnseen: true)
+				exposureSubmissionCoordinator.start(with: .success(testRegistrationInformation), markNewlyAddedCoronaTestAsUnseen: true)
 			}
 		case .checkinTab, .certificateTab:
-			exposureSubmissionCoordinator = ExposureSubmissionCoordinator(
+			let exposureSubmissionCoordinator = ExposureSubmissionCoordinator(
 				parentViewController: parentViewController,
 				exposureSubmissionService: exposureSubmissionService,
 				coronaTestService: coronaTestService,
@@ -160,7 +159,7 @@ class QRScannerCoordinator {
 				qrScannerCoordinator: self
 			)
 
-			exposureSubmissionCoordinator?.start(with: .success(testRegistrationInformation), markNewlyAddedCoronaTestAsUnseen: true)
+			exposureSubmissionCoordinator.start(with: .success(testRegistrationInformation), markNewlyAddedCoronaTestAsUnseen: true)
 		case .none:
 			break
 		}


### PR DESCRIPTION
## Description
Fixes a crash that occurred because we reused the same exposure submission coordinator instead of creating a new instance with the correct initial state. Also reduces the amount of strong references to the previous coordinator so it can be removed from memory as it should only be held by the exposure submission navigation controller as long as it is presented.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9656
