### PR TITLE
Chore/build community

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ workflows:
             branches:
               only:
                 - /release\/.*/
-      - test-community:
+      - build-community:
           requires:
             - dependencies
       - snapshot-test: # Create one set of screenshot on all branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - restore_cache:
           key: *tools_cache_key
       - run:
-          name: Run Fastlane smoke tests
+          name: Build Community
           command: cd src/xcode && bundle exec fastlane build_community
           no_output_timeout: 10m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           paths:
             - ~/sonar/
 
-  test-community:
+  build-community:
     macos:
       xcode: *xcode_version
     resource_class: *resource_class
@@ -182,12 +182,8 @@ jobs:
           key: *tools_cache_key
       - run:
           name: Run Fastlane smoke tests
-          command: cd src/xcode && bundle exec fastlane test_community
+          command: cd src/xcode && bundle exec fastlane build_community
           no_output_timeout: 10m
-      - store_test_results:
-          path: src/xcode/fastlane/test_output/
-      - store_artifacts:
-          path: src/xcode/fastlane/test_output/ENACommunity.xcresult.zip
 
   snapshot:
     macos:

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -156,39 +156,6 @@ platform :ios do
     end
   end
 
-  desc "Run smoke tests (Community)"
-  lane :test_community do
-    begin
-      run_tests(
-        scheme: "ENACommunity",
-        xcargs: "SWIFT_TREAT_WARNINGS_AS_ERRORS=NO",
-        testplan: "SmokeTests",
-        concurrent_workers: 6,
-        max_concurrent_simulators: 4,
-        result_bundle: true,
-        code_coverage: false,
-        fail_build: false,
-        output_types: "junit",
-        output_files: "report_community.junit"
-      )
-    rescue
-      UI.user_error!("Tests did fail, please check logs above or ENA.xcresult.zip")
-    ensure
-      trainer(
-        output_directory: "fastlane/test_output/",
-        path: "fastlane/test_output/",
-        extension: ".junit",
-        fail_build: false
-      )
-
-      zip(
-        path: "fastlane/test_output/ENACommunity.xcresult",
-        output_path: "fastlane/test_output/ENACommunity.xcresult.zip",
-        verbose: false
-      )
-    end
-  end
-
   desc "Create (localized) screenshots"
   lane :screenshot do |options|
     begin

--- a/src/xcode/fastlane/README.md
+++ b/src/xcode/fastlane/README.md
@@ -46,11 +46,6 @@ Lint code
 fastlane ios test
 ```
 Run tests
-### ios test_community
-```
-fastlane ios test_community
-```
-Run smoke tests (Community)
 ### ios screenshot
 ```
 fastlane ios screenshot


### PR DESCRIPTION
## Description
As discussed, to safe time on the CI the Community target gets only build and no longer tested, since we already test the ENA Target. 

