### PR TITLE
Fix/#9824 settings out of sync

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/Settings/SettingsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/Settings/SettingsViewController.swift
@@ -256,8 +256,7 @@ final class SettingsViewController: UITableViewController, ExposureStateUpdating
 		currentCenter.getNotificationSettings { [weak self] settings in
 			guard let self = self else { return }
 
-			if (settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional)
-				&& (self.store.allowRiskChangesNotification || self.store.allowTestsStatusNotification) {
+			if settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional {
 				self.settingsViewModel.notifications.setState(state: true)
 			} else {
 				self.settingsViewModel.notifications.setState(state: false)

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -25,8 +25,6 @@ final class MockTestStore: Store, PPAnalyticsData {
 	var developerSubmissionBaseURLOverride: String?
 	var developerDistributionBaseURLOverride: String?
 	var developerVerificationBaseURLOverride: String?
-	var allowRiskChangesNotification: Bool = true
-	var allowTestsStatusNotification: Bool = true
 	var appInstallationDate: Date? = Date()
 	var userNeedsToBeInformedAboutHowRiskDetectionWorks = false
 	var shouldShowQRScannerTooltip = false

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -101,16 +101,6 @@ final class SecureStore: Store, AntigenTestProfileStoring {
 		set { kvStore["developerVerificationBaseURLOverride"] = newValue }
 	}
 
-	var allowRiskChangesNotification: Bool {
-		get { kvStore["allowRiskChangesNotification"] as Bool? ?? true }
-		set { kvStore["allowRiskChangesNotification"] = newValue }
-	}
-
-	var allowTestsStatusNotification: Bool {
-		get { kvStore["allowTestsStatusNotification"] as Bool? ?? true }
-		set { kvStore["allowTestsStatusNotification"] = newValue }
-	}
-
 	var appInstallationDate: Date? {
 		get { kvStore["appInstallationDate"] as Date? }
 		set { kvStore["appInstallationDate"] = newValue }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -16,9 +16,6 @@ protocol StoreProtocol: AnyObject {
 	var developerDistributionBaseURLOverride: String? { get set }
 	var developerVerificationBaseURLOverride: String? { get set }
 
-	var allowRiskChangesNotification: Bool { get set }
-	var allowTestsStatusNotification: Bool { get set }
-
 	var appInstallationDate: Date? { get set }
 
 	/// A boolean flag that indicates whether the user has seen the background fetch disabled alert.

--- a/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/__tests__/StoreTests.swift
@@ -61,8 +61,6 @@ final class StoreTests: CWATestCase {
 
 		XCTAssertTrue(tmpStore.isOnboarded)
 		XCTAssertEqual(tmpStore.dateOfAcceptedPrivacyNotice?.description, testDate1.description)
-		XCTAssertTrue(tmpStore.allowRiskChangesNotification)
-		XCTAssertTrue(tmpStore.allowTestsStatusNotification)
 		XCTAssertEqual(tmpStore.exposureActivationConsentAcceptTimestamp, testTimeStamp)
 		XCTAssertTrue(tmpStore.exposureActivationConsentAccept)
 	}
@@ -84,12 +82,6 @@ final class StoreTests: CWATestCase {
 		let isOnboarded = store.isOnboarded
 		store.isOnboarded.toggle()
 		XCTAssertNotEqual(isOnboarded, store.isOnboarded)
-
-		let allowRiskChangesNotification = store.allowRiskChangesNotification
-		store.allowRiskChangesNotification.toggle()
-		XCTAssertNotEqual(allowRiskChangesNotification, store.allowRiskChangesNotification)
-
-		// etc.
 	}
 
 	func testBackupRestoration() throws {


### PR DESCRIPTION
## Description
This fixes the settings overview, which was not in sync with the system settings set for the notifications because we had the two old flags in the sync condition.
I removed then the two old notification flags from our code and replaces where necessary with the system's flag for notifications.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9824
