### PR TITLE
Prevent calling showHome() twice.

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -655,7 +655,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	}()
 
 	/// - Parameter launchOptions: Launch options passed on app launch
-	/// - Returns: A `Route` if a valid URL is passed in the launch options
+	/// - Returns: `true` if `launchOptions` contains user activity of type `NSUserActivityTypeBrowsingWeb`, returns `false` otherwhise.
 	private func appLaunchedFromUserActicityURL(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		guard let activityDictionary = launchOptions?[.userActivityDictionary] as? [AnyHashable: Any] else {
 			return false

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -127,7 +127,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			return false
 		}
 
-		// 'appLaunchedFromUserActivityURL' inidcates, if the app was launched through a QR-Code scan.
+		// 'appLaunchedFromUserActivityURL' inidcates, if the app was launched through a QR-Code scan, from the System Camera.
 		// Based on that, the routing and UI rendering works differently in the subsequent delegate callbacks.
 		//
 		// We can have different paths of delegate callbacks depending on the app was started with a QR-Code scan or not.

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -96,7 +96,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	}
 
 	deinit {
-		// We are (intentionally) keeping strong references for delegates. Let's clean them ups.
+		// We are (intentionally) keeping strong references for delegates. Let's clean them up.
 		self.taskExecutionDelegate = nil
 	}
 
@@ -121,12 +121,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			// Show Disabled UI
 			setupUpdateOSUI()
 			didSetupUI = true
-			return true
+
+			// Return false, because if the app is disabled, we cannot handle URL ressources or user activity.
+			// More information: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application
+			return false
 		}
 
-		// Check for any URLs passed into the app – most likely via scanning a QR code from event or antigen rapid test
-		// Route will be executed in 'applicationDidBecomeActive'
-		route = routeFromLaunchOptions(launchOptions)
+		// 'appLaunchedFromUserActivityURL' inidcates, if the app was launched through a QR-Code scan.
+		// Based on that, the routing and UI rendering works differently in the subsequent delegate callbacks.
+		//
+		// We can have different paths of delegate callbacks depending on the app was started with a QR-Code scan or not.
+		// Possible paths after QR-Code was scanned:
+		// App was suspended: didFinishLaunchingWithOptions -> applicationDidBecomeActive -> continue userActivity
+		// App was in background: continue userActivity -> applicationDidBecomeActive
+		//
+		// Either 'continue userActivity' or 'applicationDidBecomeActive' needs to show the UI.
+		// 'appLaunchedFromUserActivityURL' helps to indicate which of the two callbacks needs to show the UI.
+		appLaunchedFromUserActivityURL = appLaunchedFromUserActicityURL(launchOptions)
 
 		QuickAction.setup()
 
@@ -186,8 +197,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	func applicationDidBecomeActive(_ application: UIApplication) {
 		Log.info("Application did become active.", log: .appLifecycle)
 
-		if !didSetupUI {
-			setupUI(route)
+		// If the UI was not setup before, and the app was NOT started from an user activity,
+		// 'applicationDidBecomeActive' is the last delegate callback and needs to build up the UI.
+		if !didSetupUI && !appLaunchedFromUserActivityURL {
+			setupUI()
+			showUI()
+
+			appLaunchedFromUserActivityURL = false
 			didSetupUI = true
 			route = nil
 		}
@@ -215,15 +231,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		Log.info("Application continue user activity.", log: .appLifecycle)
 
 		// handle QR codes scanned in the camera app
-		var route: Route?
 		if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let incomingURL = userActivity.webpageURL {
 			route = Route(url: incomingURL)
 		}
-		guard store.isOnboarded else {
-			postOnboardingRoute = route
-			return false
+
+		// If the UI was not setup before, and the app was started from an user activity,
+		// 'continue userActivity' is the last delegate callback and needs to build up the UI.
+		if !didSetupUI && appLaunchedFromUserActivityURL {
+			setupUI()
+			showUI()
+
+			appLaunchedFromUserActivityURL = false
+			didSetupUI = true
+			route = nil
+		} else {
+			guard store.isOnboarded else {
+				postOnboardingRoute = route
+				return false
+			}
+			showHome(route)
 		}
-		showHome(route)
+
 		return true
 	}
 
@@ -615,6 +643,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	private var postOnboardingRoute: Route?
 	private var route: Route?
 	private var didSetupUI = false
+	private var appLaunchedFromUserActivityURL = false
 
 	private lazy var exposureDetectionExecutor: ExposureDetectionExecutor = {
 		ExposureDetectionExecutor(
@@ -627,20 +656,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	/// - Parameter launchOptions: Launch options passed on app launch
 	/// - Returns: A `Route` if a valid URL is passed in the launch options
-	private func routeFromLaunchOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Route? {
+	private func appLaunchedFromUserActicityURL(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 		guard let activityDictionary = launchOptions?[.userActivityDictionary] as? [AnyHashable: Any] else {
-			return nil
+			return false
 		}
 
 		for key in activityDictionary.keys {
 			if let userActivity = activityDictionary[key] as? NSUserActivity,
 			   userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-			   let url = userActivity.webpageURL {
-				return Route(url: url)
+			   userActivity.webpageURL != nil {
+				return true
 			}
 		}
 
-		return nil
+		return false
 	}
 
 	private func showError(_ riskProviderError: RiskProviderError) {
@@ -755,16 +784,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	private let riskConsumer = RiskConsumer()
 
-	private func setupUI(_ route: Route?) {
+	private func setupUI() {
 		setupNavigationBarAppearance()
 		setupAlertViewAppearance()
 
-		if store.isOnboarded {
-			showHome(route)
-		} else {
-			postOnboardingRoute = route
-			showOnboarding()
-		}
 		UIImageView.appearance().accessibilityIgnoresInvertColors = true
 
 		window = UIWindow(frame: UIScreen.main.bounds)
@@ -777,6 +800,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			window?.layer.speed = 100
 		}
 		#endif
+	}
+
+	private func showUI() {
+		if store.isOnboarded {
+			showHome(route)
+		} else {
+			postOnboardingRoute = route
+			showOnboarding()
+		}
 	}
 
 	private func setupNavigationBarAppearance() {


### PR DESCRIPTION
## Description
This change prevents calling showHome() twice during startup.

Detailed explanation:
We can have different paths of delegate callbacks depending on the app was started with a QR-Code scan or not.
Possible paths after QR-Code was scanned:
App was suspended: didFinishLaunchingWithOptions -> applicationDidBecomeActive -> continue userActivity
App was in background: continue userActivity -> applicationDidBecomeActive
Either 'continue userActivity' or 'applicationDidBecomeActive' needs to show the UI.

Before that fix,  'applicationDidBecomeActive' was calling showHome() and after that 'continue userActivity' was also calling showHome().

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10103

