### PR TITLE
Fix/9710 remove outdated booster rule

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -233,6 +233,12 @@ class HealthCertificateService {
 		} else {
 			Log.info("[HealthCertificateService] Successfully registered health certificate for a person with other existing certificates", log: .api)
 		}
+
+		applyBoosterRulesForHealthCertificatesOfAPerson(healthCertifiedPerson: healthCertifiedPerson) { errorMessage in
+			guard let errorMessage = errorMessage else { return }
+			Log.error(errorMessage, log: .vaccination, error: nil)
+		}
+
 		if healthCertificate.type != .test {
 			createNotifications(for: healthCertificate)
 		}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -1150,6 +1150,8 @@ class HealthCertificateService {
 				}
 				
 			case .failure(let validationError):
+				healthCertifiedPerson.boosterRule = nil
+
 				Log.error(validationError.localizedDescription, log: .vaccination, error: validationError)
 				let name = healthCertifiedPerson.name?.standardizedName ?? ""
 				completion("for \(private: name): \(validationError.localizedDescription)")


### PR DESCRIPTION
## Description
The booster rule for a person is now removed when it doesn't apply anymore. Additionally, I added a check for booster rules after registering a new health certificate so outdated rules are removed immediately.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9710
