### PR TITLE
Feature/10275 invalidate certificates/10387 state UI

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3186,6 +3186,10 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_ValidityState_Invalid_description" = "Das Zertifikat wurde von einer nicht autorisierten Stelle oder fehlerhaft ausgestellt. Bitte lassen Sie das Zertifikat von einer autorisierten Stelle erneut ausstellen.";
 
+"HealthCertificate_ValidityState_Blocked" = "Zertifikat ungültig";
+
+"HealthCertificate_ValidityState_Blocked_description" = "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
+
 /* Universal QR Scanner */
 
 "UniversalQRScanner_ScannerTitle" = "QR-Code-Scanner";

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -27,7 +27,7 @@ struct HealthCertificateQRCodeCellViewModel {
 			showInfoHit: showInfoHit
 		)
 
-		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+		if !healthCertificate.isConsideredValid {
 			switch healthCertificate.validityState {
 			case .valid:
 				self.validityStateIcon = nil
@@ -93,8 +93,7 @@ struct HealthCertificateQRCodeCellViewModel {
 	let qrCodeViewModel: HealthCertificateQRCodeViewModel
 
 	var title: String? {
-		if mode == .overview ||
-			healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+		if mode == .overview || !healthCertificate.isConsideredValid {
 			switch healthCertificate.entry {
 			case .vaccination:
 				return AppStrings.HealthCertificate.Person.VaccinationCertificate.headline

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -27,8 +27,7 @@ struct HealthCertificateQRCodeCellViewModel {
 			showInfoHit: showInfoHit
 		)
 
-		if healthCertificate.validityState == .invalid ||
-			(healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
 			switch healthCertificate.validityState {
 			case .valid:
 				self.validityStateIcon = nil
@@ -66,7 +65,16 @@ struct HealthCertificateQRCodeCellViewModel {
 					self.validityStateDescription = nil
 				}
 				self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
-			}
+			case .blocked:
+				   self.validityStateIcon = UIImage(named: "Icon_ExpiredInvalid")
+				   self.validityStateTitle = AppStrings.HealthCertificate.ValidityState.blocked
+				   if mode == .details {
+					   self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.blockedDescription
+				   } else {
+					   self.validityStateDescription = nil
+				   }
+				   self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
+		   }
 		} else {
 			self.validityStateIcon = nil
 			self.validityStateTitle = nil
@@ -86,8 +94,7 @@ struct HealthCertificateQRCodeCellViewModel {
 
 	var title: String? {
 		if mode == .overview ||
-			healthCertificate.validityState == .invalid ||
-			(healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+			healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
 			switch healthCertificate.entry {
 			case .vaccination:
 				return AppStrings.HealthCertificate.Person.VaccinationCertificate.headline

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
@@ -15,7 +15,7 @@ struct HealthCertificateQRCodeViewModel {
 		showInfoHit: @escaping () -> Void
 	) {
 		self.base45 = healthCertificate.base45
-		self.shouldBlockCertificateCode = healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired)
+		self.shouldBlockCertificateCode = !healthCertificate.isUsable
 		self.accessibilityLabel = accessibilityLabel
 		self.showInfo = showInfoHit
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
@@ -15,8 +15,7 @@ struct HealthCertificateQRCodeViewModel {
 		showInfoHit: @escaping () -> Void
 	) {
 		self.base45 = healthCertificate.base45
-		self.shouldBlockCertificateCode = healthCertificate.validityState == .invalid ||
-		(healthCertificate.type != .test && healthCertificate.validityState == .expired)
+		self.shouldBlockCertificateCode = healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired)
 		self.accessibilityLabel = accessibilityLabel
 		self.showInfo = showInfoHit
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
@@ -597,6 +597,144 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 	}
 
+	func testGIVEN_OverviewViewModelWithBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake(
+								dateOfVaccination: "2021-06-01"
+							)
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake(
+								dateOfVaccination: "2021-06-01"
+							)
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
 	func testGIVEN_OverviewViewModelWithValidTestCertificate_THEN_IsInitCorrect() throws {
 		// GIVEN
 		let date = Date()
@@ -1167,6 +1305,140 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat (Signatur) ungültig")
 		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von einer nicht autorisierten Stelle oder fehlerhaft ausgestellt. Bitte lassen Sie das Zertifikat von einer autorisierten Stelle erneut ausstellen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_OverviewViewModelWithBlockedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyBlockedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyBlockedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
 
@@ -1747,6 +2019,140 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat (Signatur) ungültig")
 		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von einer nicht autorisierten Stelle oder fehlerhaft ausgestellt. Bitte lassen Sie das Zertifikat von einer autorisierten Stelle erneut ausstellen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_OverviewViewModelWithBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: { _, _ in },
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					from: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .blocked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onValidationButtonTap: nil,
+			showInfoHit: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -114,6 +114,32 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
 	}
 
+	func testBlockedVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			"https://www.coronawarn.app/de/faq/#hc_signature_invalid"
+		)
+
+		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
 	// MARK: - Test Certificate
 
 	func testValidTestCertificate() throws {
@@ -220,6 +246,32 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
 	}
 
+	func testBlockedTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			"https://www.coronawarn.app/de/faq/#hc_signature_invalid"
+		)
+
+		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
 	// MARK: - Recovery Certificate
 
 	func testValidRecoveryCertificate() throws {
@@ -308,6 +360,32 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 				)
 			),
 			validityState: .invalid
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			"https://www.coronawarn.app/de/faq/#hc_signature_invalid"
+		)
+
+		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
+	func testBlockedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
 		)
 
 		let viewModel = HealthCertificateQRCodeViewModel(

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
@@ -283,6 +283,7 @@ final class HealthCertificateCoordinator {
 				)
 			}
 		)
+		printAction.isEnabled = healthCertificate.validityState != .blocked
 		actionSheet.addAction(printAction)
 
 		let deleteButtonTitle: String

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -21,11 +21,11 @@ final class HealthCertificateCellViewModel {
 	let healthCertificate: HealthCertificate
 
 	lazy var gradientType: GradientView.GradientType = {
-		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired) ||
-			healthCertificate != healthCertifiedPerson.mostRelevantHealthCertificate {
-			return .solidGrey(withStars: false)
-		} else {
+		if healthCertificate.isUsable &&
+			healthCertificate == healthCertifiedPerson.mostRelevantHealthCertificate {
 			return .lightBlue(withStars: false)
+		} else {
+			return .solidGrey(withStars: false)
 		}
 	}()
 
@@ -87,7 +87,7 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var validityStateInfo: String? = {
-		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+		if !healthCertificate.isConsideredValid {
 			switch healthCertificate.validityState {
 			case .valid:
 				return nil
@@ -112,7 +112,7 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var image: UIImage = {
-		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired) {
+		guard healthCertificate.isUsable else {
 			return UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small")
 		}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -21,8 +21,7 @@ final class HealthCertificateCellViewModel {
 	let healthCertificate: HealthCertificate
 
 	lazy var gradientType: GradientView.GradientType = {
-		if healthCertificate.validityState == .invalid ||
-			(healthCertificate.type != .test && healthCertificate.validityState == .expired) ||
+		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired) ||
 			healthCertificate != healthCertifiedPerson.mostRelevantHealthCertificate {
 			return .solidGrey(withStars: false)
 		} else {
@@ -88,8 +87,7 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var validityStateInfo: String? = {
-		if healthCertificate.validityState == .invalid ||
-			(healthCertificate.type != .test && healthCertificate.validityState != .valid) {
+		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState != .valid) {
 			switch healthCertificate.validityState {
 			case .valid:
 				return nil
@@ -103,6 +101,8 @@ final class HealthCertificateCellViewModel {
 				return AppStrings.HealthCertificate.ValidityState.expired
 			case .invalid:
 				return AppStrings.HealthCertificate.ValidityState.invalid
+			case .blocked:
+				return AppStrings.HealthCertificate.ValidityState.blocked
 			}
 		} else if healthCertificate.isNew {
 			return AppStrings.HealthCertificate.Person.newlyAddedCertificate
@@ -112,8 +112,7 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var image: UIImage = {
-		if healthCertificate.validityState == .invalid ||
-			(healthCertificate.type != .test && healthCertificate.validityState == .expired) {
+		if healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked || (healthCertificate.type != .test && healthCertificate.validityState == .expired) {
 			return UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small")
 		}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
@@ -253,6 +253,39 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
 	}
 
+	func testViewModelWithBlockedIncompleteVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [
+						VaccinationEntry.fake(
+							doseNumber: 1,
+							totalSeriesOfDoses: 2,
+							dateOfVaccination: "2021-06-01"
+						)
+					]
+				)
+			),
+			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey(withStars: false))
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertEqual(viewModel.subheadline, "Impfung 1 von 2")
+		XCTAssertEqual(viewModel.detail, "Geimpft am 01.06.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+	}
+
 	func testViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -478,6 +511,38 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
 	}
 
+	func testViewModelWithBlockedAntigenTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [
+						TestEntry.fake(
+							typeOfTest: "LP217198-3",
+							dateTimeOfSampleCollection: "2021-05-29T14:36:00.000Z"
+						)
+					]
+				)
+			),
+			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey(withStars: false))
+		XCTAssertEqual(viewModel.headline, "Testzertifikat")
+		XCTAssertEqual(viewModel.subheadline, "Schnelltest")
+		XCTAssertEqual(viewModel.detail, "Probenahme am 29.05.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+	}
+
 	func testViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -637,6 +702,37 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertNil(viewModel.subheadline)
 		XCTAssertEqual(viewModel.detail, "gültig bis 18.03.22")
 		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat (Signatur) ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+	}
+
+	func testViewModelWithBlockedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [
+						RecoveryEntry.fake(
+							certificateValidUntil: "2022-03-18T07:12:45.132Z"
+						)
+					]
+				)
+			),
+			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey(withStars: false))
+		XCTAssertEqual(viewModel.headline, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subheadline)
+		XCTAssertEqual(viewModel.detail, "gültig bis 18.03.22")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
 		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
 		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -31,8 +31,7 @@ class HealthCertifiedPersonCellModel {
 
 		if healthCertifiedPerson.unseenNewsCount > 0 {
 			self.caption = .unseenNews(count: healthCertifiedPerson.unseenNewsCount)
-		} else if mostRelevantCertificate.validityState == .invalid ||
-			(mostRelevantCertificate.type != .test && mostRelevantCertificate.validityState != .valid) {
+		} else if mostRelevantCertificate.validityState == .invalid || mostRelevantCertificate.validityState == .blocked || (mostRelevantCertificate.type != .test && mostRelevantCertificate.validityState != .valid) {
 			switch mostRelevantCertificate.validityState {
 			case .valid:
 				self.caption = nil
@@ -56,6 +55,11 @@ class HealthCertifiedPersonCellModel {
 				self.caption = .validityState(
 					image: UIImage(named: "Icon_ExpiredInvalid"),
 					description: AppStrings.HealthCertificate.ValidityState.invalid
+				)
+			case .blocked:
+				self.caption = .validityState(
+					image: UIImage(named: "Icon_ExpiredInvalid"),
+					description: AppStrings.HealthCertificate.ValidityState.blocked
 				)
 			}
 		} else {

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -31,7 +31,7 @@ class HealthCertifiedPersonCellModel {
 
 		if healthCertifiedPerson.unseenNewsCount > 0 {
 			self.caption = .unseenNews(count: healthCertifiedPerson.unseenNewsCount)
-		} else if mostRelevantCertificate.validityState == .invalid || mostRelevantCertificate.validityState == .blocked || (mostRelevantCertificate.type != .test && mostRelevantCertificate.validityState != .valid) {
+		} else if !mostRelevantCertificate.isConsideredValid {
 			switch mostRelevantCertificate.validityState {
 			case .valid:
 				self.caption = nil

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
@@ -6,6 +6,7 @@ import XCTest
 import HealthCertificateToolkit
 @testable import ENA
 
+// swiftlint:disable type_body_length
 class HealthCertifiedPersonCellModelTests: XCTestCase {
 
 	func testHealthCertifiedPersonWithValidVaccinationCertificate() throws {
@@ -140,6 +141,38 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 		}
 	}
 
+	func testHealthCertifiedPersonWithBlockedVaccinationCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				showInfoHit: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
 	func testHealthCertifiedPersonWithValidTestCertificate() throws {
 		// GIVEN
 		let healthCertificate = try HealthCertificate(
@@ -248,6 +281,37 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 		if case let .validityState(image: image, description: description) = viewModel.caption {
 			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
 			XCTAssertEqual(description, "Zertifikat (Signatur) ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
+	func testHealthCertifiedPersonWithBlockedTestCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				showInfoHit: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
 		} else {
 			XCTFail("Expected caption to be set to validityState")
 		}
@@ -380,6 +444,38 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 		if case let .validityState(image: image, description: description) = viewModel.caption {
 			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
 			XCTAssertEqual(description, "Zertifikat (Signatur) ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
+	func testHealthCertifiedPersonWithBlockedRecoveryCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				showInfoHit: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
 		} else {
 			XCTFail("Expected caption to be set to validityState")
 		}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -524,8 +524,8 @@ class HealthCertificateService {
 				}
 
 				if healthCertificate.validityState != previousValidityState {
-					/// Only validity states that are not `.valid` should be marked as new for the user. On test certificates only `.valid` and `.invalid` state are shown, so only the `.invalid` state is marked as new.
-					healthCertificate.isValidityStateNew = healthCertificate.type == .test && healthCertificate.validityState == .invalid || healthCertificate.type != .test && healthCertificate.validityState != .valid
+					/// Only validity states that are not `.valid` should be marked as new for the user. On test certificates only `.valid`, `.invalid`, and `.blocked` state are shown, so only the `.invalid` and `.blocked` state is marked as new.
+					healthCertificate.isValidityStateNew = healthCertificate.type == .test && (healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked) || healthCertificate.type != .test && healthCertificate.validityState != .valid
 				}
 
 				healthCertifiedPerson.triggerMostRelevantCertificateUpdate()

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -524,8 +524,8 @@ class HealthCertificateService {
 				}
 
 				if healthCertificate.validityState != previousValidityState {
-					/// Only validity states that are not `.valid` should be marked as new for the user. On test certificates only `.valid`, `.invalid`, and `.blocked` state are shown, so only the `.invalid` and `.blocked` state is marked as new.
-					healthCertificate.isValidityStateNew = healthCertificate.type == .test && (healthCertificate.validityState == .invalid || healthCertificate.validityState == .blocked) || healthCertificate.type != .test && healthCertificate.validityState != .valid
+					/// Only validity states that are not shown as `.valid` should be marked as new for the user.
+					healthCertificate.isValidityStateNew = !healthCertificate.isConsideredValid
 				}
 
 				healthCertifiedPerson.triggerMostRelevantCertificateUpdate()

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/HealthCertificateArray+MostRelevant.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/Extensions/HealthCertificateArray+MostRelevant.swift
@@ -38,26 +38,34 @@ extension Array where Element == HealthCertificate {
 	}
 
 	var mostRelevant: HealthCertificate? {
-		let sortedHealthCertificates = sorted()
+		mostRelevantValidOrExpiringSoon ?? mostRelevantExpired ?? mostRelevantInvalidOrBlocked ?? first
+	}
 
-		return sortedHealthCertificates.filter({
-			$0.validityState == .valid || $0.validityState == .expiringSoon
-		}).mostRelevantIgnoringValidityState ??
-		
-		sortedHealthCertificates.filter({
-			$0.validityState == .expired
-		}).mostRelevantIgnoringValidityState ??
-		
-		sortedHealthCertificates.filter({
-			$0.validityState == .invalid
-		}).mostRelevantIgnoringValidityState ??
+	private var mostRelevantValidOrExpiringSoon: HealthCertificate? {
+		sorted()
+			.filter {
+				$0.validityState == .valid || $0.validityState == .expiringSoon
+			}
+			.mostRelevantIgnoringValidityState
+	}
 
-		// Fallback
-		first
+	private var mostRelevantExpired: HealthCertificate? {
+		sorted()
+			.filter {
+				$0.validityState == .expired
+			}
+			.mostRelevantIgnoringValidityState
+	}
+
+	private var mostRelevantInvalidOrBlocked: HealthCertificate? {
+		sorted()
+			.filter {
+				$0.validityState == .invalid || $0.validityState == .blocked
+			}
+			.mostRelevantIgnoringValidityState
 	}
 	
 	private var mostRelevantIgnoringValidityState: HealthCertificate? {
-		
 		// PCR Test Certificate < 48 hours
 
 		let currentPCRTestCertificate = last {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -228,6 +228,15 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		return Calendar.current.dateComponents([.day], from: sortDate, to: Date()).day
 	}
 
+	var isUsable: Bool {
+		validityState == .valid || validityState == .expiringSoon || (type == .test && validityState == .expired)
+	}
+
+	var isConsideredValid: Bool {
+		/// On test certificates only `.valid`, `.invalid`, and `.blocked` states are shown, the `.expiringSoon` and `.expired` states are considered valid as well
+		validityState == .valid || type == .test && (validityState == .expiringSoon || validityState == .expired)
+	}
+
 	// MARK: - Private
 
 	private var sortDate: Date? {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -232,8 +232,8 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		validityState == .valid || validityState == .expiringSoon || (type == .test && validityState == .expired)
 	}
 
+	/// On test certificates only `.valid`, `.invalid`, and `.blocked` states are shown, the `.expiringSoon` and `.expired` states are considered valid as well
 	var isConsideredValid: Bool {
-		/// On test certificates only `.valid`, `.invalid`, and `.blocked` states are shown, the `.expiringSoon` and `.expired` states are considered valid as well
 		validityState == .valid || type == .test && (validityState == .expiringSoon || validityState == .expired)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateValidityState.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateValidityState.swift
@@ -9,4 +9,5 @@ enum HealthCertificateValidityState: Int, Codable {
 	case expiringSoon
 	case expired
 	case invalid
+	case blocked
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertificateArray+MostRelevantTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertificateArray+MostRelevantTests.swift
@@ -69,7 +69,7 @@ class HealthCertificateArrayMostRelevantTests: CWATestCase {
 		let olderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 653)
 		let expiredOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 24, validityState: .expired)
 		let invalidOlderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 24, validityState: .invalid)
-		let blockedOlderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 23, validityState: .blocked)
+		let blockedOlderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 25, validityState: .blocked)
 
 		var healthCertificates = [
 			mostRecentValidPCRTest,

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertificateArray+MostRelevantTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__test__/HealthCertificateArray+MostRelevantTests.swift
@@ -15,102 +15,122 @@ class HealthCertificateArrayMostRelevantTests: CWATestCase {
    		let olderValidPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 47)
 		let expiredRecentPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 12, validityState: .expired)
 		let invalidRecentPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 12, validityState: .invalid)
+		let blockedRecentPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 14, validityState: .blocked)
 
 		let mostRecentValidAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 2)
 		let olderValidAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 23)
 		let expiredRecentAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 1, validityState: .expired)
 		let invalidRecentAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 1, validityState: .invalid)
+		let blockedRecentAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 2, validityState: .blocked)
 
 		let mostRecentBoosterVaccinationCertificate = try vaccinationCertificate(type: .booster, ageInDays: 18)
 		let olderBoosterVaccinationCertificate = try vaccinationCertificate(type: .booster, ageInDays: 298)
 		let expiredRecentBoosterVaccinationCertificate = try vaccinationCertificate(type: .booster, ageInDays: 1, validityState: .expired)
 		let invalidRecentBoosterVaccinationCertificate = try vaccinationCertificate(type: .booster, ageInDays: 1, validityState: .invalid)
+		let blockedRecentBoosterVaccinationCertificate = try vaccinationCertificate(type: .booster, ageInDays: 2, validityState: .blocked)
 
 		let mostRecentProtectingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 17)
 		let olderProtectingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 296)
 		let expiredRecentProtectingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 15, validityState: .expired)
 		let invalidRecentProtectingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 15, validityState: .invalid)
+		let blockedRecentProtectingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 16, validityState: .blocked)
 
 		let mostRecentValidRecoveryCertificate = try recoveryCertificate(ageInDays: 10)
 		let olderValidRecoveryCertificate = try recoveryCertificate(ageInDays: 180)
 		let expiredRecentValidRecoveryCertificate = try recoveryCertificate(ageInDays: 5, validityState: .expired)
 		let invalidRecentValidRecoveryCertificate = try recoveryCertificate(ageInDays: 5, validityState: .invalid)
+		let blockedRecentValidRecoveryCertificate = try recoveryCertificate(ageInDays: 6, validityState: .blocked)
 
 		let mostRecentSeriesCompletingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 3)
 		let olderSeriesCompletingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 14)
 		let expiredRecentSeriesCompletingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 1, validityState: .expired)
 		let invalidRecentSeriesCompletingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 1, validityState: .invalid)
