### PR TITLE
Feature/10350 ticketvalidation consent/10560 second consent screen

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -2230,6 +2230,8 @@
 		50EB4FD9268DFC86009FB402 /* ValidationRulesCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationRulesCache.swift; sourceTree = "<group>"; };
 		50EE75FF2743FBE5003DE929 /* ENAUITests_19_TicketValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAUITests_19_TicketValidation.swift; sourceTree = "<group>"; };
 		50EE76012743FC6F003DE929 /* TicketValidationUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = TicketValidationUITests.xctestplan; path = TestPlans/TicketValidationUITests.xctestplan; sourceTree = "<group>"; };
+		50EE760427467CD9003DE929 /* SecondTicketValidationConsentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondTicketValidationConsentViewController.swift; sourceTree = "<group>"; };
+		50EE760527467CD9003DE929 /* SecondTicketValidationConsentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondTicketValidationConsentViewModel.swift; sourceTree = "<group>"; };
 		50F065392654FFC200774173 /* tri_state_boolean.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = tri_state_boolean.pb.swift; sourceTree = "<group>"; };
 		50F9130C253F1D7800DFE683 /* OnboardingPageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageType.swift; sourceTree = "<group>"; };
 		50FA071026021180003C1E46 /* api-response-traceWarning */ = {isa = PBXFileReference; lastKnownFileType = file; path = "api-response-traceWarning"; sourceTree = "<group>"; };
@@ -3198,6 +3200,7 @@
 			children = (
 				010E07AA273D009C00C2BE5F /* TicketValidationCoordinator.swift */,
 				010E07B0273D4CC400C2BE5F /* FirstConsent */,
+				50EE760327467CC4003DE929 /* SecondConsent */,
 			);
 			path = TicketValidation;
 			sourceTree = "<group>";
@@ -5311,6 +5314,15 @@
 				50EE75FF2743FBE5003DE929 /* ENAUITests_19_TicketValidation.swift */,
 			);
 			path = TicketValidation;
+			sourceTree = "<group>";
+		};
+		50EE760327467CC4003DE929 /* SecondConsent */ = {
+			isa = PBXGroup;
+			children = (
+				50EE760427467CD9003DE929 /* SecondTicketValidationConsentViewController.swift */,
+				50EE760527467CD9003DE929 /* SecondTicketValidationConsentViewModel.swift */,
+			);
+			path = SecondConsent;
 			sourceTree = "<group>";
 		};
 		50FA07822609EC6A003C1E46 /* __tests__ */ = {

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -714,6 +714,8 @@
 		50EACAA325E68672004DDADB /* PPAnalyticsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EACAA225E68672004DDADB /* PPAnalyticsData.swift */; };
 		50EB4FDA268DFC86009FB402 /* ValidationRulesCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EB4FD9268DFC86009FB402 /* ValidationRulesCache.swift */; };
 		50EE76022743FC87003DE929 /* ENAUITests_19_TicketValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EE75FF2743FBE5003DE929 /* ENAUITests_19_TicketValidation.swift */; };
+		50EE7606274685E0003DE929 /* SecondTicketValidationConsentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EE760427467CD9003DE929 /* SecondTicketValidationConsentViewController.swift */; };
+		50EE7607274685E0003DE929 /* SecondTicketValidationConsentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EE760527467CD9003DE929 /* SecondTicketValidationConsentViewModel.swift */; };
 		50F0653A2654FFC200774173 /* tri_state_boolean.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F065392654FFC200774173 /* tri_state_boolean.pb.swift */; };
 		50F9130D253F1D7800DFE683 /* OnboardingPageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F9130C253F1D7800DFE683 /* OnboardingPageType.swift */; };
 		50FA071126021180003C1E46 /* api-response-traceWarning in Resources */ = {isa = PBXBuildFile; fileRef = 50FA071026021180003C1E46 /* api-response-traceWarning */; };
@@ -9295,6 +9297,7 @@
 				BA00FED226BC2F35009DA07F /* AppFeatureUnencryptedEventsDecorator.swift in Sources */,
 				71FD8862246EB27F00E804D0 /* ExposureDetectionViewController.swift in Sources */,
 				01CBB82C2660F3690094CF8B /* CardView.swift in Sources */,
+				50EE7606274685E0003DE929 /* SecondTicketValidationConsentViewController.swift in Sources */,
 				AB0246DB2716D732002668A1 /* RecycleBinRestorationHandling.swift in Sources */,
 				01DE60752744EF3F00E12FA4 /* TicketValidationInitializationData.swift in Sources */,
 				013C413D255463A400826C9F /* DMDebugRiskCalculationViewController.swift in Sources */,
@@ -9668,6 +9671,7 @@
 				01E1026C26690D0B009ED803 /* dgc_parameters.pb.swift in Sources */,
 				0120ECDD25875D8B00F78944 /* DiaryDayEntryCellModel.swift in Sources */,
 				BAEFB3572656A79700497F79 /* ContactDiaryStoreSchemaV5.swift in Sources */,
+				50EE7607274685E0003DE929 /* SecondTicketValidationConsentViewModel.swift in Sources */,
 				01A1B44A252DFD7800841B63 /* MetadataObject.swift in Sources */,
 				ABE5E0BD2694590900D50C2B /* ValidationDateSelectionCell.swift in Sources */,
 				01BA07432620938E00237DD8 /* DurationFilter.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -220,7 +220,7 @@
 
 "ExposureSubmission_TestCertificate_Information_Legal_Text_5" = "Sie haben jederzeit die Möglichkeit, Testzertifikate in der App wieder zu löschen. Bis dahin bleiben die Testzertifikate auf Ihrem Smartphone gespeichert.";
 
-/* Ticket Validation */
+/* Ticket Validation First Consent */
 
 "TicketValidation_FirstConsent_Legal_title" = "Ihr Einverständnis";
 
@@ -229,3 +229,21 @@
 "TicketValidation_FirstConsent_Legal_bulletPoint1" = "Die App ruft vom Anbieter den Namen und das Geburtsdatum der bei Buchung angegebenen Person, die für die Prüfung relevanten Buchungsdetails (z. B. Zielland und Reisedatum) und die vom Anbieter zu Ihrer Buchung festgelegten Anforderungen an das Zertifikat ab.";
 
 "TicketValidation_FirstConsent_Legal_bulletPoint2" = "Die abgerufenen Daten werden von der App genutzt, um festzustellen, welche Ihrer gespeicherten Zertifikate verwendet werden können.";
+
+/* Ticket Validation Second Consent */
+
+"TicketValidation_SecondConsent_Legal_title" = "Ihr Einverständnis";
+
+"TicketValidation_SecondConsent_Legal_subtitle" = "Durch Antippen von „Einverstanden“ willigen Sie in die Übermittlung der folgenden Daten an den Prüfpartner ein:";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint1" = "Zertifikatsinhalt und elektronische Signatur des ausgewählten Zertifikats (u. a. Name und Geburtsdatum des Zertifikatsinhabers, Gültigkeitsdauer, Aussteller und Ausstellungsdatum, Angaben zu Impfstoff/Test/Genesung).";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint2" = "Die bei dem Anbieter abgerufenen Buchungsdaten:";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint1" = "Zeitraum, in dem das Zertifikat gültig sein muss (Reisedauer oder Veranstaltungsdatum)";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint2" = "bei Reisebuchungen: Ausgangsland und Zielland der Reise";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint3" = "bei grenzüberschreitenden Reisen: Anforderungen des Ziellandes an das Zertifikat";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint4" = "weitere Anforderungen des Anbieters an das Zertifikat (z. B. welche Impfstoffe oder Testverfahren akzeptiert werden)";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3429,6 +3429,14 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_SecondConsent_explination" = "Das ausgewählte Zertifikat und Ihre Buchungsdaten werden nun an den Prüfpartner des Anbieters übermittelt. Für die Übermittlung Ihrer Daten an den Prüfpartner ist Ihr Einverständnis erforderlich.";
 
