### PR TITLE
Make it clearer to only scan your certificates (COMMUNITY)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3176,7 +3176,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "UniversalQRScanner_InstructionTitle" = "Welche QR-Codes können Sie scannen?";
 
-"UniversalQRScanner_InstructionDescription" = "PCR-Tests und Schnelltests, Testzertifikate, Impfzertifikate, Genesenenzertifikate und Check-ins.";
+"UniversalQRScanner_InstructionDescription" = "Ihre PCR-Tests, Schnelltests, Testzertifikate, Impfzertifikate, Genesenenzertifikate sowie Check-ins";
 
 "UniversalQRScanner_FileButtonTitle" = "Datei öffnen";
 


### PR DESCRIPTION
## Description
This PR improves the "UniversalQRScanner_InstructionDescription" to make it clearer that one should not use the CWA to scan the certificates from others (to verify them).

## Link to Jira
- GitHub Issue: https://github.com/corona-warn-app/cwa-wishlist/issues/666
	- [EXPOSUREAPP-10263](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10263)

This PR is only a quick "improvement attempt" for https://github.com/corona-warn-app/cwa-wishlist/issues/666, there has to be done more on this to solve the issue. 
Users are thinking they can use the universal QR code scanner to verify the certificates from others. Best would be if there would be another paragraph added which states that for verifying the certificate the CovPassCheck-App has to be used. 
However, as no such change is in sight, I decided to provide this little PR. 

## Screenshots

| Light Mode | Dark Mode |
|---|---|
|  <img src="https://user-images.githubusercontent.com/67682506/140239421-b8eac4d9-e29f-4aa8-bbbf-18ec65f38c4a.png" width="300"> | <img src="https://user-images.githubusercontent.com/67682506/140239417-ed9ee6f3-3df6-43ae-93de-57b4cf3f00fd.png" width="300">  |

---
Internal Tracking ID: [EXPOSUREAPP-10408](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10408)
