### PR TITLE
Fix for crash at adding progress child 

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -83,7 +83,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 					}
 				}
 				
-				// Prevent adding a child which is perhaps already finish or cancelled because this would crash the app.
+				// Prevent adding a child which is perhaps already finished or cancelled because this would crash the app.
 				guard !exposureWindowsProgress.isFinished, !exposureWindowsProgress.isCancelled else {
 					Log.info("Not adding a child due to already finished or cancelled exposureWindowsProgress", log: .riskDetection)
 					completion(.failure(ExposureDetectionError.isAlreadyRunning))

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetectionExecutor.swift
@@ -98,7 +98,7 @@ final class ExposureDetectionExecutor: ExposureDetectionDelegate {
 			}
 		}
 		
-		// Prevent adding a child which is perhaps already finish or cancelled because this would crash the app.
+		// Prevent adding a child which is perhaps already finished or cancelled because this would crash the app.
 		guard !detectExposuresProgress.isFinished, !detectExposuresProgress.isCancelled else {
 			Log.info("Not adding a child due to already finished or cancelled detectExposuresProgress", log: .riskDetection)
 			return progress


### PR DESCRIPTION
## Description
Possibly fixes the well known Progress-Crash in our app. The crash is made when adding more child progresses then allowed. I added two guards to prevent adding a progress when it's already finished or cancelled in assumption that already finished or cancelled progresses crashed the app when you try to add them.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4368

