### PR TITLE
Feature/new app version validation check

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		010A474E27512A05000AA80E /* MockJWTVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A474D27512A05000AA80E /* MockJWTVerification.swift */; };
 		010A47512751415E000AA80E /* TicketValidationAccessToken+Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A474F27514084000AA80E /* TicketValidationAccessToken+Fake.swift */; };
 		010A47542754C1AE000AA80E /* TicketValidationAccessTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47532754C1AE000AA80E /* TicketValidationAccessTokenResult.swift */; };
-		010A47562754C1BC000AA80E /* TicketValidationAccessTokenProcessingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47552754C1BC000AA80E /* TicketValidationAccessTokenProcessingError.swift */; };
+		010A47562754C1BC000AA80E /* VersionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47552754C1BC000AA80E /* VersionError.swift */; };
 		010A47662754C74F000AA80E /* TicketValidationResultTokenResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47652754C74F000AA80E /* TicketValidationResultTokenResource.swift */; };
 		010A47682754C7E7000AA80E /* TicketValidationResultTokenSendModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47672754C7E7000AA80E /* TicketValidationResultTokenSendModel.swift */; };
 		010A476A2754D5F6000AA80E /* TicketValidationResultTokenLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010A47692754D5F6000AA80E /* TicketValidationResultTokenLocator.swift */; };
@@ -1524,6 +1524,7 @@
 		EB54936B25F7CC0400A3C459 /* CGPDFDocument+EmbedImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB54936A25F7CC0400A3C459 /* CGPDFDocument+EmbedImageTests.swift */; };
 		EB54937E25F7CE3700A3C459 /* qr-code-print-template.pdf in Resources */ = {isa = PBXBuildFile; fileRef = EB54937D25F7CE3700A3C459 /* qr-code-print-template.pdf */; };
 		EB54938525F7CFB300A3C459 /* qr-code-to-embed.png in Resources */ = {isa = PBXBuildFile; fileRef = EB54937525F7CE2300A3C459 /* qr-code-to-embed.png */; };
+		EB5F21FE2760E60A00667593 /* TicketValidationAccessTokenProcessingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5F21FD2760E60A00667593 /* TicketValidationAccessTokenProcessingError.swift */; };
 		EB5FE15C2599F5E400797E4E /* ENActivityHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5FE1532599F5DB00797E4E /* ENActivityHandling.swift */; };
 		EB66267D25C3219900C4D7C2 /* UIViewController+Child.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB66267C25C3219900C4D7C2 /* UIViewController+Child.swift */; };
 		EB67B5DB262AD48F00218EC7 /* ExposureSubmissionCheckinsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB67B5DA262AD48F00218EC7 /* ExposureSubmissionCheckinsViewController.swift */; };
@@ -1635,7 +1636,7 @@
 		010A474D27512A05000AA80E /* MockJWTVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MockJWTVerification.swift; path = Model/MockJWTVerification.swift; sourceTree = "<group>"; };
 		010A474F27514084000AA80E /* TicketValidationAccessToken+Fake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TicketValidationAccessToken+Fake.swift"; sourceTree = "<group>"; };
 		010A47532754C1AE000AA80E /* TicketValidationAccessTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketValidationAccessTokenResult.swift; sourceTree = "<group>"; };
-		010A47552754C1BC000AA80E /* TicketValidationAccessTokenProcessingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketValidationAccessTokenProcessingError.swift; sourceTree = "<group>"; };
+		010A47552754C1BC000AA80E /* VersionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionError.swift; sourceTree = "<group>"; };
 		010A47622754C674000AA80E /* TicketValidationResultTokenProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketValidationResultTokenProcessor.swift; sourceTree = "<group>"; };
 		010A47632754C674000AA80E /* TicketValidationResultTokenProcessingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketValidationResultTokenProcessingError.swift; sourceTree = "<group>"; };
 		010A47642754C674000AA80E /* TicketValidationResultTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketValidationResultTokenResult.swift; sourceTree = "<group>"; };
@@ -3149,6 +3150,7 @@
 		EB54937525F7CE2300A3C459 /* qr-code-to-embed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "qr-code-to-embed.png"; sourceTree = "<group>"; };
 		EB54937D25F7CE3700A3C459 /* qr-code-print-template.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "qr-code-print-template.pdf"; sourceTree = "<group>"; };
 		EB5DAABC271EE2EE0043065D /* RecycleBinUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RecycleBinUITests.xctestplan; path = TestPlans/RecycleBinUITests.xctestplan; sourceTree = "<group>"; };
+		EB5F21FD2760E60A00667593 /* TicketValidationAccessTokenProcessingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TicketValidationAccessTokenProcessingError.swift; sourceTree = "<group>"; };
 		EB5FE1532599F5DB00797E4E /* ENActivityHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ENActivityHandling.swift; sourceTree = "<group>"; };
 		EB66267C25C3219900C4D7C2 /* UIViewController+Child.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Child.swift"; sourceTree = "<group>"; };
 		EB67B5DA262AD48F00218EC7 /* ExposureSubmissionCheckinsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureSubmissionCheckinsViewController.swift; sourceTree = "<group>"; };
@@ -3333,6 +3335,7 @@
 				0104CBD4273EAD72009A543D /* TicketValidation.swift */,
 				010E07B1273D809800C2BE5F /* TicketValidating.swift */,
 				0104CBCC273EAC46009A543D /* TicketValidationError.swift */,
+				010A47552754C1BC000AA80E /* VersionError.swift */,
 				01DE60732744EF2E00E12FA4 /* Models */,
 				ABC506B62747DC9600698A95 /* EncryptAndSignDCC */,
 				8FB7C9212750EF2D0071C98C /* ValidationDecorator */,
@@ -3366,8 +3369,8 @@
 		010A47522754C1A3000AA80E /* AccessToken */ = {
 			isa = PBXGroup;
 			children = (
+				EB5F21FD2760E60A00667593 /* TicketValidationAccessTokenProcessingError.swift */,
 				01BB00D1274FDE750065D1D1 /* TicketValidationAccessTokenProcessor.swift */,
-				010A47552754C1BC000AA80E /* TicketValidationAccessTokenProcessingError.swift */,
 				010A47532754C1AE000AA80E /* TicketValidationAccessTokenResult.swift */,
 			);
 			path = AccessToken;
@@ -9862,7 +9865,7 @@
 				EB513DFB25FA34E60020C0B9 /* trace_location.pb.swift in Sources */,
 				01909875257E64BD0065D050 /* DiaryAddAndEditEntryViewController.swift in Sources */,
 				948AFE7A2554377F0019579A /* UNUserNotificationCenter+WarnOthers.swift in Sources */,
-				010A47562754C1BC000AA80E /* TicketValidationAccessTokenProcessingError.swift in Sources */,
+				010A47562754C1BC000AA80E /* VersionError.swift in Sources */,
 				50293D56267A41BC004B3EBE /* AddCertificateCellModel.swift in Sources */,
 				017AD16525A4559300FA2B3F /* UITableView+Dequeue.swift in Sources */,
 				0160CC2A26B7EBD500AFB7DC /* HealthCertificateQRCodeViewModel.swift in Sources */,
@@ -9934,6 +9937,7 @@
 				50680B8F26164255002EA256 /* DMRecentTraceLocationCheckedInto.swift in Sources */,
 				BACF839E26A08C8800E5876C /* HealthCertificateExpirationDateCell.swift in Sources */,
 				BA83C193271702A50039D504 /* MockTestStore+Migration.swift in Sources */,
+				EB5F21FE2760E60A00667593 /* TicketValidationAccessTokenProcessingError.swift in Sources */,
 				710ABB23247513E300948792 /* DynamicTypeTableViewCell.swift in Sources */,
 				01E10284266E2F7F009ED803 /* TestEntry+Extension.swift in Sources */,
 				50C0298B25E4067400460FA4 /* ExposureWindowsMetadata.swift in Sources */,

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3409,7 +3409,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_Error_OutdatedApp" = "In der aktuellen Version ihrer Corona-Warn-App wird die Ticketüberprüfung nicht mehr unterstützt. Bitte aktualisieren Sie Ihre App und versuchen Sie die Ticketüberprüfung erneut.";
 
-"TicketValidation_Error_UpdateAction" = "zum App Store";
+"TicketValidation_Error_UpdateAction" = "Zum App Store";
 
 "TicketValidation_Error_serviceProviderErrorNoMatchTitle" = "Sicherheitshinweis";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3407,6 +3407,14 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "TicketValidation_Error_tryAgain" = "Es trat ein Fehler bei der Verarbeitung der Daten auf. Bitte versuchen Sie es später erneut.";
 
+"TicketValidation_Error_OutdatedApp" = "In der aktuellen Version ihrer Corona-Warn-App wird die Ticketüberprüfung nicht mehr unterstützt. Bitte aktualisieren Sie Ihre App und versuchen Sie die Ticketüberprüfung erneut.";
+
+"TicketValidation_Error_UpdateAction" = "zum App Store";
+
+"TicketValidation_Error_serviceProviderErrorNoMatchTitle" = "Sicherheitshinweis";
+
+"TicketValidation_Error_serviceProviderErrorNoMatch" = "Der Anbieter ist uns nicht bekannt. Aus Sicherheitsgründen ist die Überprüfung bei Ticketbuchungen nur für bekannte Anbieter möglich. Bitte kontaktieren Sie den Anbieter, der Ihnen diesen QR-Code bereitgestellt hat und versuchen Sie Ihre App auf die neuste Version zu aktualisieren.";
+
 /* - First Consent */
 
 "TicketValidation_FirstConsent_title" = "Ihr Einverständnis";

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
@@ -408,8 +408,15 @@ class QRScannerCoordinator {
 	}
 
 	private func showErrorAlert(error: TicketValidationError, serviceProvider: String) {
+		let title: String
+		if case .allowListError(.SP_ALLOWLIST_NO_MATCH) = error {
+			title = AppStrings.TicketValidation.Error.serviceProviderErrorNoMatchTitle
+		} else {
+			title = AppStrings.TicketValidation.Error.title
+		}
+		
 		let alert = UIAlertController(
-			title: AppStrings.TicketValidation.Error.title,
+			title: title,
 			message: error.errorDescription(serviceProvider: serviceProvider),
 			preferredStyle: .alert
 		)
@@ -427,7 +434,7 @@ class QRScannerCoordinator {
 		if case .versionError = error {
 			alert.addAction(
 				UIAlertAction(
-					title: AppStrings.UpdateMessage.actionUpdate,
+					title: AppStrings.TicketValidation.Error.updateApp,
 					style: .default,
 					handler: { _ in
 						LinkHelper.open(urlString: "https://apps.apple.com/de/app/corona-warn-app/id1512595757?mt=8")

--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerCoordinator.swift
@@ -393,7 +393,7 @@ class QRScannerCoordinator {
 		}
 		#endif
 
-		ticketValidation.initialize { [weak self] result in
+		ticketValidation.initialize(appFeatureProvider: appConfiguration.featureProvider) { [weak self] result in
 			DispatchQueue.main.async {
 				self?.hideActivityIndicator()
 
@@ -423,6 +423,18 @@ class QRScannerCoordinator {
 				}
 			)
 		)
+		
+		if case .versionError = error {
+			alert.addAction(
+				UIAlertAction(
+					title: AppStrings.UpdateMessage.actionUpdate,
+					style: .default,
+					handler: { _ in
+						LinkHelper.open(urlString: "https://apps.apple.com/de/app/corona-warn-app/id1512595757?mt=8")
+					}
+				)
+			)
+		}
 
 		DispatchQueue.main.async {
 			self.qrScannerViewController?.present(alert, animated: true)

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProvider.swift
@@ -23,12 +23,23 @@ class AppFeatureProvider: AppFeatureProviding {
 	// MARK: - Protocol AppFeaturesProviding
 
 	func value(for appFeature: SAP_Internal_V2_ApplicationConfigurationIOS.AppFeature) -> Bool {
-		if let configuration = appConfigurationProvider?.currentAppConfig.value {
-			return value(for: appFeature, from: configuration)
-		} else if let configuration = appConfig {
-			return value(for: appFeature, from: configuration)
-		} else {
-			return false
+		switch appFeature {
+		case .isTicketValidationEnabled(let currentAppVersion):
+			if let configuration = appConfigurationProvider?.currentAppConfig.value {
+				return isTicketValidationEnabled(currentVersion: Version, from: configuration)
+			} else if let configuration = appConfig {
+				return isTicketValidationEnabled(currentVersion: Version, from: configuration)
+			} else {
+				return false
+			}
+		default:
+			if let configuration = appConfigurationProvider?.currentAppConfig.value {
+				return value(for: appFeature, from: configuration)
+			} else if let configuration = appConfig {
+				return value(for: appFeature, from: configuration)
+			} else {
+				return false
+			}
 		}
 	}
 
@@ -46,5 +57,20 @@ class AppFeatureProvider: AppFeatureProviding {
 			$0.label == appFeature.rawValue
 		}
 		return feature?.value == 1
+	}
+	
+	private func isTicketValidationEnabled(
+		currentVersion: Version,
+		from config: SAP_Internal_V2_ApplicationConfigurationIOS
+	) {
+		let major = config.appFeatures.appFeatures.first {
+			$0.label == "validation-service-ios-min-version-major"
+		}
+		let minor = config.appFeatures.appFeatures.first {
+			$0.label == "validation-service-ios-min-version-minor"
+		}
+		let patch = config.appFeatures.appFeatures.first {
+			$0.label == "validation-service-ios-min-version-patch"
+		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProvider.swift
@@ -66,7 +66,6 @@ class AppFeatureProvider: AppFeatureProviding {
 			$0.label == "validation-service-ios-min-version-patch"
 		}
 		
-		
 		guard let currentSemanticAppVersion = Bundle.main.appVersion.semanticVersion else {
 			return false
 		}
@@ -76,7 +75,7 @@ class AppFeatureProvider: AppFeatureProviding {
 		minimumVersion.minor = UInt32(minor?.value ?? 0)
 		minimumVersion.patch = UInt32(patch?.value ?? 0)
 		
-		return !(currentSemanticAppVersion < minimumVersion)
+		return currentSemanticAppVersion >= minimumVersion
 	}
 	
 }

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
@@ -11,8 +11,7 @@ extension SAP_Internal_V2_ApplicationConfigurationIOS {
 		
 		case disableDeviceTimeCheck = "disable-device-time-check"
 		case unencryptedCheckinsEnabled = "unencrypted-checkins-enabled"
-		case validationServiceMinVersionMajor = "validation-service-ios-min-version-major"
-		case isTicketValidationEnabled(Version) = "isTicketValidationEnabled"
+		case isTicketValidationEnabled = "isTicketValidationEnabled"
 //		case validationServiceMinVersionMajor = "validation-service-ios-min-version-major"
 //		case validationServiceMinVersionMinor = "validation-service-ios-min-version-minor"
 //		case validationServiceMinVersionPatch = "validation-service-ios-min-version-patch"

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
@@ -12,9 +12,6 @@ extension SAP_Internal_V2_ApplicationConfigurationIOS {
 		case disableDeviceTimeCheck = "disable-device-time-check"
 		case unencryptedCheckinsEnabled = "unencrypted-checkins-enabled"
 		case isTicketValidationEnabled = "isTicketValidationEnabled"
-//		case validationServiceMinVersionMajor = "validation-service-ios-min-version-major"
-//		case validationServiceMinVersionMinor = "validation-service-ios-min-version-minor"
-//		case validationServiceMinVersionPatch = "validation-service-ios-min-version-patch"
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/AppFeatures/AppFeatureProviding.swift
@@ -8,8 +8,14 @@ extension SAP_Internal_V2_ApplicationConfigurationIOS {
 
 	/// list of known app features
 	enum AppFeature: String {
+		
 		case disableDeviceTimeCheck = "disable-device-time-check"
 		case unencryptedCheckinsEnabled = "unencrypted-checkins-enabled"
+		case validationServiceMinVersionMajor = "validation-service-ios-min-version-major"
+		case isTicketValidationEnabled(Version) = "isTicketValidationEnabled"
+//		case validationServiceMinVersionMajor = "validation-service-ios-min-version-major"
+//		case validationServiceMinVersionMinor = "validation-service-ios-min-version-minor"
+//		case validationServiceMinVersionPatch = "validation-service-ios-min-version-patch"
 	}
 }
 

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/MockTicketValidation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/MockTicketValidation.swift
@@ -20,6 +20,7 @@ final class MockTicketValidation: TicketValidating {
 	var allowList = TicketValidationAllowList(validationServiceAllowList: [], serviceProviderAllowList: [])
 	
 	func initialize(
+		appFeatureProvider: AppFeatureProviding,
 		completion: @escaping (Result<Void, TicketValidationError>) -> Void
 	) {
 		DispatchQueue.global().asyncAfter(deadline: .now() + delay) {

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidating.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidating.swift
@@ -10,6 +10,7 @@ protocol TicketValidating {
 	var allowList: TicketValidationAllowList { get }
 	
 	func initialize(
+		appFeatureProvider: AppFeatureProviding,
 		completion: @escaping (Result<Void, TicketValidationError>) -> Void
 	)
 

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
@@ -28,8 +28,9 @@ final class TicketValidation: TicketValidating {
 		appFeatureProvider: AppFeatureProviding,
 		completion: @escaping (Result<Void, TicketValidationError>) -> Void
 	) {
-		guard let version = appVersion, appFeatureProvider.value(for: .isTicketValidationEnabled(version) != false) else {
-			// TODO return new error case for unsupported appversion
+		guard appFeatureProvider.value(for: .isTicketValidationEnabled) != false else {
+			completion(.failure(.versionError(.MIN_VERSION_REQUIRED)))
+			return
 		}
 		
 		validateServiceIdentityAgainstAllowlist { [weak self] result in
@@ -224,23 +225,7 @@ final class TicketValidation: TicketValidating {
 	private var encryptionResult: EncryptAndSignResult?
 
 	private var selectedHealthCertificate: HealthCertificate?
-	
-	private var appVersion: Version? {
-		let appVersionParts = Bundle.main.appVersion.split(separator: ".")
-		guard appVersionParts.count == 3,
-			  let majorAppVerson = Int(appVersionParts[0]),
-			  let minorAppVerson = Int(appVersionParts[1]),
-			  let patchAppVersion = Int((appVersionParts[2])) else {
-				  // add error code
-				  return nil
-			  }
-		return cwaVersion = Version(
-			major: majorAppVerson,
-			minor: minorAppVerson,
-			patch: patchAppVersion
-		)
-	}
-	
+		
 	private func validateIdentityDocumentOfValidationDecorator(
 		urlString: String,
 		completion:

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
@@ -5,6 +5,7 @@
 import Foundation
 import ENASecurity
 
+// swiftlint:disable type_body_length
 final class TicketValidation: TicketValidating {
 	
 	// MARK: - Protocol TicketValidating

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidation.swift
@@ -73,7 +73,7 @@ final class TicketValidation: TicketValidating {
 			}
 		}
 	}
-	
+
 	func grantFirstConsent(
 		completion: @escaping (Result<TicketValidationConditions, TicketValidationError>) -> Void
 	) {
@@ -226,7 +226,7 @@ final class TicketValidation: TicketValidating {
 	private var encryptionResult: EncryptAndSignResult?
 
 	private var selectedHealthCertificate: HealthCertificate?
-		
+
 	private func validateIdentityDocumentOfValidationDecorator(
 		urlString: String,
 		completion:

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidationError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidationError.swift
@@ -13,6 +13,7 @@ enum TicketValidationError: LocalizedError {
 	case encryption(EncryptAndSignError)
 	case resultToken(TicketValidationResultTokenProcessingError)
 	case allowListError(AllowListError)
+	case versionError(VersionError)
 	case other
 
 	// swiftlint:disable cyclomatic_complexity

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidationError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/TicketValidationError.swift
@@ -59,10 +59,12 @@ enum TicketValidationError: LocalizedError {
 		case .allowListError(let error):
 			switch error {
 			case .SP_ALLOWLIST_NO_MATCH:
-				return "\(AppStrings.TicketValidation.Error.serviceProviderErrorNoName) (\(error))"
+				return "\(AppStrings.TicketValidation.Error.serviceProviderErrorNoMatch) (\(error))"
 			case .REST_SERVICE_ERROR(let error):
 				return "\(AppStrings.TicketValidation.Error.tryAgain) (\(error))"
 			}
+		case .versionError(let error):
+			return "\(AppStrings.TicketValidation.Error.outdatedApp) (\(error))"
 		default:
 			return "\(AppStrings.TicketValidation.Error.tryAgain) (\(self))"
 		}

--- a/src/xcode/ENA/ENA/Source/Services/TicketValidation/VersionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/TicketValidation/VersionError.swift
@@ -1,0 +1,9 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+
+enum VersionError: Error, Equatable {
+	case MIN_VERSION_REQUIRED
+}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2588,6 +2588,10 @@ enum AppStrings {
 			static let serviceProviderErrorNoName = NSLocalizedString("TicketValidation_Error_serviceProviderErrorNoName", comment: "")
 			static let serviceProviderError = NSLocalizedString("TicketValidation_Error_serviceProviderError", comment: "")
 			static let tryAgain = NSLocalizedString("TicketValidation_Error_tryAgain", comment: "")
+			static let outdatedApp = NSLocalizedString("TicketValidation_Error_OutdatedApp", comment: "")
+			static let updateApp = NSLocalizedString("TicketValidation_Error_UpdateAction", comment: "")
+			static let serviceProviderErrorNoMatch = NSLocalizedString("TicketValidation_Error_serviceProviderErrorNoMatch", comment: "")
+			static let serviceProviderErrorNoMatchTitle = NSLocalizedString("TicketValidation_Error_serviceProviderErrorNoMatchTitle", comment: "")
 		}
 	}
 	// swiftlint:disable:next file_length


### PR DESCRIPTION
## Description
This PR introduces a new Check for TicketValidation, in which a minimum AppVersion is required to do the Ticketvalidation. If the App is outdated an error is displayed with the possibility to go to the AppStore to update the App. 
Also the Error Message and Title for SP_ALLOWLIST_NO_MATCH got updated.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10959

## Screenshots
![Screen Shot 2021-12-08 at 15 33 56](https://user-images.githubusercontent.com/10122052/145227204-b24acf26-2edd-4c71-93e4-026026f5d1fa.png)
![Simulator Screen Shot - iPhone 13 mini - 2021-12-08 at 15 05 38](https://user-images.githubusercontent.com/10122052/145227227-6d7ba8f0-d617-4f1d-8906-27fc996fcd21.png)