+		let blockedRecentSeriesCompletingVaccinationCertificate = try vaccinationCertificate(type: .seriesCompleting, ageInDays: 2, validityState: .blocked)
 
 		let mostRecentOtherVaccinationCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 5)
 		let olderOtherVaccinationCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 14)
 		let expiredRecentOtherVaccinationCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 3, validityState: .expired)
 		let invalidRecentOtherVaccinationCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 14, validityState: .invalid)
+		let blockedRecentOtherVaccinationCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 15, validityState: .blocked)
 
 		let mostRecentOutdatedRecoveryCertificate = try recoveryCertificate(ageInDays: 185)
 		let olderOutdatedRecoveryCertificate = try recoveryCertificate(ageInDays: 522)
 		let expiredRecentOutdatedRecoveryCertificate = try recoveryCertificate(ageInDays: 181, validityState: .expired)
 		let invalidRecentOutdatedRecoveryCertificate = try recoveryCertificate(ageInDays: 181, validityState: .invalid)
+		let blockedRecentOutdatedRecoveryCertificate = try recoveryCertificate(ageInDays: 182, validityState: .blocked)
 
 		let mostRecentOutdatedPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 48)
 		let olderOutdatedPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 1068)
 		let expiredRecentOutdatedPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 48, validityState: .expired)
 		let invalidOlderOutdatedPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 48, validityState: .invalid)
