### PR TITLE
Fix/8478 align height of the images of emptyStateView

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -38,6 +38,7 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 
 		setupSegmentedControl()
 		setupTableView()
+		tableView.reloadData()
 
 		viewModel.$day
 			.sink { [weak self] _ in
@@ -262,7 +263,15 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 			}
 		}
 		
-        tableView.backgroundView = viewModel.entriesOfSelectedType.isEmpty ? EmptyStateView(viewModel: DiaryDayEmptyStateViewModel(entryType: viewModel.selectedEntryType)) : nil
+		// Since we set the empty state view as a background view we need to push it below the add cell by
+		// adding top padding for the height of the add cell …
+		let additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
+		tableView.backgroundView = viewModel.entriesOfSelectedType.isEmpty
+			? EmptyStateView(
+				viewModel: DiaryDayEmptyStateViewModel(entryType: viewModel.selectedEntryType),
+				additionalTopPadding: additionalTopPadding
+			  )
+			: nil
 	}
 
 	@IBAction func segmentedControlValueChanged(_ sender: UISegmentedControl) {

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Overview/CheckinsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Overview/CheckinsOverviewViewController.swift
@@ -258,20 +258,20 @@ class CheckinsOverviewViewController: UITableViewController, FooterViewHandling 
 	}
 
 	private func updateEmptyState() {
-		let emptyStateView = EmptyStateView(viewModel: CheckinsOverviewEmptyStateViewModel())
-
 		// Since we set the empty state view as a background view we need to push it below the add cell by
 		// adding top padding for the height of the add cell …
-		emptyStateView.additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
+		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
 		// … + the height of the navigation bar
-		emptyStateView.additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
+		additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
 		// … + the height of the status bar
 		if #available(iOS 13.0, *) {
-			emptyStateView.additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+			additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
 		} else {
-			emptyStateView.additionalTopPadding += UIApplication.shared.statusBarFrame.height
+			additionalTopPadding += UIApplication.shared.statusBarFrame.height
 		}
-		tableView.backgroundView = viewModel.isEmpty ? emptyStateView : nil
+		tableView.backgroundView = viewModel.isEmpty
+			? EmptyStateView(viewModel: CheckinsOverviewEmptyStateViewModel(), additionalTopPadding: additionalTopPadding)
+			: nil
 	}
 
 	@objc

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/OnBehalfCheckinSubmission/TraceLocationSelection/OnBehalfTraceLocationSelectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/OnBehalfCheckinSubmission/TraceLocationSelection/OnBehalfTraceLocationSelectionViewController.swift
@@ -176,23 +176,23 @@ class OnBehalfTraceLocationSelectionViewController: UITableViewController, Dismi
 	}
 
 	private func setUpEmptyState() {
-		let emptyStateView = EmptyStateView(
-			viewModel: OnBehalfTraceLocationSelectionEmptyStateViewModel()
-		)
-
 		// Since we set the empty state view as a background view we need to push it below the add cell by
 		// adding top padding for the description and scan QR code cell
-		emptyStateView.additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 1)).maxY
+		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 1)).maxY
 		// … + the height of the navigation bar
-		emptyStateView.additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
+		additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
 		// … + the height of the status bar
 		if #available(iOS 13.0, *) {
-			emptyStateView.additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+			additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
 		} else {
-			emptyStateView.additionalTopPadding += UIApplication.shared.statusBarFrame.height
+			additionalTopPadding += UIApplication.shared.statusBarFrame.height
 		}
 
-		tableView.backgroundView = viewModel.isEmptyStateVisible ? emptyStateView : nil
+		tableView.backgroundView = viewModel.isEmptyStateVisible
+			? EmptyStateView(viewModel: OnBehalfTraceLocationSelectionEmptyStateViewModel(),
+							 additionalTopPadding: additionalTopPadding
+							)
+			: nil
 	}
 		
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/OnBehalfCheckinSubmission/TraceLocationSelection/OnBehalfTraceLocationSelectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/OnBehalfCheckinSubmission/TraceLocationSelection/OnBehalfTraceLocationSelectionViewController.swift
@@ -37,6 +37,7 @@ class OnBehalfTraceLocationSelectionViewController: UITableViewController, Dismi
 		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 
 		setUpTableView()
+		tableView.reloadData()
 		setUpEmptyState()
 		
 		viewModel.$continueEnabled
@@ -178,9 +179,10 @@ class OnBehalfTraceLocationSelectionViewController: UITableViewController, Dismi
 	private func setUpEmptyState() {
 		// Since we set the empty state view as a background view we need to push it below the add cell by
 		// adding top padding for the description and scan QR code cell
-		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 1)).maxY
+		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
+		additionalTopPadding += tableView.rectForRow(at: IndexPath(row: 0, section: 1)).maxY
 		// … + the height of the navigation bar
