### PR TITLE
Fix/5896 remove highlighting from risk legend

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/Cell/RiskLegendDotBodyCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/RiskLegend/Cell/RiskLegendDotBodyCell.swift
@@ -16,6 +16,7 @@ class RiskLegendDotBodyCell: UITableViewCell {
 	
 	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		selectionStyle = .none
 		// dotView
 		dotView.backgroundColor = .enaColor(for: .riskHigh)
 		dotView.layer.cornerRadius = 8


### PR DESCRIPTION
## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR fixes a UI/UX issue that was reported as #2245. The risk legend cells in the overview screen should not be selectable and should not highlight when you tap on this area.

Note: 
I found another reference to RiskLegendDotBodyCell from [StatisticsInfoViewController](https://github.com/corona-warn-app/cwa-app-ios/blob/49a0a173bcba2b5264f5d46a73b9daed72a0fedb/src/xcode/ENA/ENA/Source/Scenes/StatisticsInfo/StatisticsInfoViewController.swift#L65), and, tbh, I didn't understand this one ... *(can it be dead code?)*

## Link to Jira
<!-- Please add the link to the related Jira issue -->
Jira: Internal Tracking ID: EXPOSUREAPP-5896
github: #2245

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->

Adding the screenshot to make it clear which screen we are talking about.

![Simulator Screen Shot - iPhone SE (1st generation) - 2021-11-03 at 22 41 25](https://user-images.githubusercontent.com/6118267/140197124-f69cebd1-e492-4838-b1f1-070e05fed49b.png)
