### PR TITLE
Fix sonar nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,4 +413,14 @@ workflows:
             branches:
               only: /release\/.*/
     jobs:
-      - sonar
+      - dependencies:
+          filters:
+            branches:
+              only: /release\/.*/
+      - sonar:
+          requires:
+            - dependencies
+          filters:
+            branches:
+              only:
+                - /release\/.*/


### PR DESCRIPTION
## Description
This should fix our nightly sonar runs after the first try failed: 
https://app.circleci.com/pipelines/github/corona-warn-app/cwa-app-ios/21819/workflows/8d77a0b9-5b63-40e3-ad0b-11c0c3671aa5

