### PR TITLE
Feature/10275 invalidate certificates/last minute changes

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3048,13 +3048,11 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_Error_HC_QR_CODE_ERROR" = "Der QR-Code konnte nicht generiert werden. Sollte der Fehler weiterhin bestehen, kontaktieren Sie die Hotline über App-Informationen -> Technische Hotline.";
 
-"HealthCertificate_Error_invalidOrBlockedCertificate_title" = "Zertifikat ungültig";
-
-"HealthCertificate_Error_invalidOrBlockedCertificate_FAQ_Button_Title" = "FAQ zu ungültigen Zertifikaten";
+"HealthCertificate_Error_invalidSignature_title" = "Signatur ungültig";
 
 "HealthCertificate_Error_invalidSignature_msg" = "Die Signatur des Zertifikats ist ungültig. Das Zertifikat kann nicht als Nachweis verwendet werden und daher nicht importiert werden.";
 
-"HealthCertificate_Error_HC_DCC_BLOCKED" = "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
+"HealthCertificate_Error_invalidSignature_FAQ_Button_Title" = "FAQ zur Signaturprüfung";
 
 /* Health Certificate Validation Errors */
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -23,6 +23,7 @@ struct HealthCertificateQRCodeCellViewModel {
 
 		self.qrCodeViewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: mode == .details,
 			accessibilityLabel: accessibilityText,
 			showInfoHit: showInfoHit
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeViewModel.swift
@@ -11,11 +11,12 @@ struct HealthCertificateQRCodeViewModel {
 
 	init(
 		healthCertificate: HealthCertificate,
+		showRealQRCodeIfValidityStateBlocked: Bool,
 		accessibilityLabel: String,
 		showInfoHit: @escaping () -> Void
 	) {
 		self.base45 = healthCertificate.base45
-		self.shouldBlockCertificateCode = !healthCertificate.isUsable
+		self.shouldBlockCertificateCode = !healthCertificate.isUsable && !(showRealQRCodeIfValidityStateBlocked && healthCertificate.validityState == .blocked)
 		self.accessibilityLabel = accessibilityLabel
 		self.showInfo = showInfoHit
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
@@ -43,6 +43,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyValidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -80,6 +82,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithValidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -114,6 +118,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyValidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -149,6 +155,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithSoonExpiringVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -194,6 +202,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlySoonExpiringVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -240,6 +250,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithSoonExpiringVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -283,6 +295,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlySoonExpiringVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -362,6 +376,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyExpiredVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -399,6 +415,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithExpiredVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -433,6 +451,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyExpiredVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -468,6 +488,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithInvalidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -504,6 +526,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyInvalidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -541,6 +565,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithInvalidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -575,6 +601,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyInvalidVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -610,6 +638,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -646,6 +676,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -683,6 +715,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -717,6 +751,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
@@ -752,6 +788,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithValidTestCertificate_THEN_IsInitCorrect() throws {
@@ -792,6 +830,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyValidTestCertificate_THEN_IsInitCorrect() throws {
@@ -833,6 +873,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithValidTestCertificate_THEN_IsInitCorrect() throws {
@@ -867,6 +909,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyValidTestCertificate_THEN_IsInitCorrect() throws {
@@ -902,6 +946,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithSoonExpiringTestCertificate_THEN_IsInitCorrect() throws {
@@ -943,6 +989,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlySoonExpiringTestCertificate_THEN_IsInitCorrect() throws {
@@ -985,6 +1033,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithSoonExpiringTestCertificate_THEN_IsInitCorrect() throws {
@@ -1020,6 +1070,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlySoonExpiringTestCertificate_THEN_IsInitCorrect() throws {
@@ -1056,6 +1108,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithExpiredTestCertificate_THEN_IsInitCorrect() throws {
@@ -1096,6 +1150,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyExpiredTestCertificate_THEN_IsInitCorrect() throws {
@@ -1137,6 +1193,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithExpiredTestCertificate_THEN_IsInitCorrect() throws {
@@ -1171,6 +1229,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyExpiredTestCertificate_THEN_IsInitCorrect() throws {
@@ -1206,6 +1266,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithInvalidTestCertificate_THEN_IsInitCorrect() throws {
@@ -1240,6 +1302,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyInvalidTestCertificate_THEN_IsInitCorrect() throws {
@@ -1275,6 +1339,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithInvalidTestCertificate_THEN_IsInitCorrect() throws {
@@ -1309,6 +1375,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyInvalidTestCertificate_THEN_IsInitCorrect() throws {
@@ -1344,6 +1412,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithBlockedTestCertificate_THEN_IsInitCorrect() throws {
@@ -1378,6 +1448,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyBlockedTestCertificate_THEN_IsInitCorrect() throws {
@@ -1413,6 +1485,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithBlockedTestCertificate_THEN_IsInitCorrect() throws {
@@ -1447,6 +1521,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyBlockedTestCertificate_THEN_IsInitCorrect() throws {
@@ -1482,6 +1558,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithValidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1518,6 +1596,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyValidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1555,6 +1635,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithValidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1589,6 +1671,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyValidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1624,6 +1708,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithSoonExpiringRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1669,6 +1755,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlySoonExpiringRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1757,6 +1845,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlySoonExpiringRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1801,6 +1891,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithExpiredRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1835,6 +1927,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyExpiredRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1870,6 +1964,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithExpiredRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1904,6 +2000,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyExpiredRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1939,6 +2037,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithInvalidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -1973,6 +2073,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyInvalidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2008,6 +2110,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithInvalidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2042,6 +2146,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyInvalidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2077,6 +2183,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertTrue(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2111,6 +2219,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithNewlyBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2146,6 +2256,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertTrue(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2180,6 +2292,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_DetailsViewModelWithNewlyBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2215,6 +2329,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	// swiftlint:disable file_length

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -22,6 +22,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -48,6 +49,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -74,6 +76,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -100,6 +103,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -126,6 +130,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -138,6 +143,33 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 		)
 
 		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
+	func testBlockedVaccinationCertificateShowingRealQRCode() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: true,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			healthCertificate.base45
+		)
+
+		XCTAssertFalse(viewModel.shouldBlockCertificateCode)
 	}
 
 	// MARK: - Test Certificate
@@ -154,6 +186,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -180,6 +213,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -206,6 +240,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -232,6 +267,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -258,6 +294,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -270,6 +307,33 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 		)
 
 		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
+	func testBlockedTestCertificateShowingRealQRCode() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: true,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			healthCertificate.base45
+		)
+
+		XCTAssertFalse(viewModel.shouldBlockCertificateCode)
 	}
 
 	// MARK: - Recovery Certificate
@@ -286,6 +350,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -312,6 +377,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -338,6 +404,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -364,6 +431,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -390,6 +458,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "accessibilityLabel",
 			showInfoHit: { }
 		)
@@ -402,6 +471,33 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 		)
 
 		XCTAssertTrue(viewModel.shouldBlockCertificateCode)
+	}
+
+	func testBlockedRecoveryCertificateShowingRealQRCode() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [.fake()]
+				)
+			),
+			validityState: .blocked
+		)
+
+		let viewModel = HealthCertificateQRCodeViewModel(
+			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: true,
+			accessibilityLabel: "accessibilityLabel",
+			showInfoHit: { }
+		)
+
+		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+
+		XCTAssertEqual(
+			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
+			healthCertificate.base45
+		)
+
+		XCTAssertFalse(viewModel.shouldBlockCertificateCode)
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -25,6 +25,7 @@ class HealthCertifiedPersonCellModel {
 
 		qrCodeViewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: mostRelevantCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
 			showInfoHit: showInfoHit
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
@@ -23,6 +23,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "",
 			showInfoHit: {}
 		)
@@ -50,6 +51,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 
 		let viewModel = HealthCertificateQRCodeViewModel(
 			healthCertificate: healthCertificate,
+			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: "",
 			showInfoHit: {}
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerViewController.swift
@@ -287,23 +287,10 @@ class QRScannerViewController: UIViewController {
 
 		if case .certificateQrError(.invalidSignature) = error {
 			// invalid signature error on certificates needs a specific title, errorMessage and FAQ action
-			alertTitle = AppStrings.HealthCertificate.Error.invalidOrBlockedCertificateTitle
+			alertTitle = AppStrings.HealthCertificate.Error.invalidSignatureTitle
 			errorMessage = unwrappedError.localizedDescription
 			faqAlertAction = UIAlertAction(
-				title: AppStrings.HealthCertificate.Error.invalidOrBlockedCertificateFAQButtonTitle,
-				style: .default,
-				handler: { [weak self] _ in
-					if LinkHelper.open(urlString: AppStrings.Links.invalidSignatureFAQ) {
-						self?.viewModel?.activateScanning()
-					}
-				}
-			)
-		} else if case .certificateQrError(.certificateBlocked) = error {
-			// blocked certificate error needs a specific title, errorMessage and FAQ action
-			alertTitle = AppStrings.HealthCertificate.Error.invalidOrBlockedCertificateTitle
-			errorMessage = unwrappedError.localizedDescription
-			faqAlertAction = UIAlertAction(
-				title: AppStrings.HealthCertificate.Error.invalidOrBlockedCertificateFAQButtonTitle,
+				title: AppStrings.HealthCertificate.Error.invalidSignatureFAQButtonTitle,
 				style: .default,
 				handler: { [weak self] _ in
 					if LinkHelper.open(urlString: AppStrings.Links.invalidSignatureFAQ) {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -137,7 +137,6 @@ class HealthCertificateService {
 	@discardableResult
 	func registerHealthCertificate(
 		base45: Base45,
-		checkIfBlockedUpfront: Bool = true,
 		checkSignatureUpfront: Bool = true,
 		markAsNew: Bool = false
 	) -> Result<CertificateResult, HealthCertificateServiceError.RegistrationError> {
@@ -160,12 +159,6 @@ class HealthCertificateService {
 
 		do {
 			let healthCertificate = try HealthCertificate(base45: base45, isNew: markAsNew)
-
-			let blockedIdentifierChunks = appConfiguration.currentAppConfig.value
-				.dgcParameters.blockListParameters.blockedUvciChunks
-			if checkIfBlockedUpfront && healthCertificate.isBlocked(by: blockedIdentifierChunks) {
-				return .failure(.certificateBlocked)
-			}
 
 			// check signature
 			if checkSignatureUpfront {
@@ -960,7 +953,6 @@ class HealthCertificateService {
 			case .success(let healthCertificateBase45):
 				let registerResult = registerHealthCertificate(
 					base45: healthCertificateBase45,
-					checkIfBlockedUpfront: false,
 					checkSignatureUpfront: false,
 					markAsNew: true
 				)

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateServiceError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateServiceError.swift
@@ -11,7 +11,6 @@ enum HealthCertificateServiceError: Error {
 		case decodingError(CertificateDecodingError)
 		case certificateAlreadyRegistered(HealthCertificate.CertificateType)
 		case certificateHasTooManyEntries
-		case certificateBlocked
 		case invalidSignature(DCCSignatureVerificationError)
 		case other(Error)
 
@@ -63,8 +62,6 @@ enum HealthCertificateServiceError: Error {
 				}
 			case .certificateHasTooManyEntries:
 				return "\(AppStrings.HealthCertificate.Error.hcNotSupported) (HC_TOO_MANY_ENTRIES)"
-			case .certificateBlocked:
-				return "\(AppStrings.HealthCertificate.Error.blockedCertificateText) (HC_DCC_BLOCKED)"
 			case .invalidSignature(let error):
 				return "\(AppStrings.HealthCertificate.Error.invalidSignatureText) (\(error))"
 			case .other(let error):
@@ -76,7 +73,7 @@ enum HealthCertificateServiceError: Error {
 		var errorTitle: String? {
 			switch self {
 			case .invalidSignature:
-				return AppStrings.HealthCertificate.Error.invalidOrBlockedCertificateTitle
+				return AppStrings.HealthCertificate.Error.invalidSignatureTitle
 			default:
 				return nil
 			}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2238,10 +2238,9 @@ enum AppStrings {
 			static let hcNotSupported = NSLocalizedString("HealthCertificate_Error_HC_NOT_SUPPORTED", comment: "")
 			static let hcQRCodeError = NSLocalizedString("HealthCertificate_Error_HC_QR_CODE_ERROR", comment: "")
 
-			static let invalidOrBlockedCertificateTitle = NSLocalizedString("HealthCertificate_Error_invalidSignature_title", comment: "")
-			static let invalidOrBlockedCertificateFAQButtonTitle = NSLocalizedString("HealthCertificate_Error_invalidSignature_FAQ_Button_Title", comment: "")
+			static let invalidSignatureTitle = NSLocalizedString("HealthCertificate_Error_invalidSignature_title", comment: "")
 			static let invalidSignatureText = NSLocalizedString("HealthCertificate_Error_invalidSignature_msg", comment: "")
-			static let blockedCertificateText = NSLocalizedString("HealthCertificate_Error_HC_DCC_BLOCKED", comment: "")
+			static let invalidSignatureFAQButtonTitle = NSLocalizedString("HealthCertificate_Error_invalidSignature_FAQ_Button_Title", comment: "")
 
 		}
 


### PR DESCRIPTION
## Description
Implements two last-minute changes regarding blocked certificates:
- Allows blocked certificates to be imported, reverting all code changes that prevented this.
- Blocked certificate QR codes are shown unobstructed on the details screen, while still not being shown on the overview and person screen.