### PR TITLE
make onboardings more independent of flaky system settings jump.

### DIFF
--- a/src/xcode/ENA/ENAUITests/DeltaOnboarding/ENAUITests_06_DeltaOnboarding.swift
+++ b/src/xcode/ENA/ENAUITests/DeltaOnboarding/ENAUITests_06_DeltaOnboarding.swift
@@ -32,7 +32,7 @@ class ENAUITests_06_DeltaOnboarding: CWATestCase {
 		app.launch()
 		
 		checkNewFeaturesScreen()
-		checkNotificationReworkScreen()
+		skipNotificationReworkScreen()
 		checkCrossCountrySupport()
 		checkDataDonationScreen()
 		
@@ -94,7 +94,7 @@ class ENAUITests_06_DeltaOnboarding: CWATestCase {
 		app.launch()
 		
 		checkNewFeaturesScreen()
-		checkNotificationReworkScreen()
+		skipNotificationReworkScreen()
 		
 		var screenshotCounter = 0
 		let screenshotLabel = "deltaOnboarding_V15"
@@ -160,9 +160,14 @@ class ENAUITests_06_DeltaOnboarding: CWATestCase {
 	
 	func checkNewFeaturesScreen() {
 		XCTAssertTrue(app.tables.images[AccessibilityIdentifiers.DeltaOnboarding.newVersionFeaturesAccImageDescription].waitForExistence(timeout: .medium))
-		
 		// leave screen
 		app.buttons[AccessibilityIdentifiers.General.primaryFooterButton].waitAndTap()
+	}
+	
+	private func skipNotificationReworkScreen() {
+		XCTAssertTrue(app.tables.images[AccessibilityIdentifiers.NotificationSettings.DeltaOnboarding.imageOn].waitForExistence(timeout: .short))
+		// leave screen
+		app.buttons[AccessibilityIdentifiers.NotificationSettings.close].waitAndTap()
 	}
 	
 	private func checkNotificationReworkScreen() {


### PR DESCRIPTION
## Description
This a quick fix to get our tests more stable: By skipping the part of jumping out of the app, we make 2 tests more stable. This real test for jumping out of the app still remains in one test, but with that solution, we reduce the flakiness from 3 to 1 test.