### PR TITLE
Fix failing UITest for Edit Antigen Test Profile

### DIFF
--- a/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
+++ b/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
@@ -150,9 +150,15 @@ class ENAUITests_12_AntigenTestProfile: CWATestCase {
 		snapshot("antigentestprofile_screenshot_edit_actions")
 
 		/// Edit Antigen Test Profile Screen
-
-		let editTestProfileAction = try XCTUnwrap(app.sheets.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Profile.editAction])
-		editTestProfileAction.waitAndTap(.extraLong)
+		
+		let editTitle: String
+		if Locale.current.identifier == Locale(identifier: "de_DE").identifier {
+			editTitle = "Schnelltest-Profil bearbeiten"
+		} else {
+			editTitle = "Edit Rapid Test Profile"
+		}
+		let editTestProfileAction = try XCTUnwrap(app.sheets.buttons[editTitle])
+		editTestProfileAction.waitAndTap()
 
 		let editSaveProfileButton = try XCTUnwrap(app.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Create.saveButton])
 		XCTAssertTrue(editSaveProfileButton.waitForExistence(timeout: .short))
@@ -175,7 +181,13 @@ class ENAUITests_12_AntigenTestProfile: CWATestCase {
 		editTestProfileButton = try XCTUnwrap(app.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Profile.editButton])
 		editTestProfileButton.waitAndTap()
 
-		let deleteTestProfileButton = try XCTUnwrap(app.sheets.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Profile.deleteAction])
+		let deleteTitle: String
+		if Locale.current.identifier == Locale(identifier: "de_DE").identifier {
+			deleteTitle = "Schnelltest-Profil entfernen"
+		} else {
+			deleteTitle = "Delete Rapid Test Profile"
+		}
+		let deleteTestProfileButton = try XCTUnwrap(app.sheets.buttons[deleteTitle])
 		deleteTestProfileButton.waitAndTap()
 
 		// confirm deletion on popup

--- a/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
+++ b/src/xcode/ENA/ENAUITests/AntigenTestProfile/ENAUITests_12_AntigenTestProfile.swift
@@ -150,14 +150,7 @@ class ENAUITests_12_AntigenTestProfile: CWATestCase {
 		snapshot("antigentestprofile_screenshot_edit_actions")
 
 		/// Edit Antigen Test Profile Screen
-		
-		let editTitle: String
-		if Locale.current.identifier == Locale(identifier: "de_DE").identifier {
-			editTitle = "Schnelltest-Profil bearbeiten"
-		} else {
-			editTitle = "Edit Rapid Test Profile"
-		}
-		let editTestProfileAction = try XCTUnwrap(app.sheets.buttons[editTitle])
+				let editTestProfileAction = try XCTUnwrap(app.sheets.buttons[AccessibilityLabels.localized(AppStrings.AntigenProfile.Profile.editActionTitle)])
 		editTestProfileAction.waitAndTap()
 
 		let editSaveProfileButton = try XCTUnwrap(app.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Create.saveButton])
@@ -180,14 +173,7 @@ class ENAUITests_12_AntigenTestProfile: CWATestCase {
 		// edit profile button exists
 		editTestProfileButton = try XCTUnwrap(app.buttons[AccessibilityIdentifiers.ExposureSubmission.AntigenTest.Profile.editButton])
 		editTestProfileButton.waitAndTap()
-
-		let deleteTitle: String
-		if Locale.current.identifier == Locale(identifier: "de_DE").identifier {
-			deleteTitle = "Schnelltest-Profil entfernen"
-		} else {
-			deleteTitle = "Delete Rapid Test Profile"
-		}
-		let deleteTestProfileButton = try XCTUnwrap(app.sheets.buttons[deleteTitle])
+		let deleteTestProfileButton = try XCTUnwrap(app.sheets.buttons[AccessibilityLabels.localized(AppStrings.AntigenProfile.Profile.deleteActionTitle)])
 		deleteTestProfileButton.waitAndTap()
 
 		// confirm deletion on popup

--- a/src/xcode/ENA/TestPlans/AllTests.xctestplan
+++ b/src/xcode/ENA/TestPlans/AllTests.xctestplan
@@ -137,8 +137,6 @@
         "ENAUITests_09_TraceLocations\/test_screenshots_of_traceLocation_print_flow()",
         "ENAUITests_10_CheckIns\/test_screenshot_WHEN_scan_QRCode_THEN_checkin_and_checkout()",
         "ENAUITests_11_QuickActions\/testLaunchViaShortcutFromFreshInstall()",
-        "ENAUITests_12_AntigenTestProfile",
-        "ENAUITests_12_AntigenTestProfile\/test_screenshot_FIRST_CreateAntigenTestProfile_THEN_EditProfile_THEN_DeleteProfile()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CompleteVaccinationProtectionWithTestCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithFirstCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithLastCertificate()",

--- a/src/xcode/ENA/TestPlans/Screenshots.xctestplan
+++ b/src/xcode/ENA/TestPlans/Screenshots.xctestplan
@@ -72,6 +72,7 @@
         "ENAUITests_09_TraceLocations\/test_screenshots_of_traceLocation_print_flow()",
         "ENAUITests_10_CheckIns\/test_screenshot_WHEN_scan_QRCode_THEN_checkin_and_checkout()",
         "ENAUITests_12_AntigenTestProfile\/test_FIRST_CreateAntigenTestProfile_THEN_EditProfile_THEN_DeleteProfile()",
+        "ENAUITests_12_AntigenTestProfile\/test_screenshot_FIRST_CreateAntigenTestProfile_THEN_EditProfile_THEN_DeleteProfile()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CompleteVaccinationProtectionWithTestCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithFirstCertificate()",
         "ENAUITests_13_CreateHealthCertificate\/test_screenshot_CreateAntigenTestProfileWithLastCertificate()",


### PR DESCRIPTION
## Description
Temporary fix for the failed UITest and screenshot

For some reason the accessibility identifier cannot be reached or even the localized string to find the correct button to tap, it can only be fetched by it's localized title.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9739

