### PR TITLE
Fix/10619 memory issue

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -95,6 +95,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 		// Migrate the old pcr test structure from versions older than v2.1
 		coronaTestService.migrate()
+
+		#if RELEASE
+		// Delete legacy dev logs to free up disk space.
+		Log.fileLogger.deleteLegacyDevLogs()
+		#endif
 	}
 
 	deinit {

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -95,11 +95,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 		// Migrate the old pcr test structure from versions older than v2.1
 		coronaTestService.migrate()
-
-		#if RELEASE
-		// Delete legacy dev logs to free up disk space.
-		Log.fileLogger.deleteLegacyDevLogs()
-		#endif
 	}
 
 	deinit {

--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
@@ -601,7 +601,7 @@ extension DownloadedPackagesSQLLiteStoreV2 {
 				do {
 					try fileManager.removeItem(at: tempFileURL)
 				} catch {
-					Log.error("Cannot remove file temp file. Error: \(error)", log: .localData, error: error)
+					Log.error("Cannot remove old sqlite temp files. Error: \(error)", log: .localData, error: error)
 				}
 			}
 		}

--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
@@ -54,6 +54,7 @@ final class DownloadedPackagesSQLLiteStoreV2 {
 	private let migrator: SerialMigratorProtocol
 }
 
+// swiftlint:disable file_length
 extension DownloadedPackagesSQLLiteStoreV2: DownloadedPackagesStoreV2 {
 
 	func open() { // might throw errors in future versions!

--- a/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DownloadedPackagesStore/V2/DownloadedPackagesSQLLiteStoreV2.swift
@@ -585,5 +585,25 @@ extension DownloadedPackagesSQLLiteStoreV2 {
 				Log.error("Cannot move file to new location. Error: \(error)", log: .localData, error: error)
 			}
 		}
+		
+		// Remove old temp files
+		let tempFileURLs = [
+			documentDir
+					.appendingPathComponent(fileName)
+					.appendingPathExtension("sqlite3-shm"),
+			documentDir
+					.appendingPathComponent(fileName)
+					.appendingPathExtension("sqlite3-wal")
+		]
+		
+		for tempFileURL in tempFileURLs {
+			if fileManager.fileExists(atPath: tempFileURL.path) {
+				do {
+					try fileManager.removeItem(at: tempFileURL)
+				} catch {
+					Log.error("Cannot remove file temp file. Error: \(error)", log: .localData, error: error)
+				}
+			}
+		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
@@ -212,6 +212,11 @@ struct FileLogger {
 			}
 			assert(!fileManager.fileExists(atPath: oldURL.path, isDirectory: &isDir))
 		}
+		
+		#if RELEASE
+		// Delete legacy dev logs to free up disk space.
+		deleteLegacyDevLogs()
+		#endif
 	}
 
 	func log(_ logMessage: String, logType: OSLogType, file: String? = nil, line: Int? = nil, function: String? = nil) {
@@ -258,27 +263,6 @@ struct FileLogger {
 		}
 	}
 	
-	func deleteLegacyDevLogs() {
-		do {
-			let debugLogURLs = [
-				allLogsFileURL,
-				logFileBaseURL.appendingPathComponent("\(OSLogType.debug.title).log"),
-				logFileBaseURL.appendingPathComponent("\(OSLogType.info.title).log"),
-				logFileBaseURL.appendingPathComponent("\(OSLogType.error.title).log"),
-				logFileBaseURL.appendingPathComponent("\(OSLogType.default.title).log")
-			]
-			
-			for debugLogURL in debugLogURLs {
-				if FileManager.default.fileExists(atPath: debugLogURL.path) {
-					try FileManager.default.removeItem(at: debugLogURL)
-				}
-			}
-
-		} catch {
-			Log.error("Can't delete legacy dev logs", log: .localData, error: error)
-		}
-	}
-
 	// MARK: - Private
 
 	private let logDateFormatter = ISO8601DateFormatter()
