### PR TITLE
Make it clearer that one can't verify certificates from others with the CWA (COMMUNITY)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2845,7 +2845,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "CovPass_Check_Info_faq" = "FAQ zur Zertifikatsprüfung durch Dritte";
 
-"CovPass_Check_Info_text01" = "Sie selbst können Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App.";
+"CovPass_Check_Info_text01" = "Sie selbst können ihre Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App.";
 
 "CovPass_Check_Info_text02" = "Für Dritte reicht eine Sichtprüfung der Zertifikate nicht aus. Sie müssen in Deutschland die CovPassCheck-App nutzen.";
 


### PR DESCRIPTION
## Description
This PR makes it clearer that one can verify the certificates you own with the CWA, but not the ones from others.

## Link to Jira
n/a

## Screenshots
<img src="https://user-images.githubusercontent.com/67682506/139741137-74270152-b6b9-41df-9a26-af2f23c8b825.png" width="300">

---
Internal Tracking ID: [EXPOSUREAPP-10264](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10264)
