### PR TITLE
return the first passed rule according to the server  order of rules

### DIFF
--- a/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/RuleValidation/ValidationRulesAccess.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Sources/HealthCertificateToolkit/RuleValidation/ValidationRulesAccess.swift
@@ -171,12 +171,13 @@ public struct ValidationRulesAccess: ValidationRulesAccessing, BoosterRulesAcces
             log("Validation-Result: Rule-Identifier: \(String(describing: $0.rule?.identifier)), Result: \($0.result)")
         }
 
-        guard let firstPassedRule = (validationResult.first {
-            $0.result == .passed
-        }) else {
-            return .failure(.NO_PASSED_RESULT)
+        for inputRule in rules {
+            if let firstPassedRule = (validationResult.first {
+                $0.rule?.identifier == inputRule.identifier && $0.result == .passed
+            }) {
+                return .success(firstPassedRule)
+            }
         }
-
-        return .success(firstPassedRule)
+        return .failure(.NO_PASSED_RESULT)
     }
 }

--- a/src/xcode/ENA/HealthCertificateToolkit/Tests/HealthCertificateToolkitTests/RuleValidation/ValidationRulesAccessTests.swift
+++ b/src/xcode/ENA/HealthCertificateToolkit/Tests/HealthCertificateToolkitTests/RuleValidation/ValidationRulesAccessTests.swift
@@ -42,7 +42,7 @@ class ValidationRulesAccessTests: XCTestCase {
     }
 
     func test_when_applyBoosterNotificationValidationRules_then_passedResultReturned() {
-        let rules = [Rule.fake()]
+        let rules = [Rule.fake(identifier: "5"), Rule.fake(identifier: "1")]
 
         let certificates = [
             DigitalCovidCertificateWithHeader.fake(
@@ -63,10 +63,13 @@ class ValidationRulesAccessTests: XCTestCase {
             )
         ]
 
-        let passedResult = ValidationResult(rule: nil, result: .passed, validationErrors: nil)
+        let firstPassedResult = ValidationResult(rule: Rule.fake(identifier: "1"), result: .passed, validationErrors: nil)
+        let secondPassedResult = ValidationResult(rule: Rule.fake(identifier: "5"), result: .passed, validationErrors: nil)
+
         let certLogicStub = CertLogicEngineStub(validationResult: [
-            passedResult,
-            ValidationResult(rule: nil, result: .open, validationErrors: nil)
+            ValidationResult(rule: nil, result: .open, validationErrors: nil),
+            secondPassedResult,
+            firstPassedResult
         ])
         let result = ValidationRulesAccess().applyBoosterNotificationValidationRules(
             certificates: certificates,
@@ -80,7 +83,7 @@ class ValidationRulesAccessTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(validationResult, passedResult)
+        XCTAssertEqual(validationResult, secondPassedResult)
     }
 
     func test_when_applyBoosterNotificationValidationRules_then_noPassedResultFailureReturned() {


### PR DESCRIPTION
## Description
there seem to be a bug in the CertLogicEngine, if we input an array of rules, the output array of results is in different order every time, 
a solution would be to return the first passed rule according to the **arrangement coming from the server**.

Please check the screenshot for more info

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10459

## Screenshots
in red is the server array, in purple is the result from CertLogic
<img width="1089" alt="Screenshot 2021-11-08 at 16 29 31" src="https://user-images.githubusercontent.com/15270737/140779028-f33d815b-4752-4ac3-a300-8e04f775ce22.png">

here are the certLogic result with indication what passed and what not
<img width="1505" alt="Screenshot 2021-11-08 at 17 20 15" src="https://user-images.githubusercontent.com/15270737/140779210-14da641f-369a-4a38-afd3-26429957ddd3.png">

in this case we will return the rule with id **210** since it is higher in the server array