-		additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
+		additionalTopPadding += navigationController?.navigationBar.frame.height ?? 0
 		// … + the height of the status bar
 		if #available(iOS 13.0, *) {
 			additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
@@ -189,9 +191,10 @@ class OnBehalfTraceLocationSelectionViewController: UITableViewController, Dismi
 		}
 
 		tableView.backgroundView = viewModel.isEmptyStateVisible
-			? EmptyStateView(viewModel: OnBehalfTraceLocationSelectionEmptyStateViewModel(),
-							 additionalTopPadding: additionalTopPadding
-							)
+			? EmptyStateView(
+				viewModel: OnBehalfTraceLocationSelectionEmptyStateViewModel(),
+				additionalTopPadding: additionalTopPadding
+			  )
 			: nil
 	}
 		

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
@@ -243,21 +243,21 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 	}
 
 	private func updateEmptyState() {
-		let emptyStateView = EmptyStateView(viewModel: TraceLocationsOverviewEmptyStateViewModel())
-
 		// Since we set the empty state view as a background view we need to push it below the add cell by
 		// adding top padding for the height of the add cell …
-		emptyStateView.additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
+		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).maxY
 		// … + the height of the navigation bar
-		emptyStateView.additionalTopPadding += parent?.navigationController?.navigationBar.frame.height ?? 0
+		additionalTopPadding += navigationController?.navigationBar.frame.height ?? 0
 		// … + the height of the status bar
 		if #available(iOS 13.0, *) {
-			emptyStateView.additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+			additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
 		} else {
-			emptyStateView.additionalTopPadding += UIApplication.shared.statusBarFrame.height
+			additionalTopPadding += UIApplication.shared.statusBarFrame.height
 		}
 
-		tableView.backgroundView = viewModel.isEmpty ? emptyStateView : nil
+		tableView.backgroundView = viewModel.isEmpty
+			? EmptyStateView(viewModel: TraceLocationsOverviewEmptyStateViewModel(), additionalTopPadding: additionalTopPadding)
+			: nil
 	}
 
 	@objc

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
@@ -336,19 +336,20 @@ class HealthCertificateOverviewViewController: UITableViewController {
 	}
 	
 	private func updateEmptyState() {
-		let emptyStateView = EmptyStateView(viewModel: HealthCertificateOverviewEmptyStateViewModel())
-
 		// Since we set the empty state view as a background view we need to push it below the add cell by
 		// adding top padding for the height of the add cell …
-		emptyStateView.additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).height
+		var additionalTopPadding = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).height
 		// … + the height of the navigation bar
-		emptyStateView.additionalTopPadding += self.navigationController?.navigationBar.frame.height ?? 0
+		additionalTopPadding += navigationController?.navigationBar.frame.height ?? 0
 		// … + the height of the status bar
 		if #available(iOS 13.0, *) {
-			emptyStateView.additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+			additionalTopPadding += UIApplication.shared.windows.first?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
 		} else {
-			emptyStateView.additionalTopPadding += UIApplication.shared.statusBarFrame.height
+			additionalTopPadding += UIApplication.shared.statusBarFrame.height
 		}
