### PR TITLE
introduce some optional indentation for the bullet points

### DIFF
--- a/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/NSAttributedString+BulletPoint.swift
@@ -16,22 +16,30 @@ extension NSAttributedString {
 	///   - bulletPointFont: The Font for the bullet point and first part of the `from` string. Required to align and scale the bullet point.
 	///   - keepOriginalAttributes: If true, this ensures, that the original passed in attributes are kept.
 	/// - Returns: An attributed string that is prefixed with a bullet point.
-	static func bulletPointString(_ from: NSAttributedString, bulletPointFont font: UIFont, bulletPointColor color: UIColor = ColorCompatibility.label, keepOriginalAttributes: Bool = false) -> NSAttributedString {
-		// <bullet point>|--- indentation ---|<rest of text>
-		let indentation: CGFloat = 20.0
+	static func bulletPointString(
+		_ from: NSAttributedString,
+		bulletPointFont font: UIFont,
+		bulletPointColor color: UIColor = ColorCompatibility.label,
+		keepOriginalAttributes: Bool = false,
+		indentationTabs: Int = 0
+	) -> NSAttributedString {
+		// indentation ---|<bullet point>|--- spacing ---|<rest of text>
+		let spacing: CGFloat = 20.0
 		let paragraphStyle = NSMutableParagraphStyle()
-		paragraphStyle.tabStops = [NSTextTab(textAlignment: .natural, location: indentation, options: [:])]
-		paragraphStyle.defaultTabInterval = indentation
-		paragraphStyle.headIndent = indentation
+		paragraphStyle.tabStops = [NSTextTab(textAlignment: .natural, location: spacing, options: [:])]
+		paragraphStyle.defaultTabInterval = spacing
+		paragraphStyle.headIndent = spacing + (CGFloat(indentationTabs) * spacing)
 		paragraphStyle.paragraphSpacing = 8
 
 		let bulletAttributes: [NSAttributedString.Key: Any] = [
 			.font: font.scaledFont(size: font.pointSize, weight: .black),
 			.foregroundColor: color
 		]
+	
+		let tabs = String(repeating: "\t", count: indentationTabs)
 		
 		let bullet = "\u{2022}"
-		let prefixString = "\(bullet)\t"
+		let prefixString = "\(tabs)\(bullet)\t"
 		
 		let attributedString = NSMutableAttributedString(string: prefixString)
 		attributedString.append(from)
@@ -64,8 +72,17 @@ extension NSAttributedString {
 	///   - bulletPointFont: The Font for the bullet point and first part of the `from` string. Required to align and scale the bullet point.
 	///   - keepOriginalAttributes: If true, this ensures, that the original passed in attributes are kept.
 	/// - Returns: An attributed string that is prefixed with a bullet point.
-	func bulletPointString(bulletPointFont font: UIFont, keepOriginalAttributes: Bool = false) -> NSAttributedString {
-		return NSAttributedString.bulletPointString(self, bulletPointFont: font, keepOriginalAttributes: keepOriginalAttributes)
+	func bulletPointString(
+		bulletPointFont font: UIFont,
+		keepOriginalAttributes: Bool = false,
+		indentationTabs: Int = 0
+	) -> NSAttributedString {
+		return NSAttributedString.bulletPointString(
+			self,
+			bulletPointFont: font,
+			keepOriginalAttributes: keepOriginalAttributes,
+			indentationTabs: indentationTabs
+		)
 	}
 	
 	func bulletPointString(bulletPointFont font: UIFont, bulletPointColor: UIColor) -> NSAttributedString {

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerActivityIndicatorView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerActivityIndicatorView.swift
@@ -42,6 +42,7 @@ class QRScannerActivityIndicatorView: UIView {
 
 		let hudTextLabel = ENALabel(style: .body)
 		hudTextLabel.translatesAutoresizingMaskIntoConstraints = false
+		hudTextLabel.numberOfLines = 0
 		hudTextLabel.textColor = .enaColor(for: .textPrimary1Contrast)
 		hudTextLabel.text = AppStrings.FileScanner.hudText
 

--- a/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicLegalExtendedCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/ExposureSubmission/DynamicLegalExtendedCell.swift
@@ -112,7 +112,11 @@ class DynamicLegalExtendedCell: UITableViewCell, ReuseIdentifierProviding {
 		let label = ENALabel() // get the default font – create fake label
 		
 		let formattedBulletPoints = bulletPoints.map({ $0.bulletPointString(bulletPointFont: label.font) })
-		let formattedSubBulletPoints = subBulletPoints.map({ $0.bulletPointString(bulletPointFont: .systemFont(ofSize: 9)) })
+		let formattedSubBulletPoints = subBulletPoints.map({ $0.bulletPointString(
+				bulletPointFont: .systemFont(ofSize: 9),
+				indentationTabs: 1
+			)
+		})
 		
 		titleLabel.attributedText = title
 		descriptionLabel1.attributedText = description
@@ -147,9 +151,7 @@ class DynamicLegalExtendedCell: UITableViewCell, ReuseIdentifierProviding {
 			label.setContentHuggingPriority(.required, for: .vertical)
 			contentStackView2.addArrangedSubview(label)
 		}
-		// We need for the subBulletPoints some more indentation
-		contentStackView2.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 60).isActive = true
-		
+
 		cardView.layoutIfNeeded()
 	}
 


### PR DESCRIPTION
## Description
Fixes an UI problem that some legal texts were out off. The fix is not to manipulate the leading anchor of the stack view (which cut of labels randomly) but make it possible to enter some indentation before the bullet points so the text is set before the rendering of the cell is done.

This fixes also that when scanning a QR code, the label with "QR code wird gelesen" was cut of. This was fixes by giving the label 0 number of lines (Screenshot was hard to take because the label is only short time visible and this explains the transparency).

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10918

## Screenshots

![10918-indenation](https://user-images.githubusercontent.com/75615785/145018923-0991eb74-220f-43b7-ac4f-c41d8b5f7a71.PNG)
![10918-label](https://user-images.githubusercontent.com/75615785/145019002-a7256351-c2a3-4107-a06f-35e35d28012f.PNG)


