### PR TITLE
Fix/10148 delete all crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/DiaryCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/DiaryCoordinator.swift
@@ -152,17 +152,8 @@ class DiaryCoordinator {
 			onCellSelection: { [weak self] day in
 				self?.showDayScreen(day: day)
 			},
-			onInfoButtonTap: { [weak self] in
-				self?.presentInfoScreen()
-			},
-			onExportButtonTap: { [weak self] in
-				self?.showExportActivity()
-			},
-			onEditContactPersonsButtonTap: { [weak self] in
-				self?.showEditEntriesScreen(entryType: .contactPerson)
-			},
-			onEditLocationsButtonTap: { [weak self] in
-				self?.showEditEntriesScreen(entryType: .location)
+			onMoreButtonTap: { [weak self] in
+				self?.showMoreActionSheet()
 			}
 		)
 	}()
@@ -252,6 +243,37 @@ class DiaryCoordinator {
 		self.viewController.popToRootViewController(animated: false)
 		
 		self.viewController.pushViewController(viewController, animated: true)
+	}
+
+	private func showMoreActionSheet() {
+		let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+		let infoAction = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.infoActionTitle, style: .default) { [weak self] _ in
+			self?.presentInfoScreen()
+		}
+		actionSheet.addAction(infoAction)
+
+		let exportAction = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.exportActionTitle, style: .default) { [weak self] _ in
+			self?.showExportActivity()
+		}
+		actionSheet.addAction(exportAction)
+
+		let editPerson = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.editPersonTitle, style: .default) { [weak self] _ in
+			self?.showEditEntriesScreen(entryType: .contactPerson)
+		}
+		editPerson.isEnabled = diaryStore.diaryDaysPublisher.value.first?.entries.contains { $0.type == .contactPerson } ?? false
+		actionSheet.addAction(editPerson)
+
+		let editLocation = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.editLocationTitle, style: .default) { [weak self] _ in
+			self?.showEditEntriesScreen(entryType: .location)
+		}
+		editLocation.isEnabled = diaryStore.diaryDaysPublisher.value.first?.entries.contains { $0.type == .location } ?? false
+		actionSheet.addAction(editLocation)
+
+		let cancelAction = UIAlertAction(title: AppStrings.Common.alertActionCancel, style: .cancel)
+		actionSheet.addAction(cancelAction)
+
+		viewController.present(actionSheet, animated: true, completion: nil)
 	}
 
 	private func showAddAndEditEntryScreen(mode: DiaryAddAndEditEntryViewModel.Mode, from fromViewController: UIViewController? = nil) {

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.swift
@@ -107,6 +107,10 @@ class DiaryEditEntriesViewController: UIViewController, UITableViewDataSource, U
 					tableView.deleteRows(at: [indexPath], with: .automatic)
 				}, completion: { _ in
 					self.shouldReload = true
+
+					if self.viewModel.entries.isEmpty {
+						self.onDismiss()
+					}
 				})
 			}
 		)
@@ -164,6 +168,7 @@ class DiaryEditEntriesViewController: UIViewController, UITableViewDataSource, U
 					)
 				}, completion: { _ in
 					self.shouldReload = true
+					self.onDismiss()
 				})
 			}
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/EditEntries/DiaryEditEntriesViewController.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -31,7 +30,7 @@
                     <state key="normal" title="Button"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="color" keyPath="enabledBackgroundColor">
-                            <color key="value" name="ENA Button Destructive Color"/>
+                            <color key="value" systemColor="systemRedColor"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
@@ -55,15 +54,15 @@
     </objects>
     <designables>
         <designable name="8JE-dq-vsn">
-            <size key="intrinsicContentSize" width="70" height="50"/>
+            <size key="intrinsicContentSize" width="65" height="50"/>
         </designable>
     </designables>
     <resources>