+		let blockedOlderOutdatedPCRTest = try testCertificate(coronaTestType: .pcr, ageInHours: 49, validityState: .blocked)
 
 		let mostRecentOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 24)
 		let olderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 653)
 		let expiredOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 24, validityState: .expired)
 		let invalidOlderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 24, validityState: .invalid)
+		let blockedOlderOutdatedAntigenTest = try testCertificate(coronaTestType: .antigen, ageInHours: 23, validityState: .blocked)
 
 		var healthCertificates = [
 			mostRecentValidPCRTest,
 			olderValidPCRTest,
 			expiredRecentPCRTest,
 			invalidRecentPCRTest,
+			blockedRecentPCRTest,
 			
 			mostRecentValidAntigenTest,
 			olderValidAntigenTest,
 			expiredRecentAntigenTest,
 			invalidRecentAntigenTest,
+			blockedRecentAntigenTest,
 
 			mostRecentBoosterVaccinationCertificate,
 			olderBoosterVaccinationCertificate,
 			expiredRecentBoosterVaccinationCertificate,
 			invalidRecentBoosterVaccinationCertificate,
+			blockedRecentBoosterVaccinationCertificate,
 			
 			mostRecentProtectingVaccinationCertificate,
 			olderProtectingVaccinationCertificate,
 			expiredRecentProtectingVaccinationCertificate,
 			invalidRecentProtectingVaccinationCertificate,
+			blockedRecentProtectingVaccinationCertificate,
 			
 			mostRecentValidRecoveryCertificate,
 			olderValidRecoveryCertificate,
 			expiredRecentValidRecoveryCertificate,
 			invalidRecentValidRecoveryCertificate,
+			blockedRecentValidRecoveryCertificate,
 			
 			mostRecentSeriesCompletingVaccinationCertificate,
 			olderSeriesCompletingVaccinationCertificate,
 			expiredRecentSeriesCompletingVaccinationCertificate,
 			invalidRecentSeriesCompletingVaccinationCertificate,
+			blockedRecentSeriesCompletingVaccinationCertificate,
 			
 			mostRecentOtherVaccinationCertificate,
 			olderOtherVaccinationCertificate,
 			expiredRecentOtherVaccinationCertificate,
 			invalidRecentOtherVaccinationCertificate,
+			blockedRecentOtherVaccinationCertificate,
 			
 			mostRecentOutdatedRecoveryCertificate,
 			olderOutdatedRecoveryCertificate,
 			expiredRecentOutdatedRecoveryCertificate,
 			invalidRecentOutdatedRecoveryCertificate,
+			blockedRecentOutdatedRecoveryCertificate,
 			
 			mostRecentOutdatedPCRTest,
 			olderOutdatedPCRTest,
 			expiredRecentOutdatedPCRTest,
 			invalidOlderOutdatedPCRTest,
+			blockedOlderOutdatedPCRTest,
 			
 			mostRecentOutdatedAntigenTest,
 			olderOutdatedAntigenTest,
 			expiredOutdatedAntigenTest,
-			invalidOlderOutdatedAntigenTest
+			invalidOlderOutdatedAntigenTest,
+			blockedOlderOutdatedAntigenTest
 		].shuffled()
 
 		// Valid and Expiring Soon Certificates are the most relevant