+"TicketValidation_SecondConsent_BulletPoint1" = "Der Prüfpartner überprüft, ob die elektronische Signatur echt und das technische Ablaufdatum des Zertifikats noch nicht erreicht ist. Das technische Ablaufdatum und die übermittelten Zertifikatsinhalte können Sie in der App in der Detailansicht des Zertifikats einsehen.";
+
+"TicketValidation_SecondConsent_BulletPoint2" = "Die Zertifikate enthalten sensible Gesundheitsdaten. Erlauben Sie daher nur solchen Anbietern die Überprüfung, die Ihnen bekannt sind und denen Sie vertrauen.";
+
+"TicketValidation_SecondConsent_BulletPoint3" = "Für die Datenverarbeitung durch den Anbieter und den Prüfpartner ist das RKI nicht verantwortlich. Lesen Sie bitte deren Datenschutzhinweise, damit Sie wissen, wozu und wie Ihre Daten verwendet werden.";
+
+"TicketValidation_SecondConsent_BulletPoint4" = "Der Prüfpartner teilt dem Anbieter sofort das Prüfungsergebnis mit. Es wird nur mitgeteilt, ob die Prüfung erfolgreich war oder nicht.";
+
 "TicketValidation_SecondConsent_primaryButtonTitle" = "Einverstanden";
 
 "TicketValidation_SecondConsent_secondaryButtonTitle" = "Abbrechen";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3421,6 +3421,8 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 /* - Ticket Validation Second Consent */
 
+"TicketValidation_SecondConsent_title" = "Ihr Einverständnis";
+
 "TicketValidation_SecondConsent_subtitle" = "Übermittlung Ihres Zertifikats zur Prüfung";
 
 "TicketValidation_SecondConsent_serviceIdentity" = "Prüfpartner:";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3383,6 +3383,16 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_CancelAlert_continueButtonTitle" = "Überprüfung fortsetzen";
 
+"TicketValidation_Error_title" = "Fehler";
+
+"TicketValidation_Error_serviceProviderErrorNoName" = "Es trat ein Fehler bei der Verbindung mit dem Anbieter auf. Bitte kontaktieren Sie den Anbieter wenn das Problem weiterhin besteht.";
+
+"TicketValidation_Error_serviceProviderError" = "Es trat ein Fehler bei der Verbindung mit dem Anbieter „%@“ auf. Bitte kontaktieren Sie den Anbieter wenn das Problem weiterhin besteht.";
+
+"TicketValidation_Error_tryAgain" = "Es trat ein Fehler bei der Verarbeitung der Daten auf. Bitte versuchen Sie es später erneut.";
+
+/* - Ticket Validation First Consent */
+
 "TicketValidation_FirstConsent_title" = "Ihr Einverständnis";
 
 "TicketValidation_FirstConsent_imageDescription" = "Ein Zertifikat wird für ein Ticketkauf übertragen";
@@ -3409,10 +3419,8 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_FirstConsent_secondaryButtonTitle" = "Abbrechen";
 
-"TicketValidation_Error_title" = "Fehler";
+/* - Ticket Validation Second Consent */
 
-"TicketValidation_Error_serviceProviderErrorNoName" = "Es trat ein Fehler bei der Verbindung mit dem Anbieter auf. Bitte kontaktieren Sie den Anbieter wenn das Problem weiterhin besteht.";
+"TicketValidation_SecondConsent_primaryButtonTitle" = "Einverstanden";
 
-"TicketValidation_Error_serviceProviderError" = "Es trat ein Fehler bei der Verbindung mit dem Anbieter „%@“ auf. Bitte kontaktieren Sie den Anbieter wenn das Problem weiterhin besteht.";
-
-"TicketValidation_Error_tryAgain" = "Es trat ein Fehler bei der Verarbeitung der Daten auf. Bitte versuchen Sie es später erneut.";
+"TicketValidation_SecondConsent_secondaryButtonTitle" = "Abbrechen";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3427,7 +3427,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_SecondConsent_serviceProvider" = "Anbieter:";
 
-"TicketValidation_SecondConsent_explination" = "Das ausgewählte Zertifikat und Ihre Buchungsdaten werden nun an den Prüfpartner des Anbieters übermittelt.  Für die Übermittlung Ihrer Daten an den Prüfpartner ist Ihr Einverständnis erforderlich.";
+"TicketValidation_SecondConsent_explination" = "Das ausgewählte Zertifikat und Ihre Buchungsdaten werden nun an den Prüfpartner des Anbieters übermittelt. Für die Übermittlung Ihrer Daten an den Prüfpartner ist Ihr Einverständnis erforderlich.";
 
 "TicketValidation_SecondConsent_primaryButtonTitle" = "Einverstanden";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3421,6 +3421,14 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 /* - Ticket Validation Second Consent */
 
+"TicketValidation_SecondConsent_subtitle" = "Übermittlung Ihres Zertifikats zur Prüfung";
+
+"TicketValidation_SecondConsent_serviceIdentity" = "Prüfpartner:";
+
+"TicketValidation_SecondConsent_serviceProvider" = "Anbieter:";
+
+"TicketValidation_SecondConsent_explination" = "Das ausgewählte Zertifikat und Ihre Buchungsdaten werden nun an den Prüfpartner des Anbieters übermittelt.  Für die Übermittlung Ihrer Daten an den Prüfpartner ist Ihr Einverständnis erforderlich.";
+
 "TicketValidation_SecondConsent_primaryButtonTitle" = "Einverstanden";
 
 "TicketValidation_SecondConsent_secondaryButtonTitle" = "Abbrechen";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3437,6 +3437,8 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_SecondConsent_BulletPoint4" = "Der Prüfpartner teilt dem Anbieter sofort das Prüfungsergebnis mit. Es wird nur mitgeteilt, ob die Prüfung erfolgreich war oder nicht.";
 
+"TicketValidation_SecondConsent_DataPrivacyTitle" = "Ausführliche Hinweise zur Datenverarbeitung finden Sie in der Datenschutzerklärung.";
+
 "TicketValidation_SecondConsent_primaryButtonTitle" = "Einverstanden";
 
 "TicketValidation_SecondConsent_secondaryButtonTitle" = "Abbrechen";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.legal.strings
@@ -220,7 +220,7 @@
 
 "ExposureSubmission_TestCertificate_Information_Legal_Text_5" = "You have the possibility to delete test certificates in the app at any time. Until then, the test certificates will be stored on your smartphone.";
 
-/* Ticket Validation */
+/* Ticket Validation First Consent */
 
 "TicketValidation_FirstConsent_Legal_title" = "Your consent";
 
@@ -229,3 +229,22 @@
 "TicketValidation_FirstConsent_Legal_bulletPoint1" = "The app will retrieve from the provider the name and date of birth of the person specified at the time of booking, the booking details relevant to the verification (e.g. destination country and date of travel) and the certificate requirements specified by the provider for your booking.";
 
 "TicketValidation_FirstConsent_Legal_bulletPoint2" = "Once retrieved, the app will use this data to determine which of your stored certificates can be used.";
+
+/* Ticket Validation Second Consent */
+
+"TicketValidation_SecondConsent_Legal_title" = "Your consent";
+
+"TicketValidation_SecondConsent_Legal_subtitle" = "By tapping on “Accept”, you consent to the transfer of the following data to the verification partner:";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint1" = "Content and electronic signature of the selected certificate (including name and date of birth of the certificate holder, validity period, issuer and date of issue, vaccine/test/recovery details).";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint2" = "The booking details retrieved from the provider:";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint1" = "Period during which the certificate must be valid (travel duration or event date)";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint2" = "For travel bookings: Country of origin and country of destination or journey";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint3" = "For cross-border travel: Certificate requirements imposed by the destination country";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint4" = "Further certificate requirements on the part of the provider (e.g. which vaccines or test procedures are accepted)";
+

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.legal.strings
@@ -219,7 +219,7 @@
 
 "ExposureSubmission_TestCertificate_Information_Legal_Text_5" = "Test sertifikasını istediğiniz zaman Uygulamadan kaldırma seçeneğiniz vardır. Bunu yapıncaya kadar test sertifikaları akıllı telefonunuzda kayıtlı kalacaktır. ";
 
-/* Ticket Validation */
+/* Ticket Validation First Consent */
 
 "TicketValidation_FirstConsent_Legal_title" = "Rıza beyanız";
 
