### PR TITLE
fix/3868 remove unreferenced link definitions

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/en/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/en/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/en/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/en/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/en/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/de/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/de/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/de/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/de/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/de/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/en/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/en/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/en/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/en/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/en/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/en/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/en/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/en/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/en/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/en/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/en/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/en/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/en/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/en/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/en/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
@@ -1,7 +1,5 @@
 "OnboardingInfo_togetherAgainstCoronaPage_link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
-"ExposureNotificationSetting_GeneralError_LearnMore_URL" = "https://www.coronawarn.app/en/faq/";
-
 "App_Information_About_Link" = "https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-leichte-sprache-gebaerdensprache";
 
 "App_Information_Contact_Form_Link" = "https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html";

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.links.strings
@@ -26,8 +26,6 @@
 
 "Risk_Encounter_Low_FAQ_URL" = "https://www.coronawarn.app/en/faq/#encounter_but_green";
 
-"HealthCertificate_Info_register_FAQLink" = "https://www.coronawarn.app/en/faq/";
-
 "HealthCertificate_Error_FAQ_Link" = "https://www.coronawarn.app/en/faq/#hc_prefix_invalid";
 
 "HealthCertificate_Info_validation_FAQLink" = "https://www.coronawarn.app/en/faq/#cert_eu_travel";

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -821,8 +821,6 @@ enum AppStrings {
 
 		static let learnMoreActionTitle = NSLocalizedString("ExposureNotificationSetting_GeneralError_LearnMore_Action", comment: "")
 
-		static let learnMoreURL = NSLocalizedString("ExposureNotificationSetting_GeneralError_LearnMore_URL", tableName: "Localizable.links", comment: "")
-
 		static let enAuthorizationError = NSLocalizedString("ExposureNotificationSetting_AuthenticationError", comment: "")
 
 		static let enActivationRequiredError = NSLocalizedString("ExposureNotificationSetting_exposureNotification_Required", comment: "")

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -41,7 +41,6 @@ enum AppStrings {
 		static let appFaqENError11 = NSLocalizedString("General_moreInfo_URL_EN11", tableName: "Localizable.links", comment: "")
 		static let appFaqENError13 = NSLocalizedString("General_moreInfo_URL_EN13", tableName: "Localizable.links", comment: "")
 		static let exposureDetectionFAQ = NSLocalizedString("ExposureDetection_high_faq_URL", tableName: "Localizable.links", comment: "")
-		static let healthCertificateFAQ = NSLocalizedString("HealthCertificate_Info_register_FAQLink", tableName: "Localizable.links", comment: "")
 		static let healthCertificateErrorFAQ = NSLocalizedString("HealthCertificate_Error_FAQ_Link", tableName: "Localizable.links", comment: "")
 		static let testCertificateErrorFAQ = NSLocalizedString("TestCertificate_Error_FAQ_Link", tableName: "Localizable.links", comment: "")
 		static let findTestCentersFAQ = NSLocalizedString("Test_Centers_FAQ_Link", tableName: "Localizable.links", comment: "")


### PR DESCRIPTION
## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
This PR removes two unreferenced link definitions that were reported as #3868.

Of course I cannot know for sure the true reason for this.
The definition `AppStrings.Links.healthCertificateFAQ` was added on 06 May 2021, so I don't believe that this is an "unborn child" (work in progress).
My suspicion is rather that it is either no longer used and was just forgotten to clean up.
Or it was planned to be used for some purpose but this was forgotten to implement.

The definition `AppStrings.ExposureNotificationError.learnMoreURL` was added on 03 July 2020; also here I believe it was just forgotten to clean up after it was no longer used.

## Link to Jira
<!-- Please add the link to the related Jira issue -->
Jira: n/a
github: #3868

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