@@ -352,6 +336,29 @@ struct FileLogger {
 			return nil
 		}
 	}
+	
+	#if RELEASE
+	private func deleteLegacyDevLogs() {
+		do {
+			let debugLogURLs = [
+				allLogsFileURL,
+				logFileBaseURL.appendingPathComponent("\(OSLogType.debug.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.info.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.error.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.default.title).log")
+			]
+			
+			for debugLogURL in debugLogURLs {
+				if FileManager.default.fileExists(atPath: debugLogURL.path) {
+					try FileManager.default.removeItem(at: debugLogURL)
+				}
+			}
+
+		} catch {
+			Log.error("Can't delete legacy dev logs", log: .localData, error: error)
+		}
+	}
+	#endif
 }
 
 protocol Logging {

--- a/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
@@ -264,23 +264,32 @@ struct FileLogger {
 	private let writeQueue = DispatchQueue(label: "de.rki.coronawarnapp.logging.write") // Serial by default
 	
 	private func writeLog(of logType: OSLogType, message: String) {
+		#if !RELEASE
 		let logHandle = makeWriteFileHandle(with: logType)
 		let allLogsHandle = makeWriteFileHandle(with: allLogsFileURL)
+		#endif
+			
 		let errorLogHandle = makeWriteFileHandle(with: errorLogFileURL)
 
 		guard let logMessageData = message.data(using: .utf8) else { return }
 		defer {
+			#if !RELEASE
 			logHandle?.closeFile()
 			allLogsHandle?.closeFile()
+			#endif
+
 			errorLogHandle?.closeFile()
 		}
 		
 		writeQueue.sync {
+			
+			#if !RELEASE
 			logHandle?.seekToEndOfFile()
 			logHandle?.write(logMessageData)
 
 			allLogsHandle?.seekToEndOfFile()
 			allLogsHandle?.write(logMessageData)
+			#endif
 
 			if ErrorLogSubmissionService.errorLoggingEnabled {
 				errorLogHandle?.seekToEndOfFile()

--- a/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
@@ -257,6 +257,27 @@ struct FileLogger {
 			Log.error("Can't remove logs at \(logFileBaseURL)", log: .localData, error: error)
 		}
 	}
+	
+	func deleteLegacyDevLogs() {
+		do {
+			let debugLogURLs = [
+				allLogsFileURL,
+				logFileBaseURL.appendingPathComponent("\(OSLogType.debug.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.info.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.error.title).log"),
+				logFileBaseURL.appendingPathComponent("\(OSLogType.default.title).log")
+			]
+			
+			for debugLogURL in debugLogURLs {
+				if FileManager.default.fileExists(atPath: debugLogURL.path) {
+					try FileManager.default.removeItem(at: debugLogURL)
+				}
+			}
+
+		} catch {
+			Log.error("Can't delete legacy dev logs", log: .localData, error: error)
+		}
+	}
 
 	// MARK: - Private
 
@@ -326,25 +347,6 @@ struct FileLogger {
 
 			let fileHandle = try? FileHandle(forWritingTo: url)
 			return fileHandle
-		} catch {
-			Log.error("File handle error", log: .localData, error: error)
-			return nil
-		}
-	}
-
-	private func makeReadFileHandle(with logType: OSLogType) -> FileHandle? {
-		#if DEBUG
-		// logacy logs stay `txt` unless migrated
-		let logFileURL = logFileBaseURL.appendingPathComponent("\(logType.title).txt")
-		#else
-		let logFileURL = logFileBaseURL.appendingPathComponent("\(logType.title).log")
-		#endif
-		return makeReadFileHandle(with: logFileURL)
-	}
-
-	private func makeReadFileHandle(with url: URL) -> FileHandle? {
-		do {
-			return try FileHandle(forReadingFrom: url)
 		} catch {
 			Log.error("File handle error", log: .localData, error: error)
 			return nil


### PR DESCRIPTION
## Description
Delete legacy dev logs and old sql temporary files to free up disk space.
Disable further dev logging.
Remove some dead code.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10619
