### PR TITLE
Replace our logging with fallback system logging.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Logging/Logging.swift
@@ -332,7 +332,9 @@ struct FileLogger {
 			let fileHandle = try? FileHandle(forWritingTo: url)
 			return fileHandle
 		} catch {
-			Log.error("File handle error", log: .localData, error: error)
+			// We must not use our Log here because it would produce a crash (we want to log in case we cannot create a log 🤪)
+			// swiftlint:disable:next no_direct_oslog
+			os_log("%{public}@ %{public}@", log: .default, type: .error, "Error while creating log file handler. Fallback to system logging to log this error.")
 			return nil
 		}
 	}


### PR DESCRIPTION
## Description
We have a crash at logging. This fixes the crash by preventing using our custom logger when we want to create a log that our custom logger could not be created 😌. But to have this information, we use the system logging in that case.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10672
