### PR TITLE
Fix/restore certificate from bin

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -139,9 +139,10 @@ class HealthCertificateService {
 		Log.info("[HealthCertificateService] Registering health certificate from payload: \(private: base45)", log: .api)
 
 		// If the certificate is in the recycle bin, restore it and skip registration process.
-		if case let .certificate(healthCertificate) = recycleBin.item(for: base45) {
+		if let recycleBinItem = recycleBin.item(for: base45), case let .certificate(healthCertificate) = recycleBinItem.item {
 			let healthCertifiedPerson = healthCertifiedPerson(for: healthCertificate)
 			addHealthCertificate(healthCertificate, to: healthCertifiedPerson)
+			recycleBin.remove(recycleBinItem)
 
 			return .success(
 				CertificateResult(

--- a/src/xcode/ENA/ENA/Source/Services/RecycleBin/RecycleBin.swift
+++ b/src/xcode/ENA/ENA/Source/Services/RecycleBin/RecycleBin.swift
@@ -97,9 +97,9 @@ class RecycleBin {
 	///
 	/// - Parameter identifier: Identifier string for the item.
 	/// - Returns: An item for the specified `identifier`. Or `nil` if the item does not exist.
-	func item(for identifier: String) -> RecycledItem? {
+	func item(for identifier: String) -> RecycleBinItem? {
 		Log.info("Read item.", log: .recycleBin)
-		return store.recycleBinItems.first { $0.item.recycleBinIdentifier == identifier }?.item
+		return store.recycleBinItems.first { $0.item.recycleBinIdentifier == identifier }
 	}
 
 	/// Removes all items which where moved into the bin more then 30 days ago.


### PR DESCRIPTION
## Description
Fixes two issues with certificate restoration when a certificate is re-registered that already exists in the recycle bin:
- The certificate is removed from the bin when re-registered from the QR code scanner.
- The alert that informs the user about the restoration from the recycle bin is properly presented.