@@ -228,3 +228,21 @@
 "TicketValidation_FirstConsent_Legal_bulletPoint1" = "Uygulama, sağlayıcının sunduğu rezervasyonda belirtilen kişinin isim ve doğum tarihini, kontrolle ilgili rezervasyon ayrıntılarını (örn. hedef ülke ve seyahat tarihi) ve sağlayıcı tarafından rezervasyonunuza ilişkin belirlenen sertifika taleplerini açar.";
 
 "TicketValidation_FirstConsent_Legal_bulletPoint2" = "Açılan bilgiler kayıtlı sertifikalarınızdan hangilerinin kullanılabileceğini belirlemek için uygulama tarafından kullanılır.";
+
+/* Ticket Validation Second Consent */
+
+"TicketValidation_SecondConsent_Legal_title" = "Rıza beyanınız";
+
+"TicketValidation_SecondConsent_Legal_subtitle" = "“Kabul ediyorum” üzerine tıklayarak aşağıdaki bilgilerin kontrol ortağına aktarılmasına onay verirsiniz:";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint1" = "Seçilen sertifikanın (özellikle sertifika sahibinin adı ve doğum tarihi, geçerlilik süresi, düzenleyen ve düzenleme tarihi, aşı/test/iyileşme ile ilgili bilgiler) sertifika içeriği ve elektronik imza.";
+
+"TicketValidation_SecondConsent_Legal_bulletPoint2" = "Sağlayıcı tarafından açılan rezervasyon bilgileri:";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint1" = "Sertifikanın geçerli olması gereken süre (seyahat süresi ya da etkinlik süresi)";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint2" = "Seyahat rezervasyonlarında: Seyahate çıkılan çıkış ve varış ülkesi";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint3" = "Sınırları aşan seyahatlerde: gidilen ülkenin sertifikaya ilişkin talepleri";
+
+"TicketValidation_SecondConsent_Legal_subBulletPoint4" = "Sağlayıcının sertifikaya ilişkin talepleri (örn. hangi aşılar veya test yöntemleri kabul edilir)";

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
@@ -28,8 +28,10 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 	}
 
 	// MARK: - Internal
