### PR TITLE
Replace scannen with wählen

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3239,7 +3239,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "FileScanner_InvalidQRCode_title" = "Kein geeigneter QR-Code";
 
-"FileScanner_InvalidQRCode_message" = "Der QR-Code wird nicht von der Corona-Warn-App unterstützt. Bitte scannen Sie einen geeigneten QR-Code."; 
+"FileScanner_InvalidQRCode_message" = "Der QR-Code wird nicht von der Corona-Warn-App unterstützt. Bitte wählen Sie einen geeigneten QR-Code."; 
 
 "FileScanner_FileNotReadable_title" = "Datei nicht lesbar";
 


### PR DESCRIPTION
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10247

Actual result:

an error message appears: "Kein geeigneter QR-Code. Der QR-Code wird nicht von der Corona-Warn-App unterstützt. Bitte scannen Sie einen geeigneten QR-Code."


Expected result:

an error message appears: "Kein geeigneter QR-Code. Der QR-Code wird nicht von der Corona-Warn-App unterstützt. Bitte wählen Sie einen geeigneten QR-Code."

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

## Link to Jira
<!-- Please add the link to the related Jira issue -->

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