-		tableView.backgroundView = viewModel.isEmpty ? emptyStateView : nil
+
+		tableView.backgroundView = viewModel.isEmpty
+			? EmptyStateView(viewModel: HealthCertificateOverviewEmptyStateViewModel(), additionalTopPadding: additionalTopPadding)
+			: nil
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
@@ -37,11 +37,6 @@ class EmptyStateView: UIView {
 	private func setUp() {
 		backgroundColor = .clear
 
-		let containerView = UIView()
-		containerView.backgroundColor = .clear
-		addSubview(containerView)
-		containerView.translatesAutoresizingMaskIntoConstraints = false
-
 		let stackView = UIStackView()
 		stackView.axis = .vertical
 		stackView.alignment = .center
@@ -76,24 +71,39 @@ class EmptyStateView: UIView {
 		descriptionLabel.text = viewModel.description
 		stackView.addArrangedSubview(descriptionLabel)
 
-		// We take a number for that the image is not too big and not too small and fits for big and small devices for all four occurrences of the EmptyStateView (in CertificatesOverview, CheckinOverview, TraceLocationsOverview, ContactDiaryDay). The result was 3.
+		// We take a number for that the image is not too big and not too small and fits for big and small devices for all five occurrences of the EmptyStateView
+		// (in CertificatesOverview, CheckinOverview, TraceLocationsOverview, ContactDiaryDay, OnBehalfWarning).
+		// The result was 3.
 		let percentageWidth = UIScreen.main.bounds.width / 3
-		
+		let percentageHeight = UIScreen.main.bounds.height / 2
+
+		// layout strategy:
+		// stack view with full width (with a small margin) for effective horizontal centered alignment.
+		// top-aligned (with a small margin) to align the appearance of this view across pages.
+		// the view controller can configure its position with the additionalTopPadding.
+		// multiline text box (descriptionLabel) with width 280.
+		// image: 1/3 of the screen width if possible, but else shrink it to avoid that the layout exceeds the visible page.
 		NSLayoutConstraint.activate([
-			containerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-			containerView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: additionalTopPadding),
-			containerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
-			containerView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
-			stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 280),
-			stackView.leadingAnchor.constraint(greaterThanOrEqualTo: containerView.leadingAnchor, constant: 16),
-			stackView.topAnchor.constraint(greaterThanOrEqualTo: containerView.topAnchor, constant: 16),
-			stackView.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor, constant: -16),
-			stackView.bottomAnchor.constraint(lessThanOrEqualTo: containerView.bottomAnchor, constant: -16),
-			stackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-			stackView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
 			imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor),
-			imageView.widthAnchor.constraint(lessThanOrEqualToConstant: percentageWidth)
+			imageView.widthAnchor.constraint(lessThanOrEqualToConstant: percentageWidth),
+			descriptionLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 280),
+			stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+			stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+			stackView.topAnchor.constraint(equalTo: topAnchor, constant: additionalTopPadding + 16),
+			stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -16)
 		])
+		// break the following constraints in case of conflicts
+		let descriptionWidthConstraint = descriptionLabel.widthAnchor.constraint(equalToConstant: 280)
+		descriptionWidthConstraint.priority = UILayoutPriority(997)
+		descriptionWidthConstraint.isActive = true
+
+		let imageVPosConstraint = imageView.bottomAnchor.constraint(equalTo: topAnchor, constant: percentageHeight)
+		imageVPosConstraint.priority = UILayoutPriority(998)
+		imageVPosConstraint.isActive = true
+
+		let imageSizeConstraint = imageView.widthAnchor.constraint(equalToConstant: percentageWidth)
+		imageSizeConstraint.priority = UILayoutPriority(999)
+		imageSizeConstraint.isActive = true
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
@@ -18,8 +18,9 @@ class EmptyStateView: UIView {
 		fatalError("init(coder:) has not been implemented")
 	}
 
-	init(viewModel: EmptyStateViewModel) {
+	init(viewModel: EmptyStateViewModel, additionalTopPadding: CGFloat = 0) {
 		self.viewModel = viewModel
+		self.additionalTopPadding = additionalTopPadding
 
 		super.init(frame: .zero)
 
@@ -28,17 +29,10 @@ class EmptyStateView: UIView {
 
 	// MARK: - Internal
 
-	var additionalTopPadding: CGFloat = 0 {
-		didSet {
-			topConstraint.constant = additionalTopPadding
-		}
-	}
-
 	// MARK: - Private
 
 	private let viewModel: EmptyStateViewModel
-
-	private var topConstraint: NSLayoutConstraint!
+	private let additionalTopPadding: CGFloat
 
 	private func setUp() {
 		backgroundColor = .clear
@@ -82,14 +76,12 @@ class EmptyStateView: UIView {
 		descriptionLabel.text = viewModel.description
 		stackView.addArrangedSubview(descriptionLabel)
 
-		topConstraint = containerView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor)
-		
 		// We take a number for that the image is not too big and not too small and fits for big and small devices for all four occurrences of the EmptyStateView (in CertificatesOverview, CheckinOverview, TraceLocationsOverview, ContactDiaryDay). The result was 3.
 		let percentageWidth = UIScreen.main.bounds.width / 3
 		
 		NSLayoutConstraint.activate([
 			containerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-			topConstraint,
+			containerView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: additionalTopPadding),
 			containerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
 			containerView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
 			stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 280),


### PR DESCRIPTION
### Description
This PR fixes a layout issue that was reported at github #3138. Several tables have a very similar layout with a round image and variable-sized texts. But the height of the image is not aligned, and this makes the layout 'jump' if you switch between the tabs.
The solution changes the layout of the EmptyStateView from vertically centered to top-aligned.

Additionally I noticed that the health certificate view controller created the EmptyStateView again and again. This puts an unnecessary stress on the object heap management / garbage collection system, so I have refactored it. 

### Link to Jira
Internal Tracking-ID: EXPOSUREAPP-8478
github #3138 

### Screenshots