### PR TITLE
Story/10683 show always notifications/10861 show on foreground

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -3,7 +3,6 @@
 //
 
 import BackgroundTasks
-import Foundation
 import UIKit
 import HealthCertificateToolkit
 import OpenCombine
@@ -255,11 +254,6 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 
 			guard let self = self else { return }
 			if risk.riskLevelHasChanged {
-				UNUserNotificationCenter.current().presentNotification(
-					title: AppStrings.LocalNotifications.detectExposureTitle,
-					body: AppStrings.LocalNotifications.detectExposureBody,
-					identifier: ActionableNotificationIdentifier.riskDetection.identifier
-				)
 				Log.info("[ENATaskExecutionDelegate] Risk has changed.", log: .riskDetection)
 				completion(true)
 			} else {

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -34,8 +34,12 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 		if notification.request.identifier.contains(LocalNotificationIdentifier.checkout.rawValue) {
 			eventCheckoutService.checkoutOverdueCheckins()
 		}
-
-		completionHandler([.alert, .badge, .sound])
+		
+		if #available(iOS 14.0, *) {
+			completionHandler([.banner, .alert, .badge, .sound])
+		} else {
+			completionHandler([.alert, .badge, .sound])
+		}
 	}
 
 	func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -2,7 +2,6 @@
 // 🦠 Corona-Warn-App
 //
 
-import Foundation
 import ExposureNotification
 import UIKit
 import OpenCombine
@@ -420,6 +419,7 @@ final class RiskProvider: RiskProviding {
 		store.enfRiskCalculationResult = enfRiskCalculationResult
 		store.checkinRiskCalculationResult = checkinRiskCalculationResult
 
+		checkIfRiskLevelHasChangedForNotifications(risk)
 		checkIfRiskStatusLoweredAlertShouldBeShown(risk)
 		Analytics.collect(.riskExposureMetadata(.update))
 		completion(.success(risk))
@@ -438,6 +438,18 @@ final class RiskProvider: RiskProviding {
 		#endif
 		
 		consumer?.provideRiskCalculationResult(result)
+	}
+	
+	private func checkIfRiskLevelHasChangedForNotifications(_ risk: Risk) {
+		/// Triggers a notification for every risk level change.
+		if risk.riskLevelHasChanged {
+			Log.info("Trigger notification about changed risk level", log: .riskDetection)
+			UNUserNotificationCenter.current().presentNotification(
+				title: AppStrings.LocalNotifications.detectExposureTitle,
+				body: AppStrings.LocalNotifications.detectExposureBody,
+				identifier: ActionableNotificationIdentifier.riskDetection.identifier
+			)
+		}
 	}
 
 	private func checkIfRiskStatusLoweredAlertShouldBeShown(_ risk: Risk) {


### PR DESCRIPTION
## Description
Notifications will be shown now every time the risk status changes, also in foreground.

## Link to Jira
Subtask: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10861
Mainstory: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10683

## Screenshots
![10861-light](https://user-images.githubusercontent.com/75615785/145235246-332cb851-d04c-420d-91bd-e90b6cc877d5.PNG)
![10861-dark](https://user-images.githubusercontent.com/75615785/145235214-ca777fb5-214c-4742-b177-63d746d5a237.PNG)


