### PR TITLE
Fix/file scanner coordinator view model tests

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/FileScannerCoordinatorViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/FileScannerCoordinatorViewModel.swift
@@ -77,10 +77,12 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 
 	init(
 		qrCodeDetector: QRCodeDetecting,
-		qrCodeParser: QRCodeParsable
+		qrCodeParser: QRCodeParsable,
+		queue: DispatchQueue = .main
 	) {
 		self.qrCodeDetector = qrCodeDetector
 		self.qrCodeParser = qrCodeParser
+		self.queue = queue
 	}
 
 	// MARK: - Internal
@@ -113,26 +115,27 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 	}
 
 	func scan(_ image: UIImage) {
-		processingStartedOnMain()
+		processingStartedOnQueue()
+		let processingQueue = DispatchQueue.global(qos: .background)
 
-		DispatchQueue.global(qos: .background).async { [weak self] in
+		processingQueue.async { [weak self] in
 			guard let self = self,
 				  let codes = self.qrCodeDetector.findQRCodes(in: image)
 			else {
-				self?.processingFailedOnMain(.noQRCodeFound)
+				self?.processingFailedOnQueue(.noQRCodeFound)
 				Log.error("Failed to stronge self pointer")
 				return
 			}
 			guard !codes.isEmpty else {
-				self.processingFailedOnMain(.noQRCodeFound)
+				self.processingFailedOnQueue(.noQRCodeFound)
 				return
 			}
 
-			self.findValidQRCode(from: codes) { [weak self] result in
+			self.findValidQRCode(from: codes, queue: processingQueue) { [weak self] result in
 				if let result = result {
-					self?.processingFinishedOnMain(result)
+					self?.processingFinishedOnQueue(result)
 				} else {
-					self?.processingFailedOnMain(.noQRCodeFound)
+					self?.processingFailedOnQueue(.noQRCodeFound)
 				}
 			}
 		}
@@ -141,7 +144,7 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 	func unlockAndScan(_ pdfDocument: PDFDocument) {
 		Log.debug("PDF is encrypted and locked. Try to unlock, show password input screen to the user ...", log: .fileScanner)
 
-		missingPasswordForPDFOnMain { [weak self] password in
+		missingPasswordForPDFOnQueue { [weak self] password in
 			guard let self = self else { return }
 
 			if pdfDocument.unlock(withPassword: password) {
@@ -150,27 +153,28 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 				self.scan(pdfDocument)
 			} else {
 				Log.debug("PDF unlocking failed.", log: .fileScanner)
-				self.processingFailedOnMain(.passwordInput)
+				self.processingFailedOnQueue(.passwordInput)
 			}
 		}
 	}
 
 	func scan(_ pdfDocument: PDFDocument) {
-		processingStartedOnMain()
+		processingStartedOnQueue()
+		let processingQueue = DispatchQueue.global(qos: .background)
 
-		DispatchQueue.global(qos: .background).async { [weak self] in
+		processingQueue.async { [weak self] in
 			guard let self = self else {
-				self?.processingFailedOnMain(.noQRCodeFound)
+				self?.processingFailedOnQueue(.noQRCodeFound)
 				Log.error("Failed to stronge self pointer")
 				return
 			}
 
 			let codes = self.qrCodes(from: pdfDocument)
-			self.findValidQRCode(from: codes) { [weak self] result in
+			self.findValidQRCode(from: codes, queue: processingQueue) { [weak self] result in
 				if let result = result {
-					self?.processingFinishedOnMain(result)
+					self?.processingFinishedOnQueue(result)
 				} else {
-					self?.processingFailedOnMain(.noQRCodeFound)
+					self?.processingFailedOnQueue(.noQRCodeFound)
 				}
 			}
 		}
@@ -180,12 +184,13 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 
 	private let qrCodeDetector: QRCodeDetecting
 	private let qrCodeParser: QRCodeParsable
+	private let queue: DispatchQueue
 
 	@available(iOS 14, *)
 	func processItemProvider(_ itemProvider: NSItemProvider) {
 		DispatchQueue.global(qos: .background).async { [weak self] in
 			guard itemProvider.canLoadObject(ofClass: UIImage.self) else {
-				self?.processingFailedOnMain(.noQRCodeFound)
+				self?.processingFailedOnQueue(.noQRCodeFound)
 				return
 			}
 			itemProvider.loadObject(ofClass: UIImage.self) { [weak self]  provider, _ in
@@ -193,7 +198,7 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 					  let image = provider as? UIImage
 				else {
 					Log.debug("No image found in user selection.", log: .fileScanner)
-					self?.processingFailedOnMain(.noQRCodeFound)
+					self?.processingFailedOnQueue(.noQRCodeFound)
 					return
 				}
 
@@ -211,7 +216,7 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 			}
 		}
 		if found.isEmpty {
-			processingFailedOnMain(.noQRCodeFound)
+			processingFailedOnQueue(.noQRCodeFound)
 		}
 		return found
 	}
@@ -233,7 +238,7 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 		return images
 	}
 
-	private func findValidQRCode(from codes: [String], completion: @escaping (QRCodeResult?) -> Void) {
+	private func findValidQRCode(from codes: [String], queue: DispatchQueue, completion: @escaping (QRCodeResult?) -> Void) {
 		Log.debug("Try to find a valid QR-Code from codes.", log: .fileScanner)
 
 		let group = DispatchGroup()
@@ -250,11 +255,12 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 				case .success(let result):
 					validCodes.append(result)
 				}
+
 				group.leave()
 			}
 		}
 
-		group.notify(queue: .main) { [weak self] in
+		group.notify(queue: queue) { [weak self] in
 			// Return first valid result.
 			if let firstValidResult = validCodes.first {
 				Log.debug("Found valid QR-Code from codes.", log: .fileScanner)
@@ -264,35 +270,35 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 				if let parseError = errors.first,
 				   case let .certificateQrError(registerError) = parseError,
 				   case .certificateAlreadyRegistered = registerError {
-					self?.processingFailedOnMain(.alreadyRegistered)
+					self?.processingFailedOnQueue(.alreadyRegistered)
 				} else {
-					self?.processingFailedOnMain(.invalidQRCode)
+					self?.processingFailedOnQueue(.invalidQRCode)
 				}
 				completion(nil)
 			}
 		}
 	}
 
-	private func processingStartedOnMain() {
-		DispatchQueue.main.async {
+	private func processingStartedOnQueue() {
+		queue.async {
 			self.processingStarted?()
 		}
 	}
 
-	private func processingFinishedOnMain(_ result: QRCodeResult) {
-		DispatchQueue.main.async {
+	private func processingFinishedOnQueue(_ result: QRCodeResult) {
+		queue.async {
 			self.processingFinished?(result)
 		}
 	}
 
-	private func processingFailedOnMain(_ error: FileScannerError?) {
-		DispatchQueue.main.async {
+	private func processingFailedOnQueue(_ error: FileScannerError?) {
+		queue.async {
 			self.processingFailed?(error)
 		}
 	}
 
-	private func missingPasswordForPDFOnMain(_ callback: @escaping (String) -> Void) {
-		DispatchQueue.main.async {
+	private func missingPasswordForPDFOnQueue(_ callback: @escaping (String) -> Void) {
+		queue.async {
 			self.missingPasswordForPDF?(callback)
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/FileScannerCoordinatorViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/FileScannerCoordinatorViewModel.swift
@@ -165,7 +165,7 @@ class FileScannerCoordinatorViewModel: FileScannerProcessing {
 		processingQueue.async { [weak self] in
 			guard let self = self else {
 				self?.processingFailedOnQueue(.noQRCodeFound)
-				Log.error("Failed to stronge self pointer")
+				Log.error("Failed to strong self pointer")
 				return
 			}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
@@ -55,6 +55,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		return image
 	}()
 
+	private var healthCertificate: HealthCertificate = {
+		.mock()
+	}()
+
 	// MARK: - UIDocumentPicker
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PickImageWithQRCode_THEN_QRCodeResult() throws {
@@ -63,12 +67,14 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
 				expectation.fulfill()
+			} else {
+				XCTFail("Result with certificate expected.")
 			}
 		}
 
@@ -76,7 +82,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(fakeImage)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PickImageWithoutQRCode_THEN_Error() throws {
@@ -85,7 +91,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake(),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFailed = { error in
@@ -98,7 +104,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(fakeImage)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_SelectedFileWithQRCode_THEN_QRCodeResult() throws {
@@ -107,7 +113,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFinished = { result in
@@ -121,7 +127,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(pdfDocument)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PasswordProtectedPDFFileWithoutQRCode_THEN_QRCodeResult() throws {
@@ -130,7 +136,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake(),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFailed = { error in
@@ -148,7 +154,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.unlockAndScan(pdfDocument)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PasswordProtectedPDFFileButWrongPasswordIsGicen_THEN_ResultIsAnError() throws {
@@ -157,7 +163,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake(),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFailed = { error in
@@ -175,7 +181,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.unlockAndScan(pdfDocument)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PasswordProtectedPDFFileWithQRCode_THEN_QRCodeResult() throws {
@@ -184,7 +190,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFinished = { result in
@@ -202,7 +208,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.unlockAndScan(pdfDocument)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	// MARK: UIImagePicker
@@ -213,7 +219,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFinished = { result in
@@ -226,7 +232,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(fakeImage)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_SelectedImageWithoutQRCode_THEN_QRCodeResult() throws {
@@ -235,7 +241,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake(),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFailed = { error in
@@ -248,7 +254,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(fakeImage)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 	// MARK: PHPicker
@@ -260,7 +266,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
-			qrCodeParser: QRCodeParsableMock(acceptAll: true)
+			qrCodeParser: QRCodeParsableMock(acceptAll: true, certificate: healthCertificate)
 		)
 
 		viewModel.processingFinished = { result in
@@ -273,7 +279,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.scan(fakeImage)
 
 		// THEN
-		waitForExpectations(timeout: .short)
+		waitForExpectations(timeout: .long)
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
@@ -78,6 +78,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			}
 		}
 
+		viewModel.processingFailed = { error in
+			XCTFail("Processing failed. Error: \(String(describing: error))")
+		}
+
 		// WHEN
 		viewModel.scan(fakeImage)
 
@@ -120,6 +124,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			if case .certificate = result {
 				expectation.fulfill()
 			}
+		}
+
+		viewModel.processingFailed = { error in
+			XCTFail("Processing failed. Error: \(String(describing: error))")
 		}
 
 		// WHEN
@@ -186,7 +194,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 	func testGIVEN_FileScannerCoordinatorViewModel_WHEN_PasswordProtectedPDFFileWithQRCode_THEN_QRCodeResult() throws {
 		// GIVEN
-		let expectation = expectation(description: "result found")
+		let processingFinishedExpectation = expectation(description: "result found")
+		let missingPasswordForPDFExpectation = expectation(description: "missingPasswordForPDF is called")
 
 		let viewModel = FileScannerCoordinatorViewModel(
 			qrCodeDetector: QRCodeDetectorFake("something found"),
@@ -195,12 +204,17 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
-				expectation.fulfill()
+				processingFinishedExpectation.fulfill()
 			}
 		}
 
 		viewModel.missingPasswordForPDF = { password in
 			password("123456")
+			missingPasswordForPDFExpectation.fulfill()
+		}
+
+		viewModel.processingFailed = { error in
+			XCTFail("Processing of password protected PDF failed. Error: \(String(describing: error))")
 		}
 
 		// WHEN
@@ -228,6 +242,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			}
 		}
 
+		viewModel.processingFailed = { error in
+			XCTFail("Processing failed. Error: \(String(describing: error))")
+		}
+
 		// WHEN
 		viewModel.scan(fakeImage)
 
@@ -248,6 +266,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			if case .noQRCodeFound = error {
 				expectation.fulfill()
 			}
+		}
+
+		viewModel.processingFailed = { error in
+			XCTFail("Processing failed. Error: \(String(describing: error))")
 		}
 
 		// WHEN
@@ -275,6 +297,10 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			}
 		}
 
+		viewModel.processingFailed = { error in
+			XCTFail("Processing failed. Error: \(String(describing: error))")
+		}
+		
 		// WHEN
 		viewModel.scan(fakeImage)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
@@ -74,7 +74,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			if case .certificate = result {
 				expectation.fulfill()
 			} else {
-				XCTFail("Result with certificate expected.")
+				XCTFail("processingFinished with unexpected result.")
 			}
 		}
 
@@ -101,6 +101,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFailed = { error in
 			if case .noQRCodeFound = error {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFailed with unexpected result.")
 			}
 		}
 
@@ -123,6 +125,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFinished with unexpected result.")
 			}
 		}
 
@@ -150,6 +154,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFailed = { error in
 			if case .noQRCodeFound = error {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFailed with unexpected result.")
 			}
 		}
 
@@ -177,6 +183,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFailed = { error in
 			if case .passwordInput = error {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFailed with unexpected result.")
 			}
 		}
 
@@ -205,6 +213,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
 				processingFinishedExpectation.fulfill()
+			} else {
+				XCTFail("processingFinished with unexpected result.")
 			}
 		}
 
@@ -239,6 +249,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFinished with unexpected result.")
 			}
 		}
 
@@ -265,6 +277,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFailed = { error in
 			if case .noQRCodeFound = error {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFailed with unexpected result.")
 			}
 		}
 
@@ -290,6 +304,8 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFinished = { result in
 			if case .certificate = result {
 				expectation.fulfill()
+			} else {
+				XCTFail("processingFinished with unexpected result.")
 			}
 		}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/FileScannerCoordinatorViewModelTests.swift
@@ -268,10 +268,6 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 			}
 		}
 
-		viewModel.processingFailed = { error in
-			XCTFail("Processing failed. Error: \(String(describing: error))")
-		}
-
 		// WHEN
 		viewModel.scan(fakeImage)
 
@@ -300,7 +296,7 @@ class FileScannerCoordinatorViewModelTests: CWATestCase {
 		viewModel.processingFailed = { error in
 			XCTFail("Processing failed. Error: \(String(describing: error))")
 		}
-		
+
 		// WHEN
 		viewModel.scan(fakeImage)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/QRCodeParsableMock.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FileScanner/__tests__/QRCodeParsableMock.swift
@@ -8,16 +8,17 @@ class QRCodeParsableMock: QRCodeParsable {
 
 	// MARK: - Init
 
-	init(acceptAll: Bool) {
+	init(acceptAll: Bool, certificate: HealthCertificate) {
 		self.accept = acceptAll
+		self.certificate = certificate
 	}
 
 	// MARK: - Protocol QRCodeParsable
 
 	func parse(qrCode: String, completion: @escaping (Result<QRCodeResult, QRCodeParserError>) -> Void) {
+
 		if accept {
-			completion(.success(QRCodeResult.certificate(HealthCertifiedPerson(healthCertificates: []), HealthCertificate.mock()))
-			)
+			completion(.success(QRCodeResult.certificate(HealthCertifiedPerson(healthCertificates: []), certificate)))
 		} else {
 			completion(.failure(.checkinQrError(.codeNotFound)))
 		}
@@ -26,4 +27,5 @@ class QRCodeParsableMock: QRCodeParsable {
 	// MARK: - Internal
 
 	var accept: Bool = true
+	let certificate: HealthCertificate
 }


### PR DESCRIPTION
## Description
Attempt to fix flaky tests of FileScannerCoordinatorViewModel.

Changes: 

- Create 1 dummy-certificate for all tests to save time
- Finish DispatchGroup on the correct queue.
- Add callbacks for negative outcomes to the tests, to have a better logging in the case of errors.
- Change waiting time to .long, because sometimes the tests need longer.
