### PR TITLE
Fix/11112 notification opens cwa home panel instead of test result screen

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -928,6 +928,7 @@
 		8FCC60DB273923C900531BE6 /* RegistrationTokenResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FCC60DA273923C900531BE6 /* RegistrationTokenResourceTests.swift */; };
 		8FDB9403261FBA3800BA8CB1 /* AntigenTestQRCodeInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDB9402261FBA3800BA8CB1 /* AntigenTestQRCodeInformation.swift */; };
 		8FDB940B261FBAAA00BA8CB1 /* CoronaTestRegistrationInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDB940A261FBAAA00BA8CB1 /* CoronaTestRegistrationInformation.swift */; };
+		8FE0FB30278B6ACB005C7045 /* UIWindow+VisibleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE0FB2F278B6ACB005C7045 /* UIWindow+VisibleViewController.swift */; };
 		8FEC12242754B6C000C5DADC /* ValidationServiceAllowlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEC12232754B6C000C5DADC /* ValidationServiceAllowlist.swift */; };
 		8FEC122627551F6700C5DADC /* validation_service_allowlist.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEC122527551F6700C5DADC /* validation_service_allowlist.pb.swift */; };
 		8FEC1228275521E500C5DADC /* AllowListResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEC1227275521E500C5DADC /* AllowListResource.swift */; };
@@ -2575,6 +2576,7 @@
 		8FCC60DA273923C900531BE6 /* RegistrationTokenResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationTokenResourceTests.swift; sourceTree = "<group>"; };
 		8FDB9402261FBA3800BA8CB1 /* AntigenTestQRCodeInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigenTestQRCodeInformation.swift; sourceTree = "<group>"; };
 		8FDB940A261FBAAA00BA8CB1 /* CoronaTestRegistrationInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoronaTestRegistrationInformation.swift; sourceTree = "<group>"; };
+		8FE0FB2F278B6ACB005C7045 /* UIWindow+VisibleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+VisibleViewController.swift"; sourceTree = "<group>"; };
 		8FEC12232754B6C000C5DADC /* ValidationServiceAllowlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationServiceAllowlist.swift; sourceTree = "<group>"; };
 		8FEC122527551F6700C5DADC /* validation_service_allowlist.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = validation_service_allowlist.pb.swift; sourceTree = "<group>"; };
 		8FEC1227275521E500C5DADC /* AllowListResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllowListResource.swift; sourceTree = "<group>"; };
@@ -5899,6 +5901,7 @@
 				948AFE792554377F0019579A /* UNUserNotificationCenter+WarnOthers.swift */,
 				B1EDFD8C248E74D000E7EAFF /* URL+StaticString.swift */,
 				B153096924706F1000A4A1BD /* URLSession+Default.swift */,
+				8FE0FB2F278B6ACB005C7045 /* UIWindow+VisibleViewController.swift */,
 				ABC506BE2747DF8B00698A95 /* Data+Random.swift */,
 			);
 			path = Extensions;
@@ -10564,6 +10567,7 @@
 				BA7DCA1A2747DA96009E4557 /* DynamicEvaluateTrust.swift in Sources */,
 				BAAC573226CBEF7C0049B55C /* VaccinationProductType.swift in Sources */,
 				3484AC7C26A060E900CB0500 /* LocalStatisticsState.swift in Sources */,
