### PR TITLE
fix/#10179-overlapping-icons

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
@@ -56,9 +56,10 @@ class HealthCertificatePDFVersionViewController: DynamicTableViewController, UIA
 	
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		navigationController?.navigationBar.prefersLargeTitles = false
-		// Must be set here, otherwise navBar will be translucent.
-		navigationController?.navigationBar.isTranslucent = false
+		// Need to call here again to set the nav bar size correctly.
+		if let dismissHandlingNC = navigationController as? DismissHandlingNavigationController {
+			dismissHandlingNC.restoreOriginalNavigationBar()
+		}
 	}
 
 	// MARK: - Protocol UIActivityItemSource


### PR DESCRIPTION
## Description
The bug was that we made some special handling for the nav bar, which was dependent of the handling of the nav bar in the screen before. There was made a change, so the special handling for the print pdf screen broke.
Now the nav bar is not longer transparent (which is needed in the screen before).

## Github Issue ##
https://github.com/corona-warn-app/cwa-app-ios/issues/3731

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10179

## Screenshots
![10179](https://user-images.githubusercontent.com/75615785/144015442-fa20f793-4f0c-4ce5-a948-6bbc7335cb00.PNG)
![10179-dark](https://user-images.githubusercontent.com/75615785/144015446-0e3d2d44-b730-4f51-a4cc-03a2fa1ea41f.PNG)