-        <namedColor name="ENA Button Destructive Color">
-            <color red="0.75294117647058822" green="0.058823529411764705" blue="0.17647058823529413" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/DiaryOverviewTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/DiaryOverviewTableViewController.swift
@@ -12,17 +12,11 @@ class DiaryOverviewTableViewController: UITableViewController {
 	init(
 		viewModel: DiaryOverviewViewModel,
 		onCellSelection: @escaping (DiaryDay) -> Void,
-		onInfoButtonTap: @escaping () -> Void,
-		onExportButtonTap: @escaping () -> Void,
-		onEditContactPersonsButtonTap: @escaping () -> Void,
-		onEditLocationsButtonTap: @escaping () -> Void
+		onMoreButtonTap: @escaping () -> Void
 	) {
 		self.viewModel = viewModel
 		self.onCellSelection = onCellSelection
-		self.onInfoButtonTap = onInfoButtonTap
-		self.onExportButtonTap = onExportButtonTap
-		self.onEditContactPersonsButtonTap = onEditContactPersonsButtonTap
-		self.onEditLocationsButtonTap = onEditLocationsButtonTap
+		self.onMoreButtonTap = onMoreButtonTap
 
 		super.init(style: .plain)
 	}
@@ -89,10 +83,7 @@ class DiaryOverviewTableViewController: UITableViewController {
 
 	private let viewModel: DiaryOverviewViewModel
 	private let onCellSelection: (DiaryDay) -> Void
-	private let onInfoButtonTap: () -> Void
-	private let onExportButtonTap: () -> Void
-	private let onEditContactPersonsButtonTap: () -> Void
-	private let onEditLocationsButtonTap: () -> Void
+	private let onMoreButtonTap: () -> Void
 
 	private var subscriptions = [AnyCancellable]()
 	
@@ -148,31 +139,7 @@ class DiaryOverviewTableViewController: UITableViewController {
 	
 	@objc
 	private func onMore() {
-		let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-		
-		let infoAction = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.infoActionTitle, style: .default, handler: { [weak self] _ in
-			self?.onInfoButtonTap()
-		})
-		actionSheet.addAction(infoAction)
-		
-		let exportAction = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.exportActionTitle, style: .default, handler: { [weak self] _ in
-			self?.onExportButtonTap()
-		})
-		actionSheet.addAction(exportAction)
-
-		let editPerson = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.editPersonTitle, style: .default, handler: { [weak self] _ in
-			self?.onEditContactPersonsButtonTap()
-		})
-		actionSheet.addAction(editPerson)
-		
-		let editLocation = UIAlertAction(title: AppStrings.ContactDiary.Overview.ActionSheet.editLocationTitle, style: .default, handler: { [weak self] _ in
-			self?.onEditLocationsButtonTap()
-		})
-		actionSheet.addAction(editLocation)
-		
-		let cancelAction = UIAlertAction(title: AppStrings.Common.alertActionCancel, style: .cancel, handler: nil)
-		actionSheet.addAction(cancelAction)
-		
-		present(actionSheet, animated: true, completion: nil)
+		onMoreButtonTap()
 	}
+
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Overview/CheckinsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Overview/CheckinsOverviewViewController.swift
@@ -298,6 +298,7 @@ class CheckinsOverviewViewController: UITableViewController, FooterViewHandling 
 				self?.updateFor(isEditing: true)
 			}
 		)
+		editAction.isEnabled = !viewModel.isEmpty
 		actionSheet.addAction(editAction)
 
 		let cancelAction = UIAlertAction(title: AppStrings.Common.alertActionCancel, style: .cancel)

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
@@ -284,6 +284,7 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 				self?.updateFor(isEditing: true)
 			}
 		)
+		editAction.isEnabled = !viewModel.isEmpty
 		actionSheet.addAction(editAction)
 
 		let onBehalfCheckinSubmissionAction = UIAlertAction(

--- a/src/xcode/ENA/ENA/Source/Scenes/RecycleBin/RecycleBinViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/RecycleBin/RecycleBinViewController.swift
@@ -33,7 +33,6 @@ class RecycleBinViewController: UITableViewController, FooterViewHandling {
 		setupTableView()
 		navigationItem.largeTitleDisplayMode = .always
 		navigationItem.title = AppStrings.RecycleBin.title
-		navigationItem.rightBarButtonItem = editButtonItem
 
 		viewModel.$recycleBinItems
 			.receive(on: DispatchQueue.main.ocombine)
@@ -208,6 +207,8 @@ class RecycleBinViewController: UITableViewController, FooterViewHandling {
 				alignmentPadding: UIScreen.main.bounds.height / 3
 			)
 			: nil
+
+		navigationItem.rightBarButtonItem = viewModel.isEmpty ? nil : editButtonItem
 	}
 
 	private func didTapDeleteAllButton() {


### PR DESCRIPTION
## Description
Main change:
- Hides the edit button of the recycling bin if there are no recycled items as the app crashed when tapping the delete all button when no entries existed and the option to delete all did not actually make sense.

Additional changes to improve UX:
- Edit buttons in actions sheets on other screens are now deactivated if no entries exist
- the delete all button on contact persons and locations in the contact journal now has the correct color
- the edit screen of contact persons and locations is dismissed automatically after the last item is deleted

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10148

## Screenshots
![IMG_0191](https://user-images.githubusercontent.com/1157991/138453704-1ab56f4f-d718-49d5-90f5-e3643b366b06.PNG)
![IMG_0192](https://user-images.githubusercontent.com/1157991/138453714-21fd728f-0edd-4002-8ccf-c82a9ea495e6.PNG)
![IMG_0193](https://user-images.githubusercontent.com/1157991/138453735-30a3eadb-5c5a-45c8-b5b1-2bdfa337ea7e.PNG)
![IMG_0194](https://user-images.githubusercontent.com/1157991/138453747-e86639b5-96e6-45b0-936a-5c4cb193f101.PNG)
![IMG_39BADF6BEFCF-1](https://user-images.githubusercontent.com/1157991/138453895-2cd5f726-b42d-42ed-aa93-192b776f3a21.jpeg)