### PR TITLE
Show number of persons in dev menu

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMStoreViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMStoreViewController.swift
@@ -29,6 +29,9 @@ final class DMStoreViewController: UITableViewController {
 			DMStoreItem(attribute: "antigenTest") { store in
 				String(describing: store.antigenTest)
 			},
+			DMStoreItem(attribute: "healthCertifiedPersons") { store in
+				"\(store.healthCertifiedPersons.count) person(s)"
+			},
 			DMStoreItem(attribute: "lastAppConfigETag") { store in
 				store.appConfigMetadata?.lastAppConfigETag.description ?? "<nil>"
 			},


### PR DESCRIPTION
## Description
Shows the number of persons in the dev menu so testers can easily check if e.g. the maximum amount is reached.

## Screenshots
![IMG_531AC67F9B39-1](https://user-images.githubusercontent.com/1157991/148238890-42435906-4fab-46d2-be36-c248018f386c.jpeg)

