### PR TITLE
Dismiss screen allow bypasing legal text

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfileInformation/AntigenTestProfileInformationViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfileInformation/AntigenTestProfileInformationViewController.swift
@@ -33,7 +33,6 @@ class AntigenTestProfileInformationViewController: DynamicTableViewController, F
 		navigationItem.title = viewModel.title
 		navigationItem.rightBarButtonItem = dismissHandlingCloseBarButton
 		setupView()
-		viewModel.markScreenSeen()
 	}
 
 	// MARK: - Protocol FooterViewHandling
@@ -42,6 +41,8 @@ class AntigenTestProfileInformationViewController: DynamicTableViewController, F
 		guard case .primary = type else {
 			return
 		}
+		
+		viewModel.markScreenSeen()
 		didTapContinue()
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -1160,7 +1160,6 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 				self?.showAntigenTestProfileInput(editMode: false)
 			},
 			dismiss: { [weak self] in
-				self?.store.antigenTestProfileInfoScreenShown = false
 				self?.dismiss()
 			}
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -1159,7 +1159,10 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 			didTapContinue: { [weak self] in
 				self?.showAntigenTestProfileInput(editMode: false)
 			},
-			dismiss: { [weak self] in self?.dismiss() }
+			dismiss: { [weak self] in
+				self?.store.antigenTestProfileInfoScreenShown = false
+				self?.dismiss()
+			}
 		)
 
 		let footerViewModel = FooterViewModel(


### PR DESCRIPTION
## Description
With the current implementation, if a user click on the dismiss button on the antigen test profile info screen, the screen is not shown again, which is not the expected behaviour. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10456
