### PR TITLE
Fix/10442 booster rule reset

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		017EE865267B302F00CD18F6 /* HealthCertificateArray+MostRelevant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017EE864267B302F00CD18F6 /* HealthCertificateArray+MostRelevant.swift */; };
 		017EE867267B4F2600CD18F6 /* HealthCertificateArray+MostRelevantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017EE866267B3F0A00CD18F6 /* HealthCertificateArray+MostRelevantTests.swift */; };
 		0185DDDE25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0185DDDD25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift */; };
+		01865C5A273541D6001BBCE9 /* FakeBoosterNotificationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01865C5827354192001BBCE9 /* FakeBoosterNotificationsService.swift */; };
 		0186FB60268F35B900872D45 /* HealthCertificateValidationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186FB5F268F35B900872D45 /* HealthCertificateValidationViewController.swift */; };
 		0186FB62268F362200872D45 /* HealthCertificateValidationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186FB61268F362100872D45 /* HealthCertificateValidationViewModel.swift */; };
 		0187F8A026E2111900F1436E /* CertLogicRule+LocalizedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0187F89F26E210C800F1436E /* CertLogicRule+LocalizedDescription.swift */; };
@@ -1580,6 +1581,7 @@
 		017EE864267B302F00CD18F6 /* HealthCertificateArray+MostRelevant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HealthCertificateArray+MostRelevant.swift"; sourceTree = "<group>"; };
 		017EE866267B3F0A00CD18F6 /* HealthCertificateArray+MostRelevantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HealthCertificateArray+MostRelevantTests.swift"; sourceTree = "<group>"; };
 		0185DDDD25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStatisticsCellModelTests.swift; sourceTree = "<group>"; };
+		01865C5827354192001BBCE9 /* FakeBoosterNotificationsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeBoosterNotificationsService.swift; sourceTree = "<group>"; };
 		0186FB5F268F35B900872D45 /* HealthCertificateValidationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCertificateValidationViewController.swift; sourceTree = "<group>"; };
 		0186FB61268F362100872D45 /* HealthCertificateValidationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCertificateValidationViewModel.swift; sourceTree = "<group>"; };
 		0187F89F26E210C800F1436E /* CertLogicRule+LocalizedDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CertLogicRule+LocalizedDescription.swift"; sourceTree = "<group>"; };
@@ -4770,6 +4772,7 @@
 				8F0B0A9C26EA180500ED6F71 /* BoosterNotificationServiceError.swift */,
 				8F1E6EEA26DD93BD00483660 /* RulesDownloadService.swift */,
 				8F1E6EEC26DE13B800483660 /* BoosterNotificationsService.swift */,
+				01865C5827354192001BBCE9 /* FakeBoosterNotificationsService.swift */,
 				01E0D3A6268DC7A200E32CF9 /* MockHealthCertificateValidationService.swift */,
 			);
 			path = HealthCertificateValidation;
@@ -9639,6 +9642,7 @@
 				50690CAE2695FDFC00127CB2 /* HealthCertificateValidationOnboardedCountriesProviderTests.swift in Sources */,
 				01F3323C27174575005CE21E /* AntigenTest+Mock.swift in Sources */,
 				507685CB25E80E600039B7B6 /* TestDummyPPAnalyticsDataImplementation.swift in Sources */,
