### PR TITLE
Fix/11011 invalid date crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCell.swift
@@ -120,6 +120,7 @@ class HealthCertificateCell: UITableViewCell, ReuseIdentifierProviding {
 		currentlyUsedImageView.image = UIImage(named: "CurrentlyUsedCertificate_Icon")
 		currentlyUsedImageView.contentMode = .scaleAspectFit
 		currentlyUsedImageView.setContentHuggingPriority(.required, for: .horizontal)
+		currentlyUsedImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
 		currentlyUsedStackView.addArrangedSubview(currentlyUsedImageView)
 
 		currentlyUsedLabel.style = .body

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/VaccinationHint/VaccinationHintCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/VaccinationHint/VaccinationHintCellModel.swift
@@ -24,6 +24,8 @@ final class VaccinationHintCellModel {
 		guard let lastVaccinationDate = healthCertifiedPerson.vaccinationCertificates.last?.vaccinationEntry?.localVaccinationDate,
 			  let daysSinceLastVaccination = Calendar.autoupdatingCurrent.dateComponents([.day], from: lastVaccinationDate, to: Date()).day else {
 				  // Returning nil if the days since last vaccination can't be determined, e.g. in case of an invalid date, like 2021-19-29
+				  Log.info("Cannot retrieve days since last vaccination for vaccination date \(private: String(describing: healthCertifiedPerson.vaccinationCertificates.last?.vaccinationEntry?.dateOfVaccination))", log: .vaccination)
+
 				  return nil
 		}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/VaccinationHint/VaccinationHintCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/VaccinationHint/VaccinationHintCellModel.swift
@@ -23,7 +23,8 @@ final class VaccinationHintCellModel {
 	var subtitle: String? {
 		guard let lastVaccinationDate = healthCertifiedPerson.vaccinationCertificates.last?.vaccinationEntry?.localVaccinationDate,
 			  let daysSinceLastVaccination = Calendar.autoupdatingCurrent.dateComponents([.day], from: lastVaccinationDate, to: Date()).day else {
-				  fatalError("Cell cannot be shown if person is not vaccinated")
+				  // Returning nil if the days since last vaccination can't be determined, e.g. in case of an invalid date, like 2021-19-29
+				  return nil
 		}
 
 		return String(


### PR DESCRIPTION
## Description
Hides the "Last vaccination x days ago" label instead of crashing if the vaccination date in the most recent vaccination certificate is invalid.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11011

## Screenshots
![IMG_0218](https://user-images.githubusercontent.com/1157991/145807807-0939ba4f-9c27-47e2-921c-69ccabe38b22.jpg)
![IMG_0219](https://user-images.githubusercontent.com/1157991/145807816-24ebadec-04cc-4f18-bbc4-dd3188acc053.jpg)

