### PR TITLE
Fix test_AddStatisticsButton_flow

### DIFF
--- a/src/xcode/ENA/ENAUITests/Home/ENAUITests_01b_Statistics.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITests_01b_Statistics.swift
@@ -47,6 +47,9 @@ class ENAUITests_01b_Statistics: CWATestCase {
 
 		app.setPreferredContentSizeCategory(accessibility: .normal, size: .S)
 		app.launch()
+		// Wait and check for the navbar to make sure App is really launched, otherwise the swipe will do nothing
+		let leftNavbarButton = app.images[AccessibilityIdentifiers.Home.leftBarButtonDescription]
+		XCTAssertTrue(leftNavbarButton.waitForExistence(timeout: .medium))
 		app.swipeUp(velocity: .slow)
 		let statisticsCell = app.cells[AccessibilityIdentifiers.Statistics.General.tableViewCell]
 		XCTAssertTrue(statisticsCell.waitForExistence(timeout: .medium))
@@ -81,7 +84,6 @@ class ENAUITests_01b_Statistics: CWATestCase {
 		XCTAssertTrue(statisticsCell.buttons[modifyButton].isHittable)
 		statisticsCell.buttons[modifyButton].waitAndTap()
 		
-		app.buttons[modifyButton].swipeLeft()
 		XCTAssertTrue(deleteButton.waitForExistence(timeout: .medium))
 		XCTAssertTrue(deleteButton.isHittable)
 		deleteButton.waitAndTap()


### PR DESCRIPTION
## Description
Fixes test_AddStatisticsButton_flow.

During debugging I noticed that the first swipe up didn't catch since the app wasn't done loading, so I wait for the at least the navigationBar to load before we swipe.
Test would still fail that's why one unneeded `swipeLeft()` was removed as well.

