### PR TITLE
Fix testLaunchViaShortcutFromFreshInstall flakyness

### DIFF
--- a/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
+++ b/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
@@ -8,7 +8,7 @@ import ExposureNotification
 class ENAUITests_11_QuickActions: CWATestCase {
 
 	private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-	private lazy var cwaBundleDisplayName = { XCUIApplication().label }() // "Corona-Warn"
+	private lazy var cwaBundleDisplayName = "Corona-Warn" // "Corona-Warn"
 	/// The translated label string as we can't (?) use any identifiers there
 	private lazy var newDiaryEntryLabel = XCUIApplication().localized(AppStrings.QuickActions.contactDiaryNewEntry)
 	private lazy var eventCheckinLabel = XCUIApplication().localized(AppStrings.QuickActions.eventCheckin)

--- a/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
+++ b/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
@@ -8,7 +8,7 @@ import ExposureNotification
 class ENAUITests_11_QuickActions: CWATestCase {
 
 	private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-	private lazy var cwaBundleDisplayName = "Corona-Warn" // "Corona-Warn"
+	private lazy var cwaBundleDisplayName = "Corona-Warn"
 	/// The translated label string as we can't (?) use any identifiers there
 	private lazy var newDiaryEntryLabel = XCUIApplication().localized(AppStrings.QuickActions.contactDiaryNewEntry)
 	private lazy var eventCheckinLabel = XCUIApplication().localized(AppStrings.QuickActions.eventCheckin)


### PR DESCRIPTION
## Description
testLaunchViaShortcutFromFreshInstall would not be successful if it was the first test run in the test-suite. 
`XCUIApplication().label` will result in `Failed to get matching snapshot: Application de.rki.coronawarnapp-dev is not running ` when the app is not currently active. 

Since our display name will likely not change in the foreseeable future I hard coded the display name to solve this issue.