+				01865C5A273541D6001BBCE9 /* FakeBoosterNotificationsService.swift in Sources */,
 				AB6887FE25D6AAEF00907465 /* ContactDiaryStoreSchemaV3Tests.swift in Sources */,
 				5081EEFE25FF9C5E004B8FDE /* CheckinsInfoScreenViewModelTest.swift in Sources */,
 				AB1885D825238DD100D39BBE /* OnboardingInfoViewControllerTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -1165,7 +1165,9 @@ class HealthCertificateService {
 				}
 				
 			case .failure(let validationError):
-				healthCertifiedPerson.boosterRule = nil
+				if validationError == .BOOSTER_VALIDATION_ERROR(.NO_VACCINATION_CERTIFICATE) || validationError == .BOOSTER_VALIDATION_ERROR(.NO_PASSED_RESULT) {
+					healthCertifiedPerson.boosterRule = nil
+				}
 
 				Log.error(validationError.localizedDescription, log: .vaccination, error: validationError)
 				let name = healthCertifiedPerson.name?.standardizedName ?? ""

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__test__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__test__/HealthCertificateServiceTests.swift
@@ -2006,4 +2006,128 @@ class HealthCertificateServiceTests: CWATestCase {
 		XCTAssertEqual(service.unseenNewsCount.value, 0)
 	}
 
+	func testBoosterRuleIsResetOnNoPassedResultError() throws {
+		let store = MockTestStore()
+		store.healthCertifiedPersons = [
+			HealthCertifiedPerson(
+				healthCertificates: [.mock(base45: HealthCertificateMocks.firstBase45Mock)],
+				boosterRule: .fake()
+			)
+		]
+
+		let boosterNotificationsService = FakeBoosterNotificationsService(result: .failure(.BOOSTER_VALIDATION_ERROR(.NO_PASSED_RESULT)))
+
+		let service = HealthCertificateService(
+			store: store,
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			client: ClientMock(),
+			appConfiguration: CachedAppConfigurationMock(),
+			boosterNotificationsService: boosterNotificationsService,
+			recycleBin: .fake()
+		)
+
+		let registrationResult = service.registerHealthCertificate(base45: HealthCertificateMocks.lastBase45Mock)
+
+		switch registrationResult {
+		case .success:
+			XCTAssertNil(store.healthCertifiedPersons.first?.boosterRule)
+		case .failure(let error):
+			XCTFail("Registration should succeed, failed with error: \(error.localizedDescription)")
+		}
+	}
+
+	func testBoosterRuleIsResetOnNoVaccinationCertificateError() throws {
+		let store = MockTestStore()
+		store.healthCertifiedPersons = [
+			HealthCertifiedPerson(
+				healthCertificates: [.mock(base45: HealthCertificateMocks.firstBase45Mock)],
+				boosterRule: .fake()
+			)
+		]
+
+		let boosterNotificationsService = FakeBoosterNotificationsService(result: .failure(.BOOSTER_VALIDATION_ERROR(.NO_VACCINATION_CERTIFICATE)))
+
+		let service = HealthCertificateService(
+			store: store,
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			client: ClientMock(),
+			appConfiguration: CachedAppConfigurationMock(),
+			boosterNotificationsService: boosterNotificationsService,
+			recycleBin: .fake()
+		)
+
+		let registrationResult = service.registerHealthCertificate(base45: HealthCertificateMocks.lastBase45Mock)
+
+		switch registrationResult {
+		case .success:
+			XCTAssertNil(store.healthCertifiedPersons.first?.boosterRule)
+		case .failure(let error):
+			XCTFail("Registration should succeed, failed with error: \(error.localizedDescription)")
+		}
+	}
+
+	func testBoosterRuleIsNotResetOnRuleServerError() throws {
+		let store = MockTestStore()
+		store.healthCertifiedPersons = [
+			HealthCertifiedPerson(
+				healthCertificates: [.mock(base45: HealthCertificateMocks.firstBase45Mock)],
+				boosterRule: .fake()
+			)
+		]
+
+		let boosterNotificationsService = FakeBoosterNotificationsService(result: .failure(.CERTIFICATE_VALIDATION_ERROR(.RULE_SERVER_ERROR(.boosterNotification))))
+
+		let service = HealthCertificateService(
+			store: store,
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			client: ClientMock(),
+			appConfiguration: CachedAppConfigurationMock(),
+			boosterNotificationsService: boosterNotificationsService,
+			recycleBin: .fake()
+		)
+
+		let registrationResult = service.registerHealthCertificate(base45: HealthCertificateMocks.lastBase45Mock)
+
+		switch registrationResult {
+		case .success:
+			XCTAssertNotNil(store.healthCertifiedPersons.first?.boosterRule)
+		case .failure(let error):
+			XCTFail("Registration should succeed, failed with error: \(error.localizedDescription)")
+		}
+	}
+
+	func testBoosterRuleIsNotResetOnNoNetworkError() throws {
+		let store = MockTestStore()
+		store.healthCertifiedPersons = [
+			HealthCertifiedPerson(
+				healthCertificates: [.mock(base45: HealthCertificateMocks.firstBase45Mock)],
+				boosterRule: .fake()
+			)
+		]
+
+		let boosterNotificationsService = FakeBoosterNotificationsService(result: .failure(.CERTIFICATE_VALIDATION_ERROR(.NO_NETWORK)))
+
+		let service = HealthCertificateService(
+			store: store,
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			client: ClientMock(),
+			appConfiguration: CachedAppConfigurationMock(),
+			boosterNotificationsService: boosterNotificationsService,
+			recycleBin: .fake()
+		)
+
+		let registrationResult = service.registerHealthCertificate(base45: HealthCertificateMocks.lastBase45Mock)
+
+		switch registrationResult {
+		case .success:
+			XCTAssertNotNil(store.healthCertifiedPersons.first?.boosterRule)
+		case .failure(let error):
+			XCTFail("Registration should succeed, failed with error: \(error.localizedDescription)")
+		}
+	}
+
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/BoosterNotificationsService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/BoosterNotificationsService.swift
@@ -32,6 +32,8 @@ class BoosterNotificationsService: BoosterNotificationsServiceProviding {
 		self.rulesDownloadService = rulesDownloadService
 		self.validationRulesAccess = validationRulesAccess
 	}
+
+	// MARK: - Protocol BoosterNotificationsServiceProviding
 	
 	func applyRulesForCertificates(
 		certificates: [DigitalCovidCertificateWithHeader],
@@ -61,7 +63,8 @@ class BoosterNotificationsService: BoosterNotificationsServiceProviding {
 			}
 		}
 	}
-	// MARK: - Protocol BoosterNotificationsServiceProviding
+
+	// MARK: - Private
 	
 	private func downloadBoosterNotificationRules(completion: @escaping (Result<[Rule], HealthCertificateValidationError>) -> Void) {
 		self.rulesDownloadService.downloadRules(
@@ -72,8 +75,7 @@ class BoosterNotificationsService: BoosterNotificationsServiceProviding {
 		)
 	}
 	
-	// MARK: - Private
-	
 	private let rulesDownloadService: RulesDownloadServiceProviding
 	private let validationRulesAccess: BoosterRulesAccessing
+	
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/FakeBoosterNotificationsService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificateValidation/FakeBoosterNotificationsService.swift
@@ -1,0 +1,26 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+@testable import ENA
+import Foundation
+import HealthCertificateToolkit
+
+import class CertLogic.ValidationResult
+
+struct FakeBoosterNotificationsService: BoosterNotificationsServiceProviding {
+
+	// MARK: - Protocol BoosterNotificationsServiceProviding
+	
+	func applyRulesForCertificates(
+		certificates: [DigitalCovidCertificateWithHeader],
+		completion: @escaping (Result<ValidationResult, BoosterNotificationServiceError>) -> Void
+	) {
+		completion(result ?? .failure(.BOOSTER_VALIDATION_ERROR(.NO_PASSED_RESULT)))
+	}
+	
+	// MARK: - Internal
+	
+	var result: Result<ValidationResult, BoosterNotificationServiceError>?
+
+}


### PR DESCRIPTION
## Description
Booster rules should not be reset if a network error or other technical errors occur, only if there are no applicable certificates or rules.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10442