@@ -212,33 +232,63 @@ class HealthCertificateArrayMostRelevantTests: CWATestCase {
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentPCRTest)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentPCRTest })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentPCRTest)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentPCRTest })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentAntigenTest)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentAntigenTest })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentAntigenTest)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentAntigenTest })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentBoosterVaccinationCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentBoosterVaccinationCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentBoosterVaccinationCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentBoosterVaccinationCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentProtectingVaccinationCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentProtectingVaccinationCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentProtectingVaccinationCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentProtectingVaccinationCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentValidRecoveryCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentValidRecoveryCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentValidRecoveryCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentValidRecoveryCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentSeriesCompletingVaccinationCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentSeriesCompletingVaccinationCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentSeriesCompletingVaccinationCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentSeriesCompletingVaccinationCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentOtherVaccinationCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentOtherVaccinationCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentOtherVaccinationCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentOtherVaccinationCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidRecentOutdatedRecoveryCertificate)
 
 		healthCertificates.removeAll(where: { $0 == invalidRecentOutdatedRecoveryCertificate })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedRecentOutdatedRecoveryCertificate)
+
+		healthCertificates.removeAll(where: { $0 == blockedRecentOutdatedRecoveryCertificate })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidOlderOutdatedPCRTest)
 
 		healthCertificates.removeAll(where: { $0 == invalidOlderOutdatedPCRTest })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedOlderOutdatedPCRTest)
