### PR TITLE
Update "ExposureDetection_Guide_Title" text (Addresses corona-warn-app/cwa-wishlist/#738)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -123,13 +123,14 @@
 
 "ExposureDetection_Guide_Vaccination_HighRisk" = "Sollten Sie bisher nicht geimpft sein, besprechen Sie nach der Testung die Impfung mit Ihrer Hausarztpraxis.";
 
-"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, auch wenn Sie keine Symptome haben. Bei einer Warnung über ein erhöhtes Risiko (\"Rote Kachel\") haben Sie Anspruch auf einen kostenlosen Test. Dies muss nicht notwendigerweise ein PCR-Test sein.
-";
+"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, auch wenn Sie keine Symptome haben. Bei einer Warnung über ein erhöhtes Risiko (\"Rote Kachel\") haben Sie Anspruch auf einen kostenlosen Test. Abhängig von den örtlichen Regelungen kann Ihr Anspruch auf einen kostenlosen Antigen-Schnelltest beschränkt sein. Wir regen an, einen PCR-Test durchführen zu lassen, vor allem, wenn der Test kostenlos ist.";
 
 "ExposureDetection_Guide_Point1" = "Testmöglichkeiten finden Sie hier. Sie können sich auch an Ihre Hausarztpraxis oder Apotheke wenden.";
+
 "ExposureDetection_Guide_Point1_LinkText" = "Testmöglichkeiten finden Sie hier.";
 
 "ExposureDetection_Guide_Point2" = "Weitere Informationen in den FAQ zum Testablauf.";
+
 "ExposureDetection_Guide_Point2_LinkText" = "Weitere Informationen in den FAQ zum Testablauf.";
 
 "ExposureDetection_Explanation_Title" = "Infektionsrisiko";


### PR DESCRIPTION
## Description
This PR updates the "ExposureDetection_Guide_Title" text to be more specific about free of charge tests.

## Link to Jira
- GitHub Issue: https://github.com/corona-warn-app/cwa-wishlist/issues/738

## Screenshots
<img src="https://user-images.githubusercontent.com/67682506/147503310-2f564e95-ef4e-4f59-86ef-588298eb09f4.png" width="300">

## Credits
Text from @stefanbaur.
