### PR TITLE
chore/9599 cleanup remaining navigation items for Exposure Submission

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionCheckins/ExposureSubmissionCheckinsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionCheckins/ExposureSubmissionCheckinsViewController.swift
@@ -27,9 +27,9 @@ class ExposureSubmissionCheckinsViewController: UITableViewController, DismissHa
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		
-		parent?.title = viewModel.title
-		parent?.navigationItem.hidesBackButton = true
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		title = viewModel.title
+		navigationItem.hidesBackButton = true
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 		
 		tableView.separatorStyle = .none
 		tableView.backgroundColor = .enaColor(for: .background)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionSymptomsOnsetViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionSymptomsOnsetViewController.swift
@@ -41,7 +41,7 @@ class ExposureSubmissionSymptomsOnsetViewController: DynamicTableViewController,
 		onPrimaryButtonTap(selectedSymptomsOnsetSelectionOption) { [weak self] isLoading in
 			DispatchQueue.main.async {
 				self?.view.isUserInteractionEnabled = !isLoading
-				self?.parent?.navigationItem.rightBarButtonItem?.isEnabled = !isLoading
+				self?.navigationItem.rightBarButtonItem?.isEnabled = !isLoading
 				self?.footerView?.setLoadingIndicator(isLoading, disable: isLoading, button: .primary)
 			}
 		}
@@ -102,8 +102,8 @@ class ExposureSubmissionSymptomsOnsetViewController: DynamicTableViewController,
 	private func setupView() {
 		view.backgroundColor = .enaColor(for: .background)
 		
-		parent?.navigationItem.title = AppStrings.ExposureSubmissionSymptomsOnset.title
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		navigationItem.title = AppStrings.ExposureSubmissionSymptomsOnset.title
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 		
 		setupTableView()
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionSymptomsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionSymptomsViewController.swift
@@ -110,8 +110,8 @@ final class ExposureSubmissionSymptomsViewController: DynamicTableViewController
 
 	private func setupView() {
 
-		parent?.navigationItem.title = AppStrings.ExposureSubmissionSymptoms.title
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		navigationItem.title = AppStrings.ExposureSubmissionSymptoms.title
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 		
 		view.backgroundColor = .enaColor(for: .background)
 
@@ -193,7 +193,7 @@ final class ExposureSubmissionSymptomsViewController: DynamicTableViewController
 
 	private func updateForLoadingState(isLoading: Bool) {
 		view.isUserInteractionEnabled = !isLoading
-		parent?.navigationItem.rightBarButtonItem?.isEnabled = !isLoading
+		navigationItem.rightBarButtonItem?.isEnabled = !isLoading
 		footerView?.setLoadingIndicator(isLoading, disable: isLoading, button: .primary)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
@@ -86,10 +86,10 @@ class ExposureSubmissionTestResultViewController: DynamicTableViewController, Fo
 
 	private func setUpView() {
 		
-		parent?.navigationItem.title = viewModel.title
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
-		parent?.navigationItem.hidesBackButton = true
-		parent?.navigationItem.largeTitleDisplayMode = .always
+		navigationItem.title = viewModel.title
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		navigationItem.hidesBackButton = true
+		navigationItem.largeTitleDisplayMode = .always
 		
 		view.backgroundColor = .enaColor(for: .background)
 
@@ -97,9 +97,9 @@ class ExposureSubmissionTestResultViewController: DynamicTableViewController, Fo
 	}
 
 	private func setUpNavigationBarAppearance() {
-		parent?.navigationController?.navigationBar.backgroundView?.backgroundColor = .enaColor(for: .background)
-		parent?.navigationController?.navigationBar.prefersLargeTitles = true
-		parent?.navigationItem.largeTitleDisplayMode = .always
+		navigationController?.navigationBar.backgroundView?.backgroundColor = .enaColor(for: .background)
+		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationItem.largeTitleDisplayMode = .always
 	}
 	
 	private func setUpDynamicTableView() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionThankYouViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionThankYouViewController.swift
@@ -62,9 +62,9 @@ class ExposureSubmissionThankYouViewController: DynamicTableViewController, Foot
 	
 	private func setupView() {
 		
-		parent?.navigationItem.title = AppStrings.ThankYouScreen.title
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
-		parent?.navigationItem.hidesBackButton = true
+		navigationItem.title = AppStrings.ThankYouScreen.title
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		navigationItem.hidesBackButton = true
 		
 		view.backgroundColor = .enaColor(for: .background)
 		

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionWarnOthersViewController.swift
@@ -56,9 +56,9 @@ class ExposureSubmissionWarnOthersViewController: DynamicTableViewController, Fo
 	private let dismiss: () -> Void
 
 	private func setupView() {
-		parent?.navigationItem.title = AppStrings.ExposureSubmissionWarnOthers.title
-		parent?.navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
-		parent?.navigationItem.hidesBackButton = true
+		navigationItem.title = AppStrings.ExposureSubmissionWarnOthers.title
+		navigationItem.rightBarButtonItem = CloseBarButtonItem(onTap: dismiss)
+		navigationItem.hidesBackButton = true
 				
 		view.backgroundColor = .enaColor(for: .background)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TestResultAvailable/TestResultAvailableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TestResultAvailable/TestResultAvailableViewController.swift
@@ -26,9 +26,9 @@ final class TestResultAvailableViewController: DynamicTableViewController, Foote
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		
-		parent?.navigationItem.hidesBackButton = true
-		parent?.navigationItem.title = AppStrings.ExposureSubmissionTestResultAvailable.title
-		parent?.navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
+		navigationItem.hidesBackButton = true
+		navigationItem.title = AppStrings.ExposureSubmissionTestResultAvailable.title
+		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 
 		setupTableView()
 		setupViewModel()

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NotificationRework/DeltaOnboardingNotificationReworkViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NotificationRework/DeltaOnboardingNotificationReworkViewController.swift
@@ -87,7 +87,7 @@ final class DeltaOnboardingNotificationReworkViewController: DynamicTableViewCon
 		navigationFooterItem?.secondaryButtonTitle = AppStrings.NotificationSettings.DeltaOnboarding.primaryButtonTitle
 		footerView?.secondaryButton?.accessibilityIdentifier = AccessibilityIdentifiers.NotificationSettings.close
 		
-		navigationController?.navigationItem.largeTitleDisplayMode = .always
+		navigationItem.largeTitleDisplayMode = .always
 		navigationController?.navigationBar.prefersLargeTitles = true
 		
 		setupTableView()


### PR DESCRIPTION
## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR is the cleanup of the usage of the remaining navigation items for exposure submission, as suggested in #3547.
Finally the last one :-)

## Link to Jira
<!-- Please add the link to the related Jira issue -->
Jira: Internal Tracking ID: [EXPOSUREAPP-9599](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9599)

github: #3547

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
Sorry - no screenshots this time *(actually, I don't know how to test these screens of the exposure submission flow ...)*

---
Internal Tracking ID: [EXPOSUREAPP-9599](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9599)