### PR TITLE
Fix/10241 trace location qr code matching

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/Model/Parser/QRCodeParser.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/Model/Parser/QRCodeParser.swift
@@ -38,14 +38,26 @@ class QRCodeParser: QRCodeParsable {
 		// Check the prefix to know which type
 		// if we go directly and try to parse we might get an incorrect error
 		// e.g: scanning a PCR QRCode and trying to parse it at a health-certificate, we will get a healthCertificate related error
-		// which is incorrect and it should be a Corona test error, so we need to have an idea about the type of qrcode before paring it
+		// which is incorrect and it should be a Corona test error, so we need to have an idea about the type of qrcode before parsing it
 
-		let traceLocationsPrefix = "https://e.coronawarn.app"
 		let antigenTestPrefix = "https://s.coronawarn.app"
 		let pcrTestPrefix = "https://localhost"
 		let healthCertificatePrefix = "HC1:"
 
-		if String(qrCode.prefix(traceLocationsPrefix.count)).lowercased() == traceLocationsPrefix {
+		// Trace location QRCodes need to be matched from a regex provided by the app configuration
+		var traceLocationMatch: NSTextCheckingResult?
+		let traceLocationDescriptor = appConfigurationProvider.currentAppConfig.value.presenceTracingParameters.qrCodeDescriptors.first {
+			do {
+				let regex = try NSRegularExpression(pattern: $0.regexPattern, options: [.caseInsensitive])
+				traceLocationMatch = regex.firstMatch(in: qrCode, range: .init(location: 0, length: qrCode.count))
+				return traceLocationMatch != nil
+			} catch {
+				Log.error(error.localizedDescription, log: .checkin)
+				return false
+			}
+		}
+
+		if traceLocationMatch != nil, traceLocationDescriptor != nil {
 			// it is a trace Locations QRCode
 			parser = CheckinQRCodeParser(
 				appConfigurationProvider: appConfigurationProvider

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/Model/Parser/QRCodeParser.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/Model/Parser/QRCodeParser.swift
@@ -44,7 +44,7 @@ class QRCodeParser: QRCodeParsable {
 		let pcrTestPrefix = "https://localhost"
 		let healthCertificatePrefix = "HC1:"
 
-		// Trace location QRCodes need to be matched from a regex provided by the app configuration
+		// Trace location QR codes need to be matched with a regex provided by the app configuration
 		var traceLocationMatch: NSTextCheckingResult?
 		let traceLocationDescriptor = appConfigurationProvider.currentAppConfig.value.presenceTracingParameters.qrCodeDescriptors.first {
 			do {


### PR DESCRIPTION
## Description
Matches the trace location URL with the regex from the app configuration instead of using a hardcoded URL prefix.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10241