### PR TITLE
Add extra logs to monitor booster notifications flow

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -536,6 +536,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			showHealthCertificate: { [weak self] route in
 				// We must NOT call self?.showHome(route) here because we do not target the home screen. Only set the route. The rest is done automatically by the startup process of the app.
 				// Works only for notifications tapped when the app is closed. When inside the app, the notification will trigger nothing.
+				Log.debug("new route is set: \(route)")
 				self?.route = route
 			}, showHealthCertifiedPerson: { [weak self] route in
 				guard let self = self else { return }
@@ -548,6 +549,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 				if self.didSetupUI {
 					self.showHome(route)
 				} else {
+					Log.debug("new route is set: \(route)")
 					self.route = route
 				}
 			}
@@ -833,6 +835,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	func showHome(_ route: Route? = nil) {
 		// On iOS 12.5 ENManager is already activated in didFinishLaunching (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8919)
+		Log.debug("showHome Flow is called with current route: \(String(describing: route))")
 		if #available(iOS 13.5, *) {
 			if exposureManager.exposureManagerState.status == .unknown {
 				exposureManager.activate { [weak self] error in

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -126,21 +126,25 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 				healthCertifiedPerson: certifiedPerson,
 				healthCertificate: healthCertificate
 			)
+			Log.debug("Received certificateExpired notification")
 			showHealthCertificate(route)
 		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateExpiringSoon.rawValue, from: identifier) {
 			let route = Route(
 				healthCertifiedPerson: certifiedPerson,
 				healthCertificate: healthCertificate
 			)
+			Log.debug("Received certificateExpiringSoon notification")
 			showHealthCertificate(route)
 		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateInvalid.rawValue, from: identifier) {
 			let route = Route(
 				healthCertifiedPerson: certifiedPerson,
 				healthCertificate: healthCertificate
 			)
+			Log.debug("Received certificateInvalid notification")
 			showHealthCertificate(route)
 		} else if let (certifiedPerson) = extractPerson(LocalNotificationIdentifier.boosterVaccination.rawValue, from: identifier) {
 			let route = Route(healthCertifiedPerson: certifiedPerson)
+			Log.debug("Received boosterVaccination notification")
 			showHealthCertifiedPerson(route)
 		}
 	}


### PR DESCRIPTION
## Description
The booster notification is redirecting to the wrong screen according to testers, this couldn't be reproduced so i added axtra logs to give some insights

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9401
