### PR TITLE
Fix/9910 tabbar becomes transparent contact diary day view

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -34,6 +34,7 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 
 		view.backgroundColor = .enaColor(for: .darkBackground)
 
+		// a fix for transparent tab bar when there is content on the back
 		if #available(iOS 15, *) {
 			let appearance = UITabBarAppearance()
 			appearance.configureWithOpaqueBackground()
@@ -46,7 +47,7 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 
 		setupSegmentedControl()
 		setupTableView()
-		// tableView.reloadData()
+		tableView.reloadData()
 
 		viewModel.$day
 			.sink { [weak self] _ in

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -126,6 +126,21 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 			}
 			.store(in: &subscriptions)
 	}
+	
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
+		
+		// we need to reset to our default behaviour for tabbar's standardAppearance and scrollEdgeAppearance
+		if #available(iOS 15, *) {
+			let defaultAppearance = UITabBarAppearance()
+			defaultAppearance.configureWithDefaultBackground()
+			tabBarController?.tabBar.standardAppearance = defaultAppearance
+			
+			let transparentAppearance = UITabBarAppearance()
+			transparentAppearance.configureWithTransparentBackground()
+			tabBarController?.tabBar.scrollEdgeAppearance = transparentAppearance
+		}
+	}
 
 	// MARK: - Protocol UITableViewDataSource
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -34,7 +34,12 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 
 		view.backgroundColor = .enaColor(for: .darkBackground)
 
-		// a fix for transparent tab bar when there is content on the back
+		/*
+		    In iOS 15, the tab bar background automatically adjusts it self, when there is no content on the back it becomes transparent
+		    where as it has a background when there is content on the back. Unfortunately, in our case the tab bar remains transparent even
+		    through there is content on the back, so we fix this by overriding the appearance with a background.
+			Solution is inspired from: https://developer.apple.com/forums/thread/682420
+		*/
 		if #available(iOS 15, *) {
 			let appearance = UITabBarAppearance()
 			appearance.configureWithOpaqueBackground()

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewController.swift
@@ -34,11 +34,19 @@ class DiaryDayViewController: UIViewController, UITableViewDataSource, UITableVi
 
 		view.backgroundColor = .enaColor(for: .darkBackground)
 
+		if #available(iOS 15, *) {
+			let appearance = UITabBarAppearance()
+			appearance.configureWithOpaqueBackground()
+			appearance.backgroundColor = .enaColor(for: .backgroundLightGray)
+			tabBarController?.tabBar.standardAppearance = appearance
+			tabBarController?.tabBar.scrollEdgeAppearance = tabBarController?.tabBar.standardAppearance
+		}
+		
 		tableView.keyboardDismissMode = .interactive
 
 		setupSegmentedControl()
 		setupTableView()
-		tableView.reloadData()
+		// tableView.reloadData()
 
 		viewModel.$day
 			.sink { [weak self] _ in


### PR DESCRIPTION
## Description
On some research, I found out that the tabbar in iOS 15 is a bit buggy, so the easiest way to fix the issue is to set the background view for both states in contact diary day view

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9910

## Screenshots
![Simulator Screen Shot - iPhone 11 - 2021-11-03 at 18 02 47](https://user-images.githubusercontent.com/77438487/140124587-8c8e78c4-0364-4551-ac8e-ea4f9796a1b7.png)
ithubusercontent.com/77438487/140124474-1ea2ac4f-1ad3-45a6-9c5b-db6f139247a8.png)
![Simulator Screen Shot - iPhone 11 - 2021-11-03 at 18 03 05](https://user-images.githubusercontent.com/77438487/140124655-22ef6c2b-288d-43c4-b883-0bbb293a8022.png)