-
-	func configure(_ cellViewModel: HealthCertificateCellViewModel) {
+	
+	func configure(
+		_ cellViewModel: HealthCertificateCellViewModel
+	) {
 		gradientBackground.type = cellViewModel.gradientType
 		iconImageView.image = cellViewModel.image
 
@@ -42,6 +44,13 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 
 		currentlyUsedStackView.isHidden = !cellViewModel.isCurrentlyUsedCertificateHintVisible
 		unseenNewsIndicator.isHidden = !cellViewModel.isUnseenNewsIndicatorVisible
+		
+		switch cellViewModel.details {
+		case .allDetails:
+			disclosureImageView.isHidden = false
+		case .overview:
+			disclosureImageView.isHidden = true
+		}
 
 		setupAccessibility()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
@@ -30,7 +30,8 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 	// MARK: - Internal
 	
 	func configure(
-		_ cellViewModel: HealthCertificateCellViewModel
+		_ cellViewModel: HealthCertificateCellViewModel,
+		withDiscloreIndicator: Bool = true
 	) {
 		gradientBackground.type = cellViewModel.gradientType
 		iconImageView.image = cellViewModel.image
@@ -44,13 +45,8 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 
 		currentlyUsedStackView.isHidden = !cellViewModel.isCurrentlyUsedCertificateHintVisible
 		unseenNewsIndicator.isHidden = !cellViewModel.isUnseenNewsIndicatorVisible
-		
-		switch cellViewModel.details {
-		case .allDetails:
-			disclosureImageView.isHidden = false
-		case .overview:
-			disclosureImageView.isHidden = true
-		}
+	
+		disclosureImageView.isHidden = !withDiscloreIndicator
 
 		setupAccessibility()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
@@ -31,7 +31,7 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 	
 	func configure(
 		_ cellViewModel: HealthCertificateCellViewModel,
-		withDiscloreIndicator: Bool = true
+		withDisclosureIndicator: Bool = true
 	) {
 		gradientBackground.type = cellViewModel.gradientType
 		iconImageView.image = cellViewModel.image
@@ -46,7 +46,7 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 		currentlyUsedStackView.isHidden = !cellViewModel.isCurrentlyUsedCertificateHintVisible
 		unseenNewsIndicator.isHidden = !cellViewModel.isUnseenNewsIndicatorVisible
 	
-		disclosureImageView.isHidden = !withDiscloreIndicator
+		disclosureImageView.isHidden = !withDisclosureIndicator
 
 		setupAccessibility()
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -26,7 +26,6 @@ final class HealthCertificateCellViewModel {
 	}
 	
 	let healthCertificate: HealthCertificate
-	let details: HealthCertificeCellDetails
 	
 	lazy var gradientType: GradientView.GradientType = {
 		switch details {
@@ -171,4 +170,5 @@ final class HealthCertificateCellViewModel {
 	// MARK: - Private
 
 	private let healthCertifiedPerson: HealthCertifiedPerson
+	private let details: HealthCertificeCellDetails
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -10,22 +10,35 @@ final class HealthCertificateCellViewModel {
 	
 	init(
 		healthCertificate: HealthCertificate,
-		healthCertifiedPerson: HealthCertifiedPerson
+		healthCertifiedPerson: HealthCertifiedPerson,
+		details: HealthCertificeCellDetails = .allDetails
 	) {
 		self.healthCertificate = healthCertificate
 		self.healthCertifiedPerson = healthCertifiedPerson
+		self.details = details
 	}
 
 	// MARK: - Internal
 	
+	enum HealthCertificeCellDetails {
+		case allDetails
+		case overview
+	}
+	
 	let healthCertificate: HealthCertificate
-
+	let details: HealthCertificeCellDetails
+	
 	lazy var gradientType: GradientView.GradientType = {
-		if healthCertificate.isUsable &&
-			healthCertificate == healthCertifiedPerson.mostRelevantHealthCertificate {
+		switch details {
+		case .allDetails:
+			if healthCertificate.isUsable &&
+				healthCertificate == healthCertifiedPerson.mostRelevantHealthCertificate {
+				return .lightBlue(withStars: false)
+			} else {
+				return .solidGrey(withStars: false)
+			}
+		case .overview:
 			return .lightBlue(withStars: false)
-		} else {
-			return .solidGrey(withStars: false)
 		}
 	}()
 
@@ -87,26 +100,31 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var validityStateInfo: String? = {
-		if !healthCertificate.isConsideredValid {
-			switch healthCertificate.validityState {
-			case .valid:
+		switch details {
+		case .allDetails:
+			if !healthCertificate.isConsideredValid {
+				switch healthCertificate.validityState {
+				case .valid:
+					return nil
+				case .expiringSoon:
+					return String(
+						format: AppStrings.HealthCertificate.ValidityState.expiringSoon,
+						DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .short, timeStyle: .none),
+						DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .none, timeStyle: .short)
+					)
+				case .expired:
+					return AppStrings.HealthCertificate.ValidityState.expired
+				case .invalid:
+					return AppStrings.HealthCertificate.ValidityState.invalid
+				case .blocked:
+					return AppStrings.HealthCertificate.ValidityState.blocked
+				}
+			} else if healthCertificate.isNew {
+				return AppStrings.HealthCertificate.Person.newlyAddedCertificate
+			} else {
 				return nil
-			case .expiringSoon:
-				return String(
-					format: AppStrings.HealthCertificate.ValidityState.expiringSoon,
-					DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .short, timeStyle: .none),
-					DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .none, timeStyle: .short)
-				)
-			case .expired:
-				return AppStrings.HealthCertificate.ValidityState.expired
-			case .invalid:
-				return AppStrings.HealthCertificate.ValidityState.invalid
-			case .blocked:
-				return AppStrings.HealthCertificate.ValidityState.blocked
 			}
-		} else if healthCertificate.isNew {
-			return AppStrings.HealthCertificate.Person.newlyAddedCertificate
-		} else {
+		case .overview:
 			return nil
 		}
 	}()
@@ -133,15 +151,24 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var isCurrentlyUsedCertificateHintVisible: Bool = {
-		healthCertificate == healthCertifiedPerson.mostRelevantHealthCertificate
+		switch details {
+		case .allDetails:
+			return healthCertificate == healthCertifiedPerson.mostRelevantHealthCertificate
+		case .overview:
+			return false
+		}
 	}()
 
 	lazy var isUnseenNewsIndicatorVisible: Bool = {
-		healthCertificate.isNew || healthCertificate.isValidityStateNew
+		switch details {
+		case .allDetails:
+			return healthCertificate.isNew || healthCertificate.isValidityStateNew
+		case .overview:
+			return false
+		}
 	}()
 
 	// MARK: - Private
 
 	private let healthCertifiedPerson: HealthCertifiedPerson
-
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/FirstConsent/FirstTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/FirstConsent/FirstTicketValidationConsentViewController.swift
@@ -35,6 +35,7 @@ class FirstTicketValidationConsentViewController: DynamicTableViewController, Fo
 	
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
+		navigationController?.navigationBar.backgroundColor = .clear
 		navigationController?.navigationBar.prefersLargeTitles = false
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/FirstConsent/FirstTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/FirstConsent/FirstTicketValidationConsentViewModel.swift
@@ -67,15 +67,15 @@ struct FirstTicketValidationConsentViewModel {
 				cells: [
 					.legalExtendedDataDonation(
 						title: NSAttributedString(
-							string: AppStrings.TicketValidation.FirstConsent.legalTitle
+							string: AppStrings.TicketValidation.FirstConsent.Legal.title
 						),
 						description: NSAttributedString(
-							string: AppStrings.TicketValidation.FirstConsent.legalSubtitle,
+							string: AppStrings.TicketValidation.FirstConsent.Legal.subtitle,
 							attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
 						),
 						bulletPoints: [
-							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint1),
-							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint2)
+							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.Legal.bulletPoint1),
+							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.Legal.bulletPoint2)
 						],
 						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.legalBox,
 						configure: { _, cell, _ in

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
@@ -36,7 +36,7 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
 		navigationController?.navigationBar.prefersLargeTitles = true
-		navigationController?.navigationBar.backgroundColor = .white
+		navigationController?.navigationBar.backgroundColor = .enaColor(for: .background)
 	}
 	
 	// MARK: - Cell reuse identifiers.

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
@@ -35,7 +35,8 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 	
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		navigationController?.navigationBar.prefersLargeTitles = false
+		navigationController?.navigationBar.prefersLargeTitles = true
+		navigationController?.navigationBar.backgroundColor = .white
 	}
 	
 	// MARK: - Cell reuse identifiers.
@@ -73,6 +74,9 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 	private let onDismiss: () -> Void
 
 	private func setupView() {
+		
+		title = AppStrings.TicketValidation.SecondConsent.title
+		
 		navigationItem.rightBarButtonItem = CloseBarButtonItem(
 			onTap: { [weak self] in
 				self?.onDismiss()

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
@@ -1,0 +1,87 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+import UIKit
+
+class SecondTicketValidationConsentViewController: DynamicTableViewController, FooterViewHandling {
+	
+	// MARK: - Init
+	
+	init(
+		viewModel: SecondTicketValidationConsentViewModel,
+		onPrimaryButtonTap: @escaping (@escaping (Bool) -> Void) -> Void,
+		onDismiss: @escaping () -> Void
+	) {
+		self.viewModel = viewModel
+		self.onPrimaryButtonTap = onPrimaryButtonTap
+		self.onDismiss = onDismiss
+
+		super.init(nibName: nil, bundle: nil)
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	// MARK: - Overrides
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		setupView()
+	}
+	
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
+		navigationController?.navigationBar.prefersLargeTitles = false
+	}
+
+	// MARK: - Protocol FooterViewHandling
+
+	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
+		switch type {
+		case .primary:
+			onPrimaryButtonTap { [weak self] isLoading in
+				guard let self = self else { return }
+
+				self.footerView?.setLoadingIndicator(isLoading, disable: isLoading, button: .primary)
+				self.footerView?.setLoadingIndicator(false, disable: isLoading, button: .secondary)
+			}
+		case .secondary:
+			onDismiss()
+		}
+	}
+	
+	// MARK: - Internal
+	
+	enum ReuseIdentifiers: String, TableViewCellReuseIdentifiers {
+		case legalExtended = "DynamicLegalExtendedCell"
+	}
+	
+	// MARK: - Private
+
+	private let viewModel: SecondTicketValidationConsentViewModel
+	private let onPrimaryButtonTap: (@escaping (Bool) -> Void) -> Void
+	private let onDismiss: () -> Void
+
+	private func setupView() {
+		navigationItem.rightBarButtonItem = CloseBarButtonItem(
+			onTap: { [weak self] in
+				self?.onDismiss()
+			}
+		)
+
+		view.backgroundColor = .enaColor(for: .background)
+		
+		tableView.register(
+			UINib(nibName: String(describing: DynamicLegalExtendedCell.self), bundle: nil),
+			forCellReuseIdentifier: ReuseIdentifiers.legalExtended.rawValue
+		)
+
+		dynamicTableViewModel = viewModel.dynamicTableViewModel
+		tableView.separatorStyle = .none
+	}
+
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
@@ -37,6 +37,12 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 		super.viewWillAppear(animated)
 		navigationController?.navigationBar.prefersLargeTitles = false
 	}
+	
+	// MARK: - Cell reuse identifiers.
+
+	enum CustomCellReuseIdentifiers: String, TableViewCellReuseIdentifiers {
+		case legalExtended = "DynamicLegalExtendedCell"
+	}
 
 	// MARK: - Protocol FooterViewHandling
 

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewController.swift
@@ -42,6 +42,7 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 	// MARK: - Cell reuse identifiers.
 
 	enum CustomCellReuseIdentifiers: String, TableViewCellReuseIdentifiers {
+		case healthCertificateCell = "HealthCertificateCell"
 		case legalExtended = "DynamicLegalExtendedCell"
 	}
 
@@ -59,12 +60,6 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 		case .secondary:
 			onDismiss()
 		}
-	}
-	
-	// MARK: - Internal
-	
-	enum ReuseIdentifiers: String, TableViewCellReuseIdentifiers {
-		case legalExtended = "DynamicLegalExtendedCell"
 	}
 	
 	// MARK: - Private
@@ -86,8 +81,12 @@ class SecondTicketValidationConsentViewController: DynamicTableViewController, F
 		view.backgroundColor = .enaColor(for: .background)
 		
 		tableView.register(
+			HealthCertificateCell.self,
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.healthCertificateCell.rawValue
+		)
+		tableView.register(
 			UINib(nibName: String(describing: DynamicLegalExtendedCell.self), bundle: nil),
-			forCellReuseIdentifier: ReuseIdentifiers.legalExtended.rawValue
+			forCellReuseIdentifier: CustomCellReuseIdentifiers.legalExtended.rawValue
 		)
 
 		dynamicTableViewModel = viewModel.dynamicTableViewModel

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -141,3 +141,38 @@ struct SecondTicketValidationConsentViewModel {
 	private let healthCertificate: HealthCertificate
 	private let onDataPrivacyTap: () -> Void
 }
+
+internal extension DynamicCell {
+
+	/// A `legalExtendedTicketValidation` to display legal text for Data Donation screen with bullet points and sub bullet points
+	/// - Parameters:
+	///   - title: The title/header for the legal foo.
+	///   - description: Optional description text.
+	///   - bulletPoints: A list of strings to be prefixed with bullet points.
+	///   - subBulletPoints: A list of strings to be prefixed with tiny little bullet points
+	///   - accessibilityIdentifier: Optional, but highly recommended, accessibility identifier.
+	///   - configure: Optional custom cell configuration
+	/// - Returns: A `DynamicCell` to display legal texts
+	static func legalExtendedTicketValidation(
+		title: NSAttributedString,
+		description: NSAttributedString,
+		bulletPoints: [NSAttributedString],
+		subBulletPoints: [NSAttributedString],
+		accessibilityIdentifier: String,
+		configure: @escaping CellConfigurator
+	) -> Self {
+		.identifier(SecondTicketValidationConsentViewController.CustomCellReuseIdentifiers.legalExtended) { viewController, cell, indexPath in
+			guard let cell = cell as? DynamicLegalExtendedCell else {
+				fatalError("could not initialize cell of type `DynamicLegalExtendedCell`")
+			}
+			cell.configure(
+				title: title,
+				description: description,
+				bulletPoints: bulletPoints,
+				subBulletPoints: subBulletPoints,
+				accessibilityIdentifier: accessibilityIdentifier
+			)
+			configure(viewController, cell, indexPath)
+		}
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -42,7 +42,7 @@ struct SecondTicketValidationConsentViewModel {
 									healthCertifiedPerson: healthCertifiedPerson,
 									details: .overview
 								),
-								withDiscloreIndicator: false
+								withDisclosureIndicator: false
 							)
 						}
 					)

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -1,0 +1,152 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+import UIKit
+
+struct SecondTicketValidationConsentViewModel {
+	
+	init(
+		serviceIdentity: String,
+		serviceProvider: String,
+		healthCertificate: HealthCertificate,
+		onDataPrivacyTap: @escaping () -> Void
+	) {
+		self.serviceIdentity = serviceIdentity
+		self.serviceProvider = serviceProvider
+		self.healthCertificate = healthCertificate
+		self.onDataPrivacyTap = onDataPrivacyTap
+	}
+	
+	// MARK: - Internal
+	
+	var dynamicTableViewModel: DynamicTableViewModel {
+		/*
+		DynamicTableViewModel([
+			// Image with title
+			.section(
+				header: .image(
+					UIImage(named: "Illu_TicketValidation"),
+					title: AppStrings.TicketValidation.FirstConsent.title,
+					accessibilityLabel: AppStrings.TicketValidation.FirstConsent.imageDescription,
+					accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.image
+				),
+				cells: []
+			),
+			// Subtitle with service provider and subject
+			.section(
+				cells: [
+					.title2(
+						text: AppStrings.TicketValidation.FirstConsent.subtitle
+					),
+					.footnote(
+						text: AppStrings.TicketValidation.FirstConsent.serviceProvider,
+						color: .enaColor(for: .textPrimary2)
+					),
+					.bodyWithoutTopInset(
+						text: String(
+							format: AppStrings.TicketValidation.FirstConsent.serviceProviderValue,
+							serviceProvider
+						)
+					),
+					.footnote(
+						text: AppStrings.TicketValidation.FirstConsent.subject,
+						color: .enaColor(for: .textPrimary2)
+					),
+					.bodyWithoutTopInset(
+						text: String(
+							format: AppStrings.TicketValidation.FirstConsent.subjectValue,
+							subject
+						)
+					),
+					.body(
+						text: AppStrings.TicketValidation.FirstConsent.explination
+					)
+				]
+			),
+			// Bulletpoints in consent box
+			.section(
+				cells: [
+					.legalExtendedDataDonation(
+						title: NSAttributedString(
+							string: AppStrings.TicketValidation.FirstConsent.legalTitle
+						),
+						description: NSAttributedString(
+							string: AppStrings.TicketValidation.FirstConsent.legalSubtitle,
+							attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+						),
+						bulletPoints: [
+							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint1),
+							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint2)
+						],
+						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.legalBox,
+						configure: { _, cell, _ in
+							cell.backgroundColor = .enaColor(for: .background)
+						}
+					)
+				]
+			),
+			// Bulletpoints without box
+			.section(
+				cells: [
+					.space(
+						height: 20
+					),
+					.bulletPoint(
+						text: AppStrings.TicketValidation.FirstConsent.bulletPoint1
+					),
+					.space(
+						height: 20
+					),
+					.bulletPoint(
+						text: AppStrings.TicketValidation.FirstConsent.bulletPoint2
+					),
+					.space(
+						height: 20
+					),
+					.bulletPoint(
+						text: AppStrings.TicketValidation.FirstConsent.bulletPoint3
+					),
+					.space(
+						height: 20
+					),
+					.bulletPoint(
+						text: AppStrings.TicketValidation.FirstConsent.bulletPoint4
+					),
+					.space(
+						height: 20
+					)
+				]
+			),
+			
+			// Data privacy cell
+			.section(
+				separators: .all,
+				cells: [
+					.body(
+						text: AppStrings.TicketValidation.FirstConsent.dataPrivacyTitle,
+						style: DynamicCell.TextCellStyle.label,
+						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.dataPrivacy,
+						accessibilityTraits: UIAccessibilityTraits.link,
+						action: .execute { _, _ in
+							onDataPrivacyTap()
+						},
+						configure: { _, cell, _ in
+							cell.accessoryType = .disclosureIndicator
+							cell.selectionStyle = .default
+						}
+					)
+				]
+			)
+		])
+		 */
+	}
+	
+	// MARK: - Private
+	
+	private let serviceIdentity: String
+	private let serviceProvider: String
+	private let healthCertificate: HealthCertificate
+	private let onDataPrivacyTap: () -> Void	
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -22,6 +22,7 @@ struct SecondTicketValidationConsentViewModel {
 	// MARK: - Internal
 	
 	var dynamicTableViewModel: DynamicTableViewModel {
+		DynamicTableViewModel([])
 		/*
 		DynamicTableViewModel([
 			// Image with title

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -39,7 +39,8 @@ struct SecondTicketValidationConsentViewModel {
 							cell.configure(
 								HealthCertificateCellViewModel(
 									healthCertificate: healthCertificate,
-									healthCertifiedPerson: healthCertifiedPerson
+									healthCertifiedPerson: healthCertifiedPerson,
+									details: .overview
 								)
 							)
 						}

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -11,11 +11,13 @@ struct SecondTicketValidationConsentViewModel {
 		serviceIdentity: String,
 		serviceProvider: String,
 		healthCertificate: HealthCertificate,
+		healthCertifiedPerson: HealthCertifiedPerson,
 		onDataPrivacyTap: @escaping () -> Void
 	) {
 		self.serviceIdentity = serviceIdentity
 		self.serviceProvider = serviceProvider
 		self.healthCertificate = healthCertificate
+		self.healthCertifiedPerson = healthCertifiedPerson
 		self.onDataPrivacyTap = onDataPrivacyTap
 	}
 	
@@ -25,10 +27,32 @@ struct SecondTicketValidationConsentViewModel {
 		
 		DynamicTableViewModel([
 			// HealthCertificate
-			
+			.section(
+				cells: [
+					.identifier(
+						SecondTicketValidationConsentViewController.CustomCellReuseIdentifiers.healthCertificateCell,
+						configure: { _, cell, _ in
+							guard let cell = cell as? HealthCertificateCell else {
+								fatalError("could not initialize cell of type `HealthCertificateCell`")
+							}
+							
+							cell.configure(
+								HealthCertificateCellViewModel(
+									healthCertificate: healthCertificate,
+									healthCertifiedPerson: healthCertifiedPerson
+								)
+							)
+						}
+					)
+				]
+			),
 			// Subtitle with serviceIdentity and serviceProvider
 			.section(
 				cells: [
+					.space(
+						height: 15.0,
+						color: .enaColor(for: .background)
+					),
 					.title2(
 						text: AppStrings.TicketValidation.SecondConsent.subtitle
 					),
@@ -117,7 +141,6 @@ struct SecondTicketValidationConsentViewModel {
 					)
 				]
 			),
-			 
 			// Data privacy cell
 			.section(
 				separators: .all,
@@ -145,6 +168,7 @@ struct SecondTicketValidationConsentViewModel {
 	private let serviceIdentity: String
 	private let serviceProvider: String
 	private let healthCertificate: HealthCertificate
+	private let healthCertifiedPerson: HealthCertifiedPerson
 	private let onDataPrivacyTap: () -> Void
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -60,19 +60,25 @@ struct SecondTicketValidationConsentViewModel {
 			// Bulletpoints in consent box
 			.section(
 				cells: [
-					.legalExtendedDataDonation(
+					.legalExtendedTicketValidation(
 						title: NSAttributedString(
-							string: AppStrings.TicketValidation.FirstConsent.legalTitle
+							string: AppStrings.TicketValidation.SecondConsent.Legal.title
 						),
 						description: NSAttributedString(
-							string: AppStrings.TicketValidation.FirstConsent.legalSubtitle,
+							string: AppStrings.TicketValidation.SecondConsent.Legal.subtitle,
 							attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
 						),
 						bulletPoints: [
-							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint1),
-							NSAttributedString(string: AppStrings.TicketValidation.FirstConsent.legalBulletPoint2)
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.bulletPoint1),
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.bulletPoint2)
 						],
-						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.legalBox,
+						subBulletPoints: [
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.subBulletPoint1),
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.subBulletPoint2),
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.subBulletPoint3),
+							NSAttributedString(string: AppStrings.TicketValidation.SecondConsent.Legal.subBulletPoint4)
+						],
+						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.SecondConsent.legalBox,
 						configure: { _, cell, _ in
 							cell.backgroundColor = .enaColor(for: .background)
 						}
@@ -80,6 +86,7 @@ struct SecondTicketValidationConsentViewModel {
 				]
 			),
 			// Bulletpoints without box
+			/*
 			.section(
 				cells: [
 					.space(
@@ -111,6 +118,7 @@ struct SecondTicketValidationConsentViewModel {
 					)
 				]
 			),
+			 
 			
 			// Data privacy cell
 			.section(
@@ -131,6 +139,7 @@ struct SecondTicketValidationConsentViewModel {
 					)
 				]
 			)
+			 */
 		])
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -175,7 +175,7 @@ struct SecondTicketValidationConsentViewModel {
 
 internal extension DynamicCell {
 
-	/// A `legalExtendedTicketValidation` to display legal text for Data Donation screen with bullet points and sub bullet points
+	/// A `legalExtendedTicketValidation` to display legal text for Ticket Validation consent screen with bullet points and sub bullet points
 	/// - Parameters:
 	///   - title: The title/header for the legal foo.
 	///   - description: Optional description text.

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -86,32 +86,31 @@ struct SecondTicketValidationConsentViewModel {
 				]
 			),
 			// Bulletpoints without box
-			/*
 			.section(
 				cells: [
 					.space(
 						height: 20
 					),
 					.bulletPoint(
-						text: AppStrings.TicketValidation.FirstConsent.bulletPoint1
+						text: AppStrings.TicketValidation.SecondConsent.bulletPoint1
 					),
 					.space(
 						height: 20
 					),
 					.bulletPoint(
-						text: AppStrings.TicketValidation.FirstConsent.bulletPoint2
+						text: AppStrings.TicketValidation.SecondConsent.bulletPoint2
 					),
 					.space(
 						height: 20
 					),
 					.bulletPoint(
-						text: AppStrings.TicketValidation.FirstConsent.bulletPoint3
+						text: AppStrings.TicketValidation.SecondConsent.bulletPoint3
 					),
 					.space(
 						height: 20
 					),
 					.bulletPoint(
-						text: AppStrings.TicketValidation.FirstConsent.bulletPoint4
+						text: AppStrings.TicketValidation.SecondConsent.bulletPoint4
 					),
 					.space(
 						height: 20
@@ -119,7 +118,6 @@ struct SecondTicketValidationConsentViewModel {
 				]
 			),
 			 
-			
 			// Data privacy cell
 			.section(
 				separators: .all,
@@ -139,7 +137,6 @@ struct SecondTicketValidationConsentViewModel {
 					)
 				]
 			)
-			 */
 		])
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -22,47 +22,38 @@ struct SecondTicketValidationConsentViewModel {
 	// MARK: - Internal
 	
 	var dynamicTableViewModel: DynamicTableViewModel {
-		DynamicTableViewModel([])
-		/*
+		
 		DynamicTableViewModel([
-			// Image with title
-			.section(
-				header: .image(
-					UIImage(named: "Illu_TicketValidation"),
-					title: AppStrings.TicketValidation.FirstConsent.title,
-					accessibilityLabel: AppStrings.TicketValidation.FirstConsent.imageDescription,
-					accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.image
-				),
-				cells: []
-			),
-			// Subtitle with service provider and subject
+			// HealthCertificate
+			
+			// Subtitle with serviceIdentity and serviceProvider
 			.section(
 				cells: [
 					.title2(
-						text: AppStrings.TicketValidation.FirstConsent.subtitle
+						text: AppStrings.TicketValidation.SecondConsent.subtitle
 					),
 					.footnote(
-						text: AppStrings.TicketValidation.FirstConsent.serviceProvider,
+						text: AppStrings.TicketValidation.SecondConsent.serviceIdentity,
 						color: .enaColor(for: .textPrimary2)
 					),
 					.bodyWithoutTopInset(
 						text: String(
-							format: AppStrings.TicketValidation.FirstConsent.serviceProviderValue,
+							format: AppStrings.TicketValidation.SecondConsent.serviceIdentityValue,
+							serviceIdentity
+						)
+					),
+					.footnote(
+						text: AppStrings.TicketValidation.SecondConsent.serviceProvider,
+						color: .enaColor(for: .textPrimary2)
+					),
+					.bodyWithoutTopInset(
+						text: String(
+							format: AppStrings.TicketValidation.SecondConsent.serviceProviderValue,
 							serviceProvider
 						)
 					),
-					.footnote(
-						text: AppStrings.TicketValidation.FirstConsent.subject,
-						color: .enaColor(for: .textPrimary2)
-					),
-					.bodyWithoutTopInset(
-						text: String(
-							format: AppStrings.TicketValidation.FirstConsent.subjectValue,
-							subject
-						)
-					),
 					.body(
-						text: AppStrings.TicketValidation.FirstConsent.explination
+						text: AppStrings.TicketValidation.SecondConsent.explination
 					)
 				]
 			),
@@ -141,7 +132,6 @@ struct SecondTicketValidationConsentViewModel {
 				]
 			)
 		])
-		 */
 	}
 	
 	// MARK: - Private
@@ -149,5 +139,5 @@ struct SecondTicketValidationConsentViewModel {
 	private let serviceIdentity: String
 	private let serviceProvider: String
 	private let healthCertificate: HealthCertificate
-	private let onDataPrivacyTap: () -> Void	
+	private let onDataPrivacyTap: () -> Void
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -123,9 +123,9 @@ struct SecondTicketValidationConsentViewModel {
 				separators: .all,
 				cells: [
 					.body(
-						text: AppStrings.TicketValidation.FirstConsent.dataPrivacyTitle,
+						text: AppStrings.TicketValidation.SecondConsent.dataPrivacyTitle,
 						style: DynamicCell.TextCellStyle.label,
-						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.FirstConsent.dataPrivacy,
+						accessibilityIdentifier: AccessibilityIdentifiers.TicketValidation.SecondConsent.dataPrivacy,
 						accessibilityTraits: UIAccessibilityTraits.link,
 						action: .execute { _, _ in
 							onDataPrivacyTap()

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/SecondConsent/SecondTicketValidationConsentViewModel.swift
@@ -41,7 +41,8 @@ struct SecondTicketValidationConsentViewModel {
 									healthCertificate: healthCertificate,
 									healthCertifiedPerson: healthCertifiedPerson,
 									details: .overview
-								)
+								),
+								withDiscloreIndicator: false
 							)
 						}
 					)

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
@@ -44,6 +44,13 @@ final class TicketValidationCoordinator {
 			),
 			onPrimaryButtonTap: { [weak self] isLoading in
 				isLoading(true)
+				
+				let mockCert = HealthCertificate.mock()
+				self?.showSecondConsentScreen(
+					selectedCertificate: mockCert,
+					selectedCertifiedPerson: HealthCertifiedPerson(healthCertificates: [mockCert])
+				)
+				/*
 
 				self?.ticketValidation.grantFirstConsent { result in
 					DispatchQueue.main.async {
@@ -57,6 +64,7 @@ final class TicketValidationCoordinator {
 						}
 					}
 				}
+				 */
 			},
 			onDismiss: {
 				self.showDismissAlert()
@@ -97,13 +105,15 @@ final class TicketValidationCoordinator {
 	}
 
 	private func showSecondConsentScreen(
-		selectedCertificate: HealthCertificate
+		selectedCertificate: HealthCertificate,
+		selectedCertifiedPerson: HealthCertifiedPerson
 	) {
 		let secondConsentViewController = SecondTicketValidationConsentViewController(
 			viewModel: SecondTicketValidationConsentViewModel(
 				serviceIdentity: ticketValidation.initializationData.serviceIdentity,
 				serviceProvider: ticketValidation.initializationData.serviceProvider,
 				healthCertificate: selectedCertificate,
+				healthCertifiedPerson: selectedCertifiedPerson,
 				onDataPrivacyTap: {
 					self.showDataPrivacy()
 				}

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
@@ -112,7 +112,19 @@ final class TicketValidationCoordinator {
 			),
 			onPrimaryButtonTap: { [weak self] isLoading in
 				isLoading(true)
-				// call grantSecondConsent()
+				
+				self?.ticketValidation.validate { result in
+					DispatchQueue.main.async {
+						isLoading(false)
+
+						switch result {
+						case .success(let ticketValidationResult):
+							self?.showResultScreen(for: ticketValidationResult)
+						case .failure(let error):
+							self?.showErrorAlert(error: error)
+						}
+					}
+				}
 			},
 			onDismiss: {
 				self.showDismissAlert()

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
@@ -96,8 +96,43 @@ final class TicketValidationCoordinator {
 
 	}
 
-	private func showSecondConsentScreen(selectedCertificate: HealthCertificate) {
-
+	private func showSecondConsentScreen(
+		selectedCertificate: HealthCertificate
+	) {
+		let secondConsentViewController = SecondTicketValidationConsentViewController(
+			viewModel: SecondTicketValidationConsentViewModel(
+				serviceIdentity: ticketValidation.initializationData.serviceIdentity,
+				serviceProvider: ticketValidation.initializationData.serviceProvider,
+				healthCertificate: selectedCertificate,
+				onDataPrivacyTap: {
+					self.showDataPrivacy()
+				}
+			),
+			onPrimaryButtonTap: { [weak self] isLoading in
+				isLoading(true)
+				// call grantSecondConsent()
+			},
+			onDismiss: {
+				self.showDismissAlert()
+			}
+		)
+		
+		let footerViewController = FooterViewController(
+			FooterViewModel(
+				primaryButtonName: AppStrings.TicketValidation.SecondConsent.primaryButtonTitle,
+				secondaryButtonName: AppStrings.TicketValidation.SecondConsent.secondaryButtonTitle,
+				isSecondaryButtonEnabled: true,
+				isPrimaryButtonHidden: false,
+				isSecondaryButtonHidden: false
+			)
+		)
+		
+		let topBottomContainerViewController = TopBottomContainerViewController(
+			topController: secondConsentViewController,
+			bottomController: footerViewController
+		)
+		
+		navigationController.pushViewController(topBottomContainerViewController, animated: true)
 	}
 
 	private func showResultScreen(for result: TicketValidationResult) {

--- a/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/TicketValidation/TicketValidationCoordinator.swift
@@ -44,13 +44,6 @@ final class TicketValidationCoordinator {
 			),
 			onPrimaryButtonTap: { [weak self] isLoading in
 				isLoading(true)
-				
-				let mockCert = HealthCertificate.mock()
-				self?.showSecondConsentScreen(
-					selectedCertificate: mockCert,
-					selectedCertifiedPerson: HealthCertifiedPerson(healthCertificates: [mockCert])
-				)
-				/*
 
 				self?.ticketValidation.grantFirstConsent { result in
 					DispatchQueue.main.async {
@@ -64,7 +57,6 @@ final class TicketValidationCoordinator {
 						}
 					}
 				}
-				 */
 			},
 			onDismiss: {
 				self.showDismissAlert()

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -760,6 +760,11 @@ enum AccessibilityIdentifiers {
 			static let legalBox = "TicketValidation.FirstConsent.legalBox"
 			static let dataPrivacy = "TicketValidation.FirstConsent.dataPrivacy"
 		}
+		
+		enum SecondConsent {
+			static let legalBox = "TicketValidation.SecondConsent.legalBox"
+			static let dataPrivacy = "TicketValidation.SecondConsent.dataPrivacy"
+		}
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2503,6 +2503,10 @@ enum AppStrings {
 			static let serviceProvider = NSLocalizedString("TicketValidation_SecondConsent_serviceProvider", comment: "")
 			static let serviceProviderValue = NSLocalizedString("\"%@\"", comment: "")
 			static let explination = NSLocalizedString("TicketValidation_SecondConsent_explination", comment: "")
+			static let bulletPoint1 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint1", comment: "")
+			static let bulletPoint2 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint2", comment: "")
+			static let bulletPoint3 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint3", comment: "")
+			static let bulletPoint4 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint4", comment: "")
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_secondaryButtonTitle", comment: "")
 			enum Legal {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2497,6 +2497,7 @@ enum AppStrings {
 		}
 		
 		enum SecondConsent {
+			static let title = NSLocalizedString("TicketValidation_SecondConsent_title", comment: "")
 			static let subtitle = NSLocalizedString("TicketValidation_SecondConsent_subtitle", comment: "")
 			static let serviceIdentity = NSLocalizedString("TicketValidation_SecondConsent_serviceIdentity", comment: "")
 			static let serviceIdentityValue = NSLocalizedString("\"%@\"", comment: "")

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2492,6 +2492,11 @@ enum AppStrings {
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_FirstConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_FirstConsent_secondaryButtonTitle", comment: "")
 		}
+		
+		enum SecondConsent {
+			static let primaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_primaryButtonTitle", comment: "")
+			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_secondaryButtonTitle", comment: "")
+		}
 
 		enum CancelAlert {
 			static let title = NSLocalizedString("TicketValidation_CancelAlert_title", comment: "")

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2494,6 +2494,12 @@ enum AppStrings {
 		}
 		
 		enum SecondConsent {
+			static let subtitle = NSLocalizedString("TicketValidation_SecondConsent_subtitle", comment: "")
+			static let serviceIdentity = NSLocalizedString("TicketValidation_SecondConsent_serviceIdentity", comment: "")
+			static let serviceIdentityValue = NSLocalizedString("\"%@\"", comment: "")
+			static let serviceProvider = NSLocalizedString("TicketValidation_SecondConsent_serviceProvider", comment: "")
+			static let serviceProviderValue = NSLocalizedString("\"%@\"", comment: "")
+			static let explination = NSLocalizedString("TicketValidation_SecondConsent_explination", comment: "")
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_secondaryButtonTitle", comment: "")
 		}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2480,10 +2480,6 @@ enum AppStrings {
 			static let subject = NSLocalizedString("TicketValidation_FirstConsent_subject", comment: "")
 			static let subjectValue = NSLocalizedString("\"%@\"", comment: "")
 			static let explination = NSLocalizedString("TicketValidation_FirstConsent_explination", comment: "")
-			static let legalTitle = NSLocalizedString("TicketValidation_FirstConsent_Legal_title", tableName: "Localizable.legal", comment: "")
-			static let legalSubtitle = NSLocalizedString("TicketValidation_FirstConsent_Legal_subtitle", tableName: "Localizable.legal", comment: "")
-			static let legalBulletPoint1 = NSLocalizedString("TicketValidation_FirstConsent_Legal_bulletPoint1", tableName: "Localizable.legal", comment: "")
-			static let legalBulletPoint2 = NSLocalizedString("TicketValidation_FirstConsent_Legal_bulletPoint2", tableName: "Localizable.legal", comment: "")
 			static let bulletPoint1 = NSLocalizedString("TicketValidation_FirstConsent_BulletPoint1", comment: "")
 			static let bulletPoint2 = NSLocalizedString("TicketValidation_FirstConsent_BulletPoint2", comment: "")
 			static let bulletPoint3 = NSLocalizedString("TicketValidation_FirstConsent_BulletPoint3", comment: "")
@@ -2491,6 +2487,13 @@ enum AppStrings {
 			static let dataPrivacyTitle = NSLocalizedString("TicketValidation_FirstConsent_DataPrivacyTitle", comment: "")
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_FirstConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_FirstConsent_secondaryButtonTitle", comment: "")
+			
+			enum Legal {
+				static let title = NSLocalizedString("TicketValidation_FirstConsent_Legal_title", tableName: "Localizable.legal", comment: "")
+				static let subtitle = NSLocalizedString("TicketValidation_FirstConsent_Legal_subtitle", tableName: "Localizable.legal", comment: "")
+				static let bulletPoint1 = NSLocalizedString("TicketValidation_FirstConsent_Legal_bulletPoint1", tableName: "Localizable.legal", comment: "")
+				static let bulletPoint2 = NSLocalizedString("TicketValidation_FirstConsent_Legal_bulletPoint2", tableName: "Localizable.legal", comment: "")
+			}
 		}
 		
 		enum SecondConsent {
@@ -2502,6 +2505,17 @@ enum AppStrings {
 			static let explination = NSLocalizedString("TicketValidation_SecondConsent_explination", comment: "")
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_secondaryButtonTitle", comment: "")
+			enum Legal {
+				static let title = NSLocalizedString("TicketValidation_SecondConsent_Legal_title", tableName: "Localizable.legal", comment: "")
+				static let subtitle = NSLocalizedString("TicketValidation_SecondConsent_Legal_subtitle", tableName: "Localizable.legal", comment: "")
+				static let bulletPoint1 = NSLocalizedString("TicketValidation_SecondConsent_Legal_bulletPoint1", tableName: "Localizable.legal", comment: "")
+				static let bulletPoint2 = NSLocalizedString("TicketValidation_SecondConsent_Legal_bulletPoint2", tableName: "Localizable.legal", comment: "")
+				static let subBulletPoint1 = NSLocalizedString("TicketValidation_SecondConsent_Legal_subBulletPoint1", tableName: "Localizable.legal", comment: "")
+				static let subBulletPoint2 = NSLocalizedString("TicketValidation_SecondConsent_Legal_subBulletPoint2", tableName: "Localizable.legal", comment: "")
+				static let subBulletPoint3 = NSLocalizedString("TicketValidation_SecondConsent_Legal_subBulletPoint3", tableName: "Localizable.legal", comment: "")
+				static let subBulletPoint4 = NSLocalizedString("TicketValidation_SecondConsent_Legal_subBulletPoint4", tableName: "Localizable.legal", comment: "")
+			}
+	
 		}
 
 		enum CancelAlert {

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2507,6 +2507,7 @@ enum AppStrings {
 			static let bulletPoint2 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint2", comment: "")
 			static let bulletPoint3 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint3", comment: "")
 			static let bulletPoint4 = NSLocalizedString("TicketValidation_SecondConsent_BulletPoint4", comment: "")
+			static let dataPrivacyTitle = NSLocalizedString("TicketValidation_SecondConsent_DataPrivacyTitle", comment: "")
 			static let primaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_primaryButtonTitle", comment: "")
 			static let secondaryButtonTitle = NSLocalizedString("TicketValidation_SecondConsent_secondaryButtonTitle", comment: "")
 			enum Legal {

--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicLegalExtendedCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicLegalExtendedCell.swift
@@ -76,7 +76,7 @@ class DynamicLegalExtendedCell: UITableViewCell, ReuseIdentifierProviding {
 		let description2 = NSAttributedString(string: "")
 		configure(title: title, description1: description, description2: description2, textBlocks1: textBlocks1, textBlocks2: textBlocks2, accessibilityIdentifier: accessibilityIdentifier)
 	}
-
+	
 	/// Configure a legal extended cell:
 	/// - Parameters:
 	/// - title, (bold)
@@ -95,9 +95,72 @@ class DynamicLegalExtendedCell: UITableViewCell, ReuseIdentifierProviding {
 		
 		configure(title: title, description1: description, description2: NSAttributedString(), textBlocks1: textBlocks1, textBlocks2: textBlocks2, accessibilityIdentifier: accessibilityIdentifier)
 	}
+	
+	/// Configure a legal extended cell with bullet points and sub bullet points:
+	/// - Parameters:
+	/// - title, (bold)
+	/// - description
+	/// - bulletPoints
+	/// - subBulletPoints
+	func configure(
+		title: NSAttributedString,
+		description: NSAttributedString,
+		bulletPoints: [NSAttributedString],
+		subBulletPoints: [NSAttributedString],
+		accessibilityIdentifier: String
+	) {
+		let label = ENALabel() // get the default font – create fake label
+		
+		let formattedBulletPoints = bulletPoints.map({ $0.bulletPointString(bulletPointFont: label.font) })
+		let formattedSubBulletPoints = subBulletPoints.map({ $0.bulletPointString(bulletPointFont: .systemFont(ofSize: 9)) })
+		
+		titleLabel.attributedText = title
+		descriptionLabel1.attributedText = description
 
+		descriptionLabel1.isHidden = false
+		descriptionLabel2.isHidden = true
+		
+		self.accessibilityIdentifier = accessibilityIdentifier
+		
+		// pruning stack view before setting (new) label
+		contentStackView1.removeAllArrangedSubviews()
+		contentStackView2.removeAllArrangedSubviews()
+		
+		formattedBulletPoints.forEach { string in
+			let label = ENALabel()
+			label.style = .body
+			label.numberOfLines = 0
+			label.lineBreakMode = .byWordWrapping
+			label.attributedText = string
+			label.setContentCompressionResistancePriority(.required, for: .vertical)
+			label.setContentHuggingPriority(.required, for: .vertical)
+			contentStackView1.addArrangedSubview(label)
+		}
+		
+		formattedSubBulletPoints.forEach { string in
+			let label = ENALabel()
+			label.style = .body
+			label.numberOfLines = 0
+			label.lineBreakMode = .byWordWrapping
+			label.attributedText = string
+			label.setContentCompressionResistancePriority(.required, for: .vertical)
+			label.setContentHuggingPriority(.required, for: .vertical)
+			contentStackView2.addArrangedSubview(label)
+		}
+		// We need for the subBulletPoints some more indentation
+		contentStackView2.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 60).isActive = true
+		
+		cardView.layoutIfNeeded()
+	}
 
-	func configure(title: NSAttributedString, description1: NSAttributedString?, description2: NSAttributedString?, textBlocks1: [NSAttributedString], textBlocks2: [NSAttributedString], accessibilityIdentifier: String? = nil) {
+	private func configure(
+		title: NSAttributedString,
+		description1: NSAttributedString?,
+		description2: NSAttributedString?,
+		textBlocks1: [NSAttributedString],
+		textBlocks2: [NSAttributedString],
+		accessibilityIdentifier: String? = nil
+	) {
 		
 		titleLabel.attributedText = title
 		descriptionLabel1.attributedText = description1
@@ -133,7 +196,6 @@ class DynamicLegalExtendedCell: UITableViewCell, ReuseIdentifierProviding {
 			label.setContentHuggingPriority(.required, for: .vertical)
 			contentStackView2.addArrangedSubview(label)
 		}
-		
 		cardView.layoutIfNeeded()
 	}
 


### PR DESCRIPTION
## Description
Second consent screen during the ticket validation flow.
- Added several strings
- Added view model and view controller
- Extended newly `DynamicCell` for new sub bullet points under bullet points
- Made `HealthCertificateCell` configurable to differ between two view states

Note: Actually you cannot retest, because you cannot reach the screen until the certificate selection is created.

## Link to Jira
Mainstory: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10351
Subtask: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10560

## Screenshots
![10560-1](https://user-images.githubusercontent.com/75615785/142640640-d67673c5-ef14-44cd-80f8-14e25945bba5.png)
![10560-2](https://user-images.githubusercontent.com/75615785/142640645-801a17a8-b8fd-4dde-bf4f-ffb220c7b29f.png)
![10560-3](https://user-images.githubusercontent.com/75615785/142640648-02c3b15b-cfe6-4bec-873d-e15ea1b98e0e.png)
![10560-4](https://user-images.githubusercontent.com/75615785/142640650-60a3a807-1222-4733-a7f0-3bba2498b629.png)

![10560-1-dark](https://user-images.githubusercontent.com/75615785/142640658-58d841a9-6ab0-4387-8200-224e76e128e3.png)
![10560-2-dark](https://user-images.githubusercontent.com/75615785/142640663-a884b934-075f-49c5-bbcf-38aeb0ea2dbb.png)
![10560-3-dark](https://user-images.githubusercontent.com/75615785/142640670-a42dfae3-b8a4-4bc9-ac93-43c3a0c9bf20.png)
![10560-4-dark](https://user-images.githubusercontent.com/75615785/142640681-7341e7f1-af18-40ad-a3ee-87ce7c57ca21.png)