+
+		healthCertificates.removeAll(where: { $0 == blockedOlderOutdatedPCRTest })
 		XCTAssertEqual(healthCertificates.mostRelevant, invalidOlderOutdatedAntigenTest)
 
 		healthCertificates.removeAll(where: { $0 == invalidOlderOutdatedAntigenTest })
+		XCTAssertEqual(healthCertificates.mostRelevant, blockedOlderOutdatedAntigenTest)
+
+		healthCertificates.removeAll(where: { $0 == blockedOlderOutdatedAntigenTest })
 		XCTAssertTrue(healthCertificates.isEmpty)
 	}
 	// MARK: - Private

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2205,6 +2205,8 @@ enum AppStrings {
 			static let expiredDescription = NSLocalizedString("HealthCertificate_ValidityState_Expired_description", comment: "")
 			static let invalid = NSLocalizedString("HealthCertificate_ValidityState_Invalid", comment: "")
 			static let invalidDescription = NSLocalizedString("HealthCertificate_ValidityState_Invalid_description", comment: "")
+			static let blocked = NSLocalizedString("HealthCertificate_ValidityState_Blocked", comment: "")
+			static let blockedDescription = NSLocalizedString("HealthCertificate_ValidityState_Blocked_description", comment: "")
 		}
 
 		enum Alert {


### PR DESCRIPTION
## Description
Adds the enum case and the adapted UI for the new blocked certificate validity state. Also disables printing for blocked certificates.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10387
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10389

## Screenshots
![IMG_0199](https://user-images.githubusercontent.com/1157991/140311959-b7eb1b3b-ac44-4d9d-be23-464792e93910.jpeg)
![IMG_0200](https://user-images.githubusercontent.com/1157991/140312022-742fb7c6-9aa0-405d-9944-d12f153e8850.jpeg)
![IMG_0201](https://user-images.githubusercontent.com/1157991/140312033-7b57b6f5-6a2f-403d-b0be-a3799a01adcc.jpeg)
![IMG_0202](https://user-images.githubusercontent.com/1157991/140312049-eb8b63e6-c49a-4476-81b0-3ec2b473d224.jpeg)
![IMG_0203](https://user-images.githubusercontent.com/1157991/140312064-2a2b41a6-8b9e-4aa4-9323-fd37cb26f1cf.jpeg)


