### PR TITLE
Update ExposureDetection_Guide_Home string

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 
 "ExposureDetection_Guide_Symptoms" = "Be alert for typical symptoms. Even vaccinated people and those who have recovered can develop symptoms. If you feel sick or develop any symptoms, please contact your family doctor.";
 
-"ExposureDetection_Guide_Home" = "If possible, please go home and stay at home and avoid any encounters outside of your own household..";
+"ExposureDetection_Guide_Home" = "If possible, please go home and stay at home and avoid any encounters outside of your own household.";
 
 "ExposureDetection_Guide_Hotline" = "If you have any other questions, please contact the general medical emergency service on telephone number 116 117.";
 


### PR DESCRIPTION
## Description
There is an unnecessary second dot at the end of the ExposureDetection_Guide_Home string in the English localization.