+				8FE0FB30278B6ACB005C7045 /* UIWindow+VisibleViewController.swift in Sources */,
 				01B7232724F812BC0064C0EB /* OptionGroupView.swift in Sources */,
 				8F4E623A25EE878E00FF4F0A /* BottomErrorReportViewController.swift in Sources */,
 				50E3BE5A250127DF0033E2C7 /* AppInformationDynamicAction.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -556,7 +556,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			},
 			showTestResultFromNotification: { [weak self] test in
 				Log.debug("Will open test result from notification")
-				self?.coordinator.showTestResultFromNotification(with: test, vc: self?.window?.visibleViewController)
+				self?.coordinator.showTestResultFromNotification(with: test, visibleViewController: self?.window?.visibleViewController)
 			},
 			showHealthCertificate: { [weak self] route in
 				// We must NOT call self?.showHome(route) here because we do not target the home screen. Only set the route. The rest is done automatically by the startup process of the app.

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -554,7 +554,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 				// We don't need the Route parameter in the NotificationManager
 				self?.showHome()
 			},
-			showTestResultFromNotification: coordinator.showTestResultFromNotification,
+			showTestResultFromNotification: { [weak self] test in
+				Log.debug("Will open test result from notification")
+				self?.coordinator.showTestResultFromNotification(with: test, vc: self?.window?.visibleViewController)
+			},
 			showHealthCertificate: { [weak self] route in
 				// We must NOT call self?.showHome(route) here because we do not target the home screen. Only set the route. The rest is done automatically by the startup process of the app.
 				// Works only for notifications tapped when the app is closed. When inside the app, the notification will trigger nothing.

--- a/src/xcode/ENA/ENA/Source/Extensions/UIWindow+VisibleViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UIWindow+VisibleViewController.swift
@@ -1,0 +1,25 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import UIKit
+
+extension UIWindow {
+	var visibleViewController: UIViewController? {
+		return UIWindow.getVisibleViewControllerFrom(self.rootViewController)
+	}
+
+	static func getVisibleViewControllerFrom(_ viewController: UIViewController?) -> UIViewController? {
+		if let navigationController = viewController as? UINavigationController {
+			return UIWindow.getVisibleViewControllerFrom(navigationController.visibleViewController)
+		} else if let tabBarController = viewController as? UITabBarController {
+			return UIWindow.getVisibleViewControllerFrom(tabBarController.selectedViewController)
+		} else {
+			if let presentedViewController = viewController?.presentedViewController {
+				return UIWindow.getVisibleViewControllerFrom(presentedViewController)
+			} else {
+				return viewController
+			}
+		}
+	}
+}

--- a/src/xcode/ENA/ENA/Source/RootCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/RootCoordinator.swift
@@ -250,17 +250,17 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 		viewController.embedViewController(childViewController: tabBarController)
 	}
 
-	func showTestResultFromNotification(with testType: CoronaTestType, vc: UIViewController? = nil) {
+	func showTestResultFromNotification(with testType: CoronaTestType, visibleViewController: UIViewController? = nil) {
 		guard let homeCoordinator = homeCoordinator else {
 			showHome(enStateHandler: ENStateHandler(
 				initialExposureManagerState: exposureManager.exposureManagerState,
 				delegate: self
 			), route: nil
 			)
-			homeCoordinator?.showTestResultFromNotification(with: testType, vc: vc)
+			homeCoordinator?.showTestResultFromNotification(with: testType, visibleViewController: visibleViewController)
 			return
 		}
-		homeCoordinator.showTestResultFromNotification(with: testType, vc: vc)
+		homeCoordinator.showTestResultFromNotification(with: testType, visibleViewController: visibleViewController)
 	}
 	
 	func showHealthCertificateFromNotification(

--- a/src/xcode/ENA/ENA/Source/RootCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/RootCoordinator.swift
@@ -250,8 +250,17 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 		viewController.embedViewController(childViewController: tabBarController)
 	}
 
-	func showTestResultFromNotification(with testType: CoronaTestType) {
-		homeCoordinator?.showTestResultFromNotification(with: testType)
+	func showTestResultFromNotification(with testType: CoronaTestType, vc: UIViewController? = nil) {
+		guard let homeCoordinator = homeCoordinator else {
+			showHome(enStateHandler: ENStateHandler(
+				initialExposureManagerState: exposureManager.exposureManagerState,
+				delegate: self
+			), route: nil
+			)
+			homeCoordinator?.showTestResultFromNotification(with: testType, vc: vc)
+			return
+		}
+		homeCoordinator.showTestResultFromNotification(with: testType, vc: vc)
 	}
 	
 	func showHealthCertificateFromNotification(

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
@@ -159,13 +159,13 @@ class HomeCoordinator: RequiresAppDependencies {
 		})
 	}
 
-	func showTestResultFromNotification(with testType: CoronaTestType) {
+	func showTestResultFromNotification(with testType: CoronaTestType, visibleViewController: UIViewController?) {
 		if let presentedViewController = rootViewController.presentedViewController {
 			presentedViewController.dismiss(animated: true) {
-				self.showExposureSubmission(testType: testType)
+				self.showExposureSubmission(testType: testType, visibleViewController: visibleViewController)
 			}
 		} else {
-			self.showExposureSubmission(testType: testType)
+			self.showExposureSubmission(testType: testType, visibleViewController: visibleViewController)
 		}
 	}
 
@@ -320,12 +320,12 @@ class HomeCoordinator: RequiresAppDependencies {
 		exposureDetectionCoordinator?.start()
 	}
 
-	private func showExposureSubmission(testType: CoronaTestType? = nil, testInformationResult: Result<CoronaTestRegistrationInformation, QRCodeError>? = nil) {
+	private func showExposureSubmission(testType: CoronaTestType? = nil, visibleViewController: UIViewController? = nil, testInformationResult: Result<CoronaTestRegistrationInformation, QRCodeError>? = nil) {
 		// A strong reference to the coordinator is passed to the exposure submission navigation controller
 		// when .start() is called. The coordinator is then bound to the lifecycle of this navigation controller
 		// which is managed by UIKit.
 		let coordinator = ExposureSubmissionCoordinator(
-			parentViewController: rootViewController,
+			parentViewController: visibleViewController ?? rootViewController,
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: coronaTestService,
 			healthCertificateService: healthCertificateService,


### PR DESCRIPTION
## Description
Currently when the the User gets a notification that his test result has arrived it opens the homeViewController While it should have opened the testResultViewController.

The reasons and solutions:

1. The HomeCoordinator gets deallocated -> so we need to re-instantiate it.
2. the ParentViewController from which we are trying to present is **not** in the view Hierarchy -> so we to get the current visible ViewController from the UIWindow and do the presentation from it if it exists.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11112

## Video
https://user-images.githubusercontent.com/15270737/148697784-341d33bf-0ee7-41b8-bea0-3cbb5db6ab35.MP4
