### PR TITLE
Fix layout in no-g rule

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -28,7 +28,7 @@ class HealthCertifiedPersonCellModel {
 			healthCertificate: mostRelevantCertificate,
 			showRealQRCodeIfValidityStateBlocked: false,
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
-			covPassCheckInfoPosition: healthCertifiedPerson.admissionState == .other ? .top : .bottom,
+			covPassCheckInfoPosition: .bottom,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
@@ -704,7 +704,7 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 			)
 		)
 
-		XCTAssertEqual(cellModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+		XCTAssertEqual(cellModel.qrCodeViewModel.covPassCheckInfoPosition, .bottom)
 		XCTAssertFalse(cellModel.isStatusTitleVisible)
 		XCTAssertTrue(cellModel.switchableHealthCertificates.isEmpty)
 		XCTAssertNil(cellModel.shortStatus)


### PR DESCRIPTION
## Description
The CovPass info text should always be on the bottom. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11085

## Screenshots
![WhatsApp Image 2021-12-20 at 4 36 02 PM](https://user-images.githubusercontent.com/77438487/146793221-080b8ad9-949b-4c47-a2ac-7559d9be7f52.jpeg)
![WhatsApp Image 2021-12-20 at 4 36 02 PM-2](https://user-images.githubusercontent.com/77438487/146793234-37cbddae-f1f4-48bf-92cb-27c585743146.jpeg)

