### PR TITLE
Remove typing of tan by prefilling the model

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TANInputViewController/TanInputViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TANInputViewController/TanInputViewModel.swift
@@ -19,6 +19,13 @@ final class TanInputViewModel {
 		self.description = description
 		self.onPrimaryButtonTap = onPrimaryButtonTap
 		self.text = givenTan ?? ""
+#if DEBUG
+		if isUITesting {
+			// UI-Tests sometimes fail to enter a tan via the software keyboard, so we prefill it on UI-Tests
+			self.text = "QWDZXCSRHE"
+			isPrimaryButtonEnabled = isChecksumValid
+		}
+#endif
 	}
 
 	// MARK: - Internal

--- a/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
+++ b/src/xcode/ENA/ENAUITests/AppDelegate/ENAUITests_11_QuickActions.swift
@@ -102,11 +102,7 @@ class ENAUITests_11_QuickActions: CWATestCase {
 		
 		let continueButton = app.buttons[AccessibilityIdentifiers.ExposureSubmission.primaryButton]
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(continueButton.isEnabled)
 
-		"qwdzxcsrhe".forEach {
-			app.keyboards.keys[String($0)].waitAndTap()
-		}
 
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
 		XCTAssertTrue(continueButton.isEnabled)

--- a/src/xcode/ENA/ENAUITests/ExposureSubmission/ENAUITests_04a_ExposureSubmission.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureSubmission/ENAUITests_04a_ExposureSubmission.swift
@@ -265,10 +265,6 @@ class ENAUITests_04a_ExposureSubmission: CWATestCase {
 
 		let continueButton = app.buttons[AccessibilityIdentifiers.ExposureSubmission.primaryButton]
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(continueButton.isEnabled)
-
-		// Fill in dummy TAN.
-		type(app, text: "qwdzxcsrhe")
 
 		// Click continue button.
 		XCTAssertTrue(continueButton.isEnabled)
@@ -309,10 +305,6 @@ class ENAUITests_04a_ExposureSubmission: CWATestCase {
 		
 		let continueButton = app.buttons[AccessibilityIdentifiers.ExposureSubmission.primaryButton]
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(continueButton.isEnabled)
-
-		// Fill in dummy TAN.
-		type(app, text: "qwdzxcsrhe")
 
 		// Click continue button.
 
@@ -441,10 +433,6 @@ class ENAUITests_04a_ExposureSubmission: CWATestCase {
 
 		let continueButton = app.buttons[AccessibilityIdentifiers.ExposureSubmission.primaryButton]
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(continueButton.isEnabled)
-
-		// Fill in dummy TAN.
-		type(app, text: "qwdzxcsrhe")
 
 		// Click continue button.
 		XCTAssertTrue(continueButton.isEnabled)
@@ -668,9 +656,6 @@ class ENAUITests_04a_ExposureSubmission: CWATestCase {
 		// Fill in dummy TAN.
 		let continueButton = app.buttons[AccessibilityIdentifiers.ExposureSubmission.primaryButton]
 		XCTAssertTrue(continueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(continueButton.isEnabled)
-		
-		type(app, text: "qwdzxcsrhe")
 		
 		// Click continue button.
 		XCTAssertTrue(continueButton.isEnabled)

--- a/src/xcode/ENA/ENAUITests/TraceLocations/ENAUITests_15_OnBehalfCheckinSubmission.swift
+++ b/src/xcode/ENA/ENAUITests/TraceLocations/ENAUITests_15_OnBehalfCheckinSubmission.swift
@@ -93,12 +93,8 @@ class ENAUITests_15_OnBehalfCheckinSubmission: CWATestCase {
 
 		let tanContinueButton = app.buttons[AccessibilityIdentifiers.General.primaryFooterButton]
 		XCTAssertTrue(tanContinueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(tanContinueButton.isEnabled)
-
+		
 		snapshot("onbehalfwarning_tan")
-
-		// Fill in dummy TAN.
-		type(app, text: "qwdzxcsrhe")
 
 		// Tap continue
 		XCTAssertTrue(tanContinueButton.isEnabled)
@@ -166,11 +162,6 @@ class ENAUITests_15_OnBehalfCheckinSubmission: CWATestCase {
 
 		let tanContinueButton = app.buttons[AccessibilityIdentifiers.General.primaryFooterButton]
 		XCTAssertTrue(tanContinueButton.waitForExistence(timeout: .medium))
-		XCTAssertFalse(tanContinueButton.isEnabled)
-
-		// Fill in dummy TAN.
-		XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: .medium))
-		type(app, text: "qwdzxcsrhe")
 
 		// Tap continue
 		XCTAssertTrue(tanContinueButton.isEnabled)


### PR DESCRIPTION
## Description
Somehow the Simulator sometimes fails to enter a TAN correctly (one character is missing) which then fails our UI-Tests since the TAN was not entered completely. 
On UITests the Tan will now be prefilled which makes it obsolete to type the TAN. 

This should stabilise all UI-Tests that requires entering a TAN.
