### PR TITLE
Fix/5897 highlight on selection of transnational exposure logging

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/Cells/EuTracingTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/Cells/EuTracingTableViewCell.swift
@@ -13,7 +13,7 @@ class EuTracingTableViewCell: UITableViewCell {
 	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: style, reuseIdentifier: reuseIdentifier)
 		// self
-		selectionStyle = .none
+		selectionStyle = .default
 		backgroundColor = .enaColor(for: .background)
 		accessoryType = .disclosureIndicator
 		// iconView


### PR DESCRIPTION


## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR fixes an UI/UX issue that was reported as #2246.
Selecting the transnational exposure logging table cell should give a visual feedback before showing the new screen.

## Link to Jira
<!-- Please add the link to the related Jira issue -->
Jira: Internal Tracking ID: EXPOSUREAPP-5897
github: #2246
 
## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->

https://user-images.githubusercontent.com/6118267/140180823-54048dfa-0f11-4fd3-95c6-5f97c237546f.mp4


https://user-images.githubusercontent.com/6118267/140180918-5bd45b27-b9e4-42e5-9593-14cd6a485d89.mp4

