### PR TITLE
Regenerate protobuf models

### DIFF
--- a/src/xcode/gen/output/external/exposurenotification/temporary_exposure_key_export.pb.swift
+++ b/src/xcode/gen/output/external/exposurenotification/temporary_exposure_key_export.pb.swift
@@ -278,21 +278,25 @@ extension SAP_External_Exposurenotification_TemporaryExposureKeyExport: SwiftPro
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._startTimestamp {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._startTimestamp {
       try visitor.visitSingularFixed64Field(value: v, fieldNumber: 1)
-    }
-    if let v = self._endTimestamp {
+    } }()
+    try { if let v = self._endTimestamp {
       try visitor.visitSingularFixed64Field(value: v, fieldNumber: 2)
-    }
-    if let v = self._region {
+    } }()
+    try { if let v = self._region {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    }
-    if let v = self._batchNum {
+    } }()
+    try { if let v = self._batchNum {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
-    }
-    if let v = self._batchSize {
+    } }()
+    try { if let v = self._batchSize {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 5)
-    }
+    } }()
     if !self.signatureInfos.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.signatureInfos, fieldNumber: 6)
     }
@@ -342,21 +346,25 @@ extension SAP_External_Exposurenotification_SignatureInfo: SwiftProtobuf.Message
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._appBundleID {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._appBundleID {
       try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    }
-    if let v = self._androidPackage {
+    } }()
+    try { if let v = self._androidPackage {
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
-    if let v = self._verificationKeyVersion {
+    } }()
+    try { if let v = self._verificationKeyVersion {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    }
-    if let v = self._verificationKeyID {
+    } }()
+    try { if let v = self._verificationKeyID {
       try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    }
-    if let v = self._signatureAlgorithm {
+    } }()
+    try { if let v = self._signatureAlgorithm {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -400,24 +408,28 @@ extension SAP_External_Exposurenotification_TemporaryExposureKey: SwiftProtobuf.
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._keyData {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._keyData {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-    }
-    if let v = self._transmissionRiskLevel {
+    } }()
+    try { if let v = self._transmissionRiskLevel {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    }
-    if let v = self._rollingStartIntervalNumber {
+    } }()
+    try { if let v = self._rollingStartIntervalNumber {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-    }
-    if let v = self._rollingPeriod {
+    } }()
+    try { if let v = self._rollingPeriod {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 4)
-    }
-    if let v = self._reportType {
+    } }()
+    try { if let v = self._reportType {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    }
-    if let v = self._daysSinceOnsetOfSymptoms {
+    } }()
+    try { if let v = self._daysSinceOnsetOfSymptoms {
       try visitor.visitSingularSInt32Field(value: v, fieldNumber: 6)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/external/exposurenotification/temporary_exposure_key_signature_list.pb.swift
+++ b/src/xcode/gen/output/external/exposurenotification/temporary_exposure_key_signature_list.pb.swift
@@ -153,18 +153,22 @@ extension SAP_External_Exposurenotification_TEKSignature: SwiftProtobuf.Message,
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._signatureInfo {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._signatureInfo {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._batchNum {
+    } }()
+    try { if let v = self._batchNum {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    }
-    if let v = self._batchSize {
+    } }()
+    try { if let v = self._batchSize {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 3)
-    }
-    if let v = self._signature {
+    } }()
+    try { if let v = self._signature {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/app_config.pb.swift
+++ b/src/xcode/gen/output/internal/app_config.pb.swift
@@ -211,39 +211,43 @@ extension SAP_Internal_ApplicationConfiguration: SwiftProtobuf.Message, SwiftPro
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
       if _storage._minRiskScore != 0 {
         try visitor.visitSingularInt32Field(value: _storage._minRiskScore, fieldNumber: 1)
       }
-      if let v = _storage._riskScoreClasses {
+      try { if let v = _storage._riskScoreClasses {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._exposureConfig {
+      } }()
+      try { if let v = _storage._exposureConfig {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
-      if let v = _storage._attenuationDuration {
+      } }()
+      try { if let v = _storage._attenuationDuration {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }
-      if let v = _storage._appVersion {
+      } }()
+      try { if let v = _storage._appVersion {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._appFeatures {
+      } }()
+      try { if let v = _storage._appFeatures {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }
+      } }()
       if !_storage._supportedCountries.isEmpty {
         try visitor.visitRepeatedStringField(value: _storage._supportedCountries, fieldNumber: 7)
       }
-      if let v = _storage._iosKeyDownloadParameters {
+      try { if let v = _storage._iosKeyDownloadParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._androidKeyDownloadParameters {
+      } }()
+      try { if let v = _storage._androidKeyDownloadParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }
-      if let v = _storage._iosExposureDetectionParameters {
+      } }()
+      try { if let v = _storage._iosExposureDetectionParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }
-      if let v = _storage._androidExposureDetectionParameters {
+      } }()
+      try { if let v = _storage._androidExposureDetectionParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/src/xcode/gen/output/internal/app_version_config.pb.swift
+++ b/src/xcode/gen/output/internal/app_version_config.pb.swift
@@ -125,12 +125,16 @@ extension SAP_Internal_ApplicationVersionConfiguration: SwiftProtobuf.Message, S
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._ios {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._ios {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._android {
+    } }()
+    try { if let v = self._android {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -163,12 +167,16 @@ extension SAP_Internal_ApplicationVersionInfo: SwiftProtobuf.Message, SwiftProto
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._latest {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._latest {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._min {
+    } }()
+    try { if let v = self._min {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/attenuation_duration.pb.swift
+++ b/src/xcode/gen/output/internal/attenuation_duration.pb.swift
@@ -116,12 +116,16 @@ extension SAP_Internal_AttenuationDuration: SwiftProtobuf.Message, SwiftProtobuf
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._thresholds {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._thresholds {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._weights {
+    } }()
+    try { if let v = self._weights {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.defaultBucketOffset != 0 {
       try visitor.visitSingularInt32Field(value: self.defaultBucketOffset, fieldNumber: 3)
     }

--- a/src/xcode/gen/output/internal/dgc/value_sets.pb.swift
+++ b/src/xcode/gen/output/internal/dgc/value_sets.pb.swift
@@ -175,27 +175,31 @@ extension SAP_Internal_Dgc_ValueSets: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._vp {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._vp {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._mp {
+    } }()
+    try { if let v = self._mp {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
-    if let v = self._ma {
+    } }()
+    try { if let v = self._ma {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
-    if let v = self._tg {
+    } }()
+    try { if let v = self._tg {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    }
-    if let v = self._tcTt {
+    } }()
+    try { if let v = self._tcTt {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
-    if let v = self._tcMa {
+    } }()
+    try { if let v = self._tcMa {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
-    if let v = self._tcTr {
+    } }()
+    try { if let v = self._tcTr {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/evreg/check_in.pb.swift
+++ b/src/xcode/gen/output/internal/evreg/check_in.pb.swift
@@ -157,12 +157,16 @@ extension SAP_Internal_Evreg_CheckIn: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.trl != 0 {
       try visitor.visitSingularUInt32Field(value: self.trl, fieldNumber: 1)
     }
-    if let v = self._signedEvent {
+    try { if let v = self._signedEvent {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.checkinTime != 0 {
       try visitor.visitSingularUInt32Field(value: self.checkinTime, fieldNumber: 3)
     }
@@ -339,12 +343,16 @@ extension SAP_Internal_Evreg_CheckInOption4: SwiftProtobuf.Message, SwiftProtobu
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.trl != 0 {
       try visitor.visitSingularUInt32Field(value: self.trl, fieldNumber: 1)
     }
-    if let v = self._signedEvent {
+    try { if let v = self._signedEvent {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.checkinTime != 0 {
       try visitor.visitSingularUInt32Field(value: self.checkinTime, fieldNumber: 3)
     }

--- a/src/xcode/gen/output/internal/evreg/signed_event.pb.swift
+++ b/src/xcode/gen/output/internal/evreg/signed_event.pb.swift
@@ -70,9 +70,13 @@ extension SAP_Internal_Evreg_SignedEvent: SwiftProtobuf.Message, SwiftProtobuf._
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._event {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._event {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.signature.isEmpty {
       try visitor.visitSingularBytesField(value: self.signature, fieldNumber: 2)
     }

--- a/src/xcode/gen/output/internal/ppdd/edus_otp_request_ios.pb.swift
+++ b/src/xcode/gen/output/internal/ppdd/edus_otp_request_ios.pb.swift
@@ -78,12 +78,16 @@ extension SAP_Internal_Ppdd_EDUSOneTimePasswordRequestIOS: SwiftProtobuf.Message
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._authentication {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._authentication {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._payload {
+    } }()
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/ppdd/els_otp_request_ios.pb.swift
+++ b/src/xcode/gen/output/internal/ppdd/els_otp_request_ios.pb.swift
@@ -78,12 +78,16 @@ extension SAP_Internal_Ppdd_ELSOneTimePasswordRequestIOS: SwiftProtobuf.Message,
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._authentication {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._authentication {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._payload {
+    } }()
+    try { if let v = self._payload {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/ppdd/ppa_data.pb.swift
+++ b/src/xcode/gen/output/internal/ppdd/ppa_data.pb.swift
@@ -909,6 +909,10 @@ extension SAP_Internal_Ppdd_PPADataIOS: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.requestPadding.isEmpty {
       try visitor.visitSingularBytesField(value: self.requestPadding, fieldNumber: 1)
     }
@@ -924,12 +928,12 @@ extension SAP_Internal_Ppdd_PPADataIOS: SwiftProtobuf.Message, SwiftProtobuf._Me
     if !self.keySubmissionMetadataSet.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.keySubmissionMetadataSet, fieldNumber: 5)
     }
-    if let v = self._clientMetadata {
+    try { if let v = self._clientMetadata {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
-    if let v = self._userMetadata {
+    } }()
+    try { if let v = self._userMetadata {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -977,6 +981,10 @@ extension SAP_Internal_Ppdd_PPADataAndroid: SwiftProtobuf.Message, SwiftProtobuf
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.requestPadding.isEmpty {
       try visitor.visitSingularBytesField(value: self.requestPadding, fieldNumber: 1)
     }
@@ -992,12 +1000,12 @@ extension SAP_Internal_Ppdd_PPADataAndroid: SwiftProtobuf.Message, SwiftProtobuf
     if !self.keySubmissionMetadataSet.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.keySubmissionMetadataSet, fieldNumber: 5)
     }
-    if let v = self._clientMetadata {
+    try { if let v = self._clientMetadata {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
-    if let v = self._userMetadata {
+    } }()
+    try { if let v = self._userMetadata {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1111,9 +1119,13 @@ extension SAP_Internal_Ppdd_PPANewExposureWindow: SwiftProtobuf.Message, SwiftPr
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._exposureWindow {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._exposureWindow {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.transmissionRiskLevel != 0 {
       try visitor.visitSingularInt32Field(value: self.transmissionRiskLevel, fieldNumber: 2)
     }
@@ -1445,12 +1457,16 @@ extension SAP_Internal_Ppdd_PPAClientMetadataIOS: SwiftProtobuf.Message, SwiftPr
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._cwaVersion {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._cwaVersion {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._iosVersion {
+    } }()
+    try { if let v = self._iosVersion {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if !self.appConfigEtag.isEmpty {
       try visitor.visitSingularStringField(value: self.appConfigEtag, fieldNumber: 3)
     }
@@ -1491,9 +1507,13 @@ extension SAP_Internal_Ppdd_PPAClientMetadataAndroid: SwiftProtobuf.Message, Swi
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._cwaVersion {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._cwaVersion {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.androidApiLevel != 0 {
       try visitor.visitSingularInt64Field(value: self.androidApiLevel, fieldNumber: 2)
     }

--- a/src/xcode/gen/output/internal/ppdd/ppa_data_request_ios.pb.swift
+++ b/src/xcode/gen/output/internal/ppdd/ppa_data_request_ios.pb.swift
@@ -102,12 +102,16 @@ extension SAP_Internal_Ppdd_PPADataRequestIOS: SwiftProtobuf.Message, SwiftProto
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._authentication {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._authentication {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._payload {
+      } }()
+      try { if let v = _storage._payload {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/src/xcode/gen/output/internal/pt/qr_code_poster_template.pb.swift
+++ b/src/xcode/gen/output/internal/pt/qr_code_poster_template.pb.swift
@@ -167,6 +167,10 @@ extension SAP_Internal_Pt_QRCodePosterTemplateAndroid: SwiftProtobuf.Message, Sw
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.template.isEmpty {
       try visitor.visitSingularBytesField(value: self.template, fieldNumber: 1)
     }
@@ -179,9 +183,9 @@ extension SAP_Internal_Pt_QRCodePosterTemplateAndroid: SwiftProtobuf.Message, Sw
     if self.qrCodeSideLength != 0 {
       try visitor.visitSingularUInt32Field(value: self.qrCodeSideLength, fieldNumber: 4)
     }
-    if let v = self._descriptionTextBox {
+    try { if let v = self._descriptionTextBox {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -287,6 +291,10 @@ extension SAP_Internal_Pt_QRCodePosterTemplateIOS: SwiftProtobuf.Message, SwiftP
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.template.isEmpty {
       try visitor.visitSingularBytesField(value: self.template, fieldNumber: 1)
     }
@@ -299,12 +307,12 @@ extension SAP_Internal_Pt_QRCodePosterTemplateIOS: SwiftProtobuf.Message, SwiftP
     if self.qrCodeSideLength != 0 {
       try visitor.visitSingularUInt32Field(value: self.qrCodeSideLength, fieldNumber: 4)
     }
-    if let v = self._descriptionTextBox {
+    try { if let v = self._descriptionTextBox {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
-    if let v = self._addressTextBox {
+    } }()
+    try { if let v = self._addressTextBox {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/pt/trace_location.pb.swift
+++ b/src/xcode/gen/output/internal/pt/trace_location.pb.swift
@@ -245,15 +245,19 @@ extension SAP_Internal_Pt_QRCodePayload: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.version != 0 {
       try visitor.visitSingularUInt32Field(value: self.version, fieldNumber: 1)
     }
-    if let v = self._locationData {
+    try { if let v = self._locationData {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
-    if let v = self._crowdNotifierData {
+    } }()
+    try { if let v = self._crowdNotifierData {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     if !self.vendorData.isEmpty {
       try visitor.visitSingularBytesField(value: self.vendorData, fieldNumber: 4)
     }

--- a/src/xcode/gen/output/internal/risk_score_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/risk_score_parameters.pb.swift
@@ -295,27 +295,31 @@ extension SAP_Internal_RiskScoreParameters: SwiftProtobuf.Message, SwiftProtobuf
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._transmission {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._transmission {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
+      } }()
       if _storage._transmissionWeight != 0 {
         try visitor.visitSingularDoubleField(value: _storage._transmissionWeight, fieldNumber: 2)
       }
-      if let v = _storage._duration {
+      try { if let v = _storage._duration {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+      } }()
       if _storage._durationWeight != 0 {
         try visitor.visitSingularDoubleField(value: _storage._durationWeight, fieldNumber: 4)
       }
-      if let v = _storage._daysSinceLastExposure {
+      try { if let v = _storage._daysSinceLastExposure {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
+      } }()
       if _storage._daysWeight != 0 {
         try visitor.visitSingularDoubleField(value: _storage._daysWeight, fieldNumber: 6)
       }
-      if let v = _storage._attenuation {
+      try { if let v = _storage._attenuation {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }
+      } }()
       if _storage._attenuationWeight != 0 {
         try visitor.visitSingularDoubleField(value: _storage._attenuationWeight, fieldNumber: 8)
       }

--- a/src/xcode/gen/output/internal/stats/key_figure_card.pb.swift
+++ b/src/xcode/gen/output/internal/stats/key_figure_card.pb.swift
@@ -230,9 +230,13 @@ extension SAP_Internal_Stats_KeyFigureCard: SwiftProtobuf.Message, SwiftProtobuf
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._header {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._header {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.keyFigures.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.keyFigures, fieldNumber: 2)
     }

--- a/src/xcode/gen/output/internal/stats/local_statistics.pb.swift
+++ b/src/xcode/gen/output/internal/stats/local_statistics.pb.swift
@@ -187,23 +187,11 @@ struct SAP_Internal_Stats_AdministrativeUnitData {
   /// Clears the value of `sevenDayIncidence`. Subsequent reads from it will return its default value.
   mutating func clearSevenDayIncidence() {self._sevenDayIncidence = nil}
 
-  var sevenDayHospitalizationIncidenceUpdatedAt: Int64 = 0
-
-  var sevenDayHospitalizationIncidence: SAP_Internal_Stats_SevenDayIncidenceData {
-    get {return _sevenDayHospitalizationIncidence ?? SAP_Internal_Stats_SevenDayIncidenceData()}
-    set {_sevenDayHospitalizationIncidence = newValue}
-  }
-  /// Returns true if `sevenDayHospitalizationIncidence` has been explicitly set.
-  var hasSevenDayHospitalizationIncidence: Bool {return self._sevenDayHospitalizationIncidence != nil}
-  /// Clears the value of `sevenDayHospitalizationIncidence`. Subsequent reads from it will return its default value.
-  mutating func clearSevenDayHospitalizationIncidence() {self._sevenDayHospitalizationIncidence = nil}
-
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
   fileprivate var _sevenDayIncidence: SAP_Internal_Stats_SevenDayIncidenceData? = nil
-  fileprivate var _sevenDayHospitalizationIncidence: SAP_Internal_Stats_SevenDayIncidenceData? = nil
 }
 
 struct SAP_Internal_Stats_SevenDayIncidenceData {
@@ -289,21 +277,25 @@ extension SAP_Internal_Stats_FederalStateData: SwiftProtobuf.Message, SwiftProto
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.federalState != .sh {
       try visitor.visitSingularEnumField(value: self.federalState, fieldNumber: 1)
     }
     if self.updatedAt != 0 {
       try visitor.visitSingularInt64Field(value: self.updatedAt, fieldNumber: 2)
     }
-    if let v = self._sevenDayIncidence {
+    try { if let v = self._sevenDayIncidence {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     if self.sevenDayHospitalizationIncidenceUpdatedAt != 0 {
       try visitor.visitSingularInt64Field(value: self.sevenDayHospitalizationIncidenceUpdatedAt, fieldNumber: 4)
     }
-    if let v = self._sevenDayHospitalizationIncidence {
+    try { if let v = self._sevenDayHospitalizationIncidence {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -345,8 +337,6 @@ extension SAP_Internal_Stats_AdministrativeUnitData: SwiftProtobuf.Message, Swif
     1: .same(proto: "administrativeUnitShortId"),
     2: .same(proto: "updatedAt"),
     3: .same(proto: "sevenDayIncidence"),
-    4: .same(proto: "sevenDayHospitalizationIncidenceUpdatedAt"),
-    5: .same(proto: "sevenDayHospitalizationIncidence"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -358,29 +348,25 @@ extension SAP_Internal_Stats_AdministrativeUnitData: SwiftProtobuf.Message, Swif
       case 1: try { try decoder.decodeSingularUInt32Field(value: &self.administrativeUnitShortID) }()
       case 2: try { try decoder.decodeSingularInt64Field(value: &self.updatedAt) }()
       case 3: try { try decoder.decodeSingularMessageField(value: &self._sevenDayIncidence) }()
-      case 4: try { try decoder.decodeSingularInt64Field(value: &self.sevenDayHospitalizationIncidenceUpdatedAt) }()
-      case 5: try { try decoder.decodeSingularMessageField(value: &self._sevenDayHospitalizationIncidence) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.administrativeUnitShortID != 0 {
       try visitor.visitSingularUInt32Field(value: self.administrativeUnitShortID, fieldNumber: 1)
     }
     if self.updatedAt != 0 {
       try visitor.visitSingularInt64Field(value: self.updatedAt, fieldNumber: 2)
     }
-    if let v = self._sevenDayIncidence {
+    try { if let v = self._sevenDayIncidence {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
-    if self.sevenDayHospitalizationIncidenceUpdatedAt != 0 {
-      try visitor.visitSingularInt64Field(value: self.sevenDayHospitalizationIncidenceUpdatedAt, fieldNumber: 4)
-    }
-    if let v = self._sevenDayHospitalizationIncidence {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -388,8 +374,6 @@ extension SAP_Internal_Stats_AdministrativeUnitData: SwiftProtobuf.Message, Swif
     if lhs.administrativeUnitShortID != rhs.administrativeUnitShortID {return false}
     if lhs.updatedAt != rhs.updatedAt {return false}
     if lhs._sevenDayIncidence != rhs._sevenDayIncidence {return false}
-    if lhs.sevenDayHospitalizationIncidenceUpdatedAt != rhs.sevenDayHospitalizationIncidenceUpdatedAt {return false}
-    if lhs._sevenDayHospitalizationIncidence != rhs._sevenDayHospitalizationIncidence {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/src/xcode/gen/output/internal/submission_payload.pb.swift
+++ b/src/xcode/gen/output/internal/submission_payload.pb.swift
@@ -155,27 +155,31 @@ extension SAP_Internal_SubmissionPayload: SwiftProtobuf.Message, SwiftProtobuf._
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.keys.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.keys, fieldNumber: 1)
     }
-    if let v = self._requestPadding {
+    try { if let v = self._requestPadding {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 2)
-    }
+    } }()
     if !self.visitedCountries.isEmpty {
       try visitor.visitRepeatedStringField(value: self.visitedCountries, fieldNumber: 3)
     }
-    if let v = self._origin {
+    try { if let v = self._origin {
       try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    }
-    if let v = self._consentToFederation {
+    } }()
+    try { if let v = self._consentToFederation {
       try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
-    }
+    } }()
     if !self.checkIns.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.checkIns, fieldNumber: 6)
     }
-    if let v = self._submissionType {
+    try { if let v = self._submissionType {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
-    }
+    } }()
     if !self.checkInProtectedReports.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.checkInProtectedReports, fieldNumber: 8)
     }

--- a/src/xcode/gen/output/internal/v2/app_config_ios.pb.swift
+++ b/src/xcode/gen/output/internal/v2/app_config_ios.pb.swift
@@ -292,48 +292,52 @@ extension SAP_Internal_V2_ApplicationConfigurationIOS: SwiftProtobuf.Message, Sw
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if let v = _storage._minVersion {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._minVersion {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-      }
-      if let v = _storage._latestVersion {
+      } }()
+      try { if let v = _storage._latestVersion {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      if let v = _storage._appFeatures {
+      } }()
+      try { if let v = _storage._appFeatures {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }
+      } }()
       if !_storage._supportedCountries.isEmpty {
         try visitor.visitRepeatedStringField(value: _storage._supportedCountries, fieldNumber: 4)
       }
-      if let v = _storage._keyDownloadParameters {
+      try { if let v = _storage._keyDownloadParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }
-      if let v = _storage._exposureDetectionParameters {
+      } }()
+      try { if let v = _storage._exposureDetectionParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }
-      if let v = _storage._riskCalculationParameters {
+      } }()
+      try { if let v = _storage._riskCalculationParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-      }
-      if let v = _storage._exposureConfiguration {
+      } }()
+      try { if let v = _storage._exposureConfiguration {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }
-      if let v = _storage._eventDrivenUserSurveyParameters {
+      } }()
+      try { if let v = _storage._eventDrivenUserSurveyParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }
-      if let v = _storage._privacyPreservingAnalyticsParameters {
+      } }()
+      try { if let v = _storage._privacyPreservingAnalyticsParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }
-      if let v = _storage._errorLogSharingParameters {
+      } }()
+      try { if let v = _storage._errorLogSharingParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }
-      if let v = _storage._presenceTracingParameters {
+      } }()
+      try { if let v = _storage._presenceTracingParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-      }
-      if let v = _storage._coronaTestParameters {
+      } }()
+      try { if let v = _storage._coronaTestParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-      }
-      if let v = _storage._dgcParameters {
+      } }()
+      try { if let v = _storage._dgcParameters {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-      }
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/src/xcode/gen/output/internal/v2/corona_test_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/corona_test_parameters.pb.swift
@@ -78,9 +78,13 @@ extension SAP_Internal_V2_CoronaTestParameters: SwiftProtobuf.Message, SwiftProt
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._coronaRapidAntigenTestParameters {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._coronaRapidAntigenTestParameters {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/v2/dgc_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/dgc_parameters.pb.swift
@@ -38,11 +38,21 @@ struct SAP_Internal_V2_DGCParameters {
 
   var expirationThresholdInDays: UInt32 = 0
 
+  var blockListParameters: SAP_Internal_V2_DGCBlocklistParameters {
+    get {return _blockListParameters ?? SAP_Internal_V2_DGCBlocklistParameters()}
+    set {_blockListParameters = newValue}
+  }
+  /// Returns true if `blockListParameters` has been explicitly set.
+  var hasBlockListParameters: Bool {return self._blockListParameters != nil}
+  /// Clears the value of `blockListParameters`. Subsequent reads from it will return its default value.
+  mutating func clearBlockListParameters() {self._blockListParameters = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
   fileprivate var _testCertificateParameters: SAP_Internal_V2_DGCTestCertificateParameters? = nil
+  fileprivate var _blockListParameters: SAP_Internal_V2_DGCBlocklistParameters? = nil
 }
 
 struct SAP_Internal_V2_DGCTestCertificateParameters {
@@ -59,6 +69,32 @@ struct SAP_Internal_V2_DGCTestCertificateParameters {
   init() {}
 }
 
+struct SAP_Internal_V2_DGCBlocklistParameters {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var blockedUvciChunks: [SAP_Internal_V2_DGCBlockedUVCIChunk] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+struct SAP_Internal_V2_DGCBlockedUVCIChunk {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var indices: [UInt32] = []
+
+  var hash: Data = Data()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "SAP.internal.v2"
@@ -68,6 +104,7 @@ extension SAP_Internal_V2_DGCParameters: SwiftProtobuf.Message, SwiftProtobuf._M
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "testCertificateParameters"),
     2: .same(proto: "expirationThresholdInDays"),
+    3: .same(proto: "blockListParameters"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -78,24 +115,33 @@ extension SAP_Internal_V2_DGCParameters: SwiftProtobuf.Message, SwiftProtobuf._M
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._testCertificateParameters) }()
       case 2: try { try decoder.decodeSingularUInt32Field(value: &self.expirationThresholdInDays) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._blockListParameters) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._testCertificateParameters {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._testCertificateParameters {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.expirationThresholdInDays != 0 {
       try visitor.visitSingularUInt32Field(value: self.expirationThresholdInDays, fieldNumber: 2)
     }
+    try { if let v = self._blockListParameters {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: SAP_Internal_V2_DGCParameters, rhs: SAP_Internal_V2_DGCParameters) -> Bool {
     if lhs._testCertificateParameters != rhs._testCertificateParameters {return false}
     if lhs.expirationThresholdInDays != rhs.expirationThresholdInDays {return false}
+    if lhs._blockListParameters != rhs._blockListParameters {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -134,6 +180,76 @@ extension SAP_Internal_V2_DGCTestCertificateParameters: SwiftProtobuf.Message, S
   static func ==(lhs: SAP_Internal_V2_DGCTestCertificateParameters, rhs: SAP_Internal_V2_DGCTestCertificateParameters) -> Bool {
     if lhs.waitAfterPublicKeyRegistrationInSeconds != rhs.waitAfterPublicKeyRegistrationInSeconds {return false}
     if lhs.waitForRetryInSeconds != rhs.waitForRetryInSeconds {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SAP_Internal_V2_DGCBlocklistParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".DGCBlocklistParameters"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "blockedUvciChunks"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.blockedUvciChunks) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.blockedUvciChunks.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.blockedUvciChunks, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SAP_Internal_V2_DGCBlocklistParameters, rhs: SAP_Internal_V2_DGCBlocklistParameters) -> Bool {
+    if lhs.blockedUvciChunks != rhs.blockedUvciChunks {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SAP_Internal_V2_DGCBlockedUVCIChunk: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".DGCBlockedUVCIChunk"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "indices"),
+    2: .same(proto: "hash"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedUInt32Field(value: &self.indices) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self.hash) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.indices.isEmpty {
+      try visitor.visitPackedUInt32Field(value: self.indices, fieldNumber: 1)
+    }
+    if !self.hash.isEmpty {
+      try visitor.visitSingularBytesField(value: self.hash, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: SAP_Internal_V2_DGCBlockedUVCIChunk, rhs: SAP_Internal_V2_DGCBlockedUVCIChunk) -> Bool {
+    if lhs.indices != rhs.indices {return false}
+    if lhs.hash != rhs.hash {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/src/xcode/gen/output/internal/v2/ppdd_edus_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/ppdd_edus_parameters.pb.swift
@@ -125,12 +125,16 @@ extension SAP_Internal_V2_PPDDEventDrivenUserSurveyParametersIOS: SwiftProtobuf.
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -163,12 +167,16 @@ extension SAP_Internal_V2_PPDDEventDrivenUserSurveyParametersAndroid: SwiftProto
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/v2/ppdd_els_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/ppdd_els_parameters.pb.swift
@@ -119,12 +119,16 @@ extension SAP_Internal_V2_PPDDErrorLogSharingParametersIOS: SwiftProtobuf.Messag
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -157,12 +161,16 @@ extension SAP_Internal_V2_PPDDErrorLogSharingParametersAndroid: SwiftProtobuf.Me
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/v2/ppdd_ppa_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/ppdd_ppa_parameters.pb.swift
@@ -127,12 +127,16 @@ extension SAP_Internal_V2_PPDDPrivacyPreservingAnalyticsParametersIOS: SwiftProt
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -165,12 +169,16 @@ extension SAP_Internal_V2_PPDDPrivacyPreservingAnalyticsParametersAndroid: Swift
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._common {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._common {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._ppac {
+    } }()
+    try { if let v = self._ppac {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/src/xcode/gen/output/internal/v2/presence_tracing_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/presence_tracing_parameters.pb.swift
@@ -341,21 +341,25 @@ extension SAP_Internal_V2_PresenceTracingParameters: SwiftProtobuf.Message, Swif
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._riskCalculationParameters {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._riskCalculationParameters {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._submissionParameters {
+    } }()
+    try { if let v = self._submissionParameters {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.qrCodeErrorCorrectionLevel != .medium {
       try visitor.visitSingularEnumField(value: self.qrCodeErrorCorrectionLevel, fieldNumber: 3)
     }
     if !self.revokedTraceLocationVersions.isEmpty {
       try visitor.visitPackedUInt32Field(value: self.revokedTraceLocationVersions, fieldNumber: 4)
     }
-    if let v = self._plausibleDeniabilityParameters {
+    try { if let v = self._plausibleDeniabilityParameters {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    }
+    } }()
     if !self.qrCodeDescriptors.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.qrCodeDescriptors, fieldNumber: 6)
     }
@@ -484,9 +488,13 @@ extension SAP_Internal_V2_PresenceTracingSubmissionParameters.DurationFilter: Sw
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._dropIfMinutesInRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._dropIfMinutesInRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -520,9 +528,13 @@ extension SAP_Internal_V2_PresenceTracingSubmissionParameters.AerosoleDecayFunct
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._minutesRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._minutesRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.slope != 0 {
       try visitor.visitSingularDoubleField(value: self.slope, fieldNumber: 2)
     }
@@ -628,9 +640,13 @@ extension SAP_Internal_V2_PresenceTracingPlausibleDeniabilityParameters.NumberOf
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._randomNumberRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._randomNumberRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.p != 0 {
       try visitor.visitSingularDoubleField(value: self.p, fieldNumber: 2)
     }

--- a/src/xcode/gen/output/internal/v2/risk_calculation_parameters.pb.swift
+++ b/src/xcode/gen/output/internal/v2/risk_calculation_parameters.pb.swift
@@ -294,6 +294,10 @@ extension SAP_Internal_V2_RiskCalculationParameters: SwiftProtobuf.Message, Swif
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.minutesAtAttenuationFilters.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.minutesAtAttenuationFilters, fieldNumber: 1)
     }
@@ -309,9 +313,9 @@ extension SAP_Internal_V2_RiskCalculationParameters: SwiftProtobuf.Message, Swif
     if !self.normalizedTimePerDayToRiskLevelMapping.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.normalizedTimePerDayToRiskLevelMapping, fieldNumber: 5)
     }
-    if let v = self._trlEncoding {
+    try { if let v = self._trlEncoding {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
+    } }()
     if self.transmissionRiskLevelMultiplier != 0 {
       try visitor.visitSingularDoubleField(value: self.transmissionRiskLevelMultiplier, fieldNumber: 7)
     }
@@ -406,12 +410,16 @@ extension SAP_Internal_V2_MinutesAtAttenuationFilter: SwiftProtobuf.Message, Swi
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._attenuationRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._attenuationRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._dropIfMinutesInRange {
+    } }()
+    try { if let v = self._dropIfMinutesInRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -442,9 +450,13 @@ extension SAP_Internal_V2_TrlFilter: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._dropIfTrlInRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._dropIfTrlInRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -476,9 +488,13 @@ extension SAP_Internal_V2_MinutesAtAttenuationWeight: SwiftProtobuf.Message, Swi
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._attenuationRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._attenuationRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.weight != 0 {
       try visitor.visitSingularDoubleField(value: self.weight, fieldNumber: 2)
     }
@@ -514,9 +530,13 @@ extension SAP_Internal_V2_NormalizedTimeToRiskLevelMapping: SwiftProtobuf.Messag
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._normalizedTimeRange {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._normalizedTimeRange {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if self.riskLevel != .unspecified {
       try visitor.visitSingularEnumField(value: self.riskLevel, fieldNumber: 2)
     }


### PR DESCRIPTION
## Description
Regenerates the protobuf models. 

Seems like there was an update of Swift ProtoBuf that changes all the generated files. Relevant changes are in [src/xcode/gen/output/internal/v2/dgc_parameters.pb.swift](https://github.com/corona-warn-app/cwa-app-ios/compare/story/10275-invalidate-certificates...feature/10275-invalidate-certificates/generate-protobuf?expand=1#diff-d976fe61fff786d4d892441a25ab756122587897d77375f570ba503a176dec9c)