### PR TITLE
Story/11162 http caching part1/archive for testing

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		5081EEFE25FF9C5E004B8FDE /* CheckinsInfoScreenViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5081EEFD25FF9C5E004B8FDE /* CheckinsInfoScreenViewModelTest.swift */; };
 		5081EF0625FFB7E0004B8FDE /* CheckinsInfoScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5081EF0525FFB7E0004B8FDE /* CheckinsInfoScreenViewController.swift */; };
 		5081EF0E25FFDEC7004B8FDE /* ENAUITests_10_CheckIns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5081EF0D25FFDEC7004B8FDE /* ENAUITests_10_CheckIns.swift */; };
+		508266DA278DA60000091991 /* Archive+CBOR.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508266D8278DA5DE00091991 /* Archive+CBOR.swift */; };
 		50842BEC274FB9150015E63F /* ServiceIdentityDocumentProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC506D2274F8F0600698A95 /* ServiceIdentityDocumentProcessorTests.swift */; };
 		50842BF0274FCFFB0015E63F /* TicketValidationServiceIdentityDocument+Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50842BEF274FCFFB0015E63F /* TicketValidationServiceIdentityDocument+Fake.swift */; };
 		50842BF2275127940015E63F /* DisabledPinningRestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50842BF1275127940015E63F /* DisabledPinningRestService.swift */; };
@@ -2331,6 +2332,7 @@
 		5081EEFD25FF9C5E004B8FDE /* CheckinsInfoScreenViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckinsInfoScreenViewModelTest.swift; sourceTree = "<group>"; };
 		5081EF0525FFB7E0004B8FDE /* CheckinsInfoScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckinsInfoScreenViewController.swift; sourceTree = "<group>"; };
 		5081EF0D25FFDEC7004B8FDE /* ENAUITests_10_CheckIns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENAUITests_10_CheckIns.swift; sourceTree = "<group>"; };
+		508266D8278DA5DE00091991 /* Archive+CBOR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+CBOR.swift"; sourceTree = "<group>"; };
 		50842BEF274FCFFB0015E63F /* TicketValidationServiceIdentityDocument+Fake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TicketValidationServiceIdentityDocument+Fake.swift"; sourceTree = "<group>"; };
 		50842BF1275127940015E63F /* DisabledPinningRestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledPinningRestService.swift; sourceTree = "<group>"; };
 		5084889F26822D91004299E6 /* DMErrorLogSharingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMErrorLogSharingViewModel.swift; sourceTree = "<group>"; };
@@ -5971,6 +5973,7 @@
 		71176E2C24891BCF004B0C9F /* __tests__ */ = {
 			isa = PBXGroup;
 			children = (
+				508266D8278DA5DE00091991 /* Archive+CBOR.swift */,
 				35C0C882261492D5004BF509 /* ArrayExtensionTests.swift */,
 				01A1FA3726F0E91C0047B4CC /* CertLogicRule+LocalizedDescriptionTests.swift */,
 				71176E2D24891C02004B0C9F /* ENAColorTests.swift */,
@@ -10940,6 +10943,7 @@
 				509B1E4426D62BB2007B97E0 /* HealthCertificatePDFGenerationInfoViewModelTests.swift in Sources */,
 				358D780C2632FA7C00070BED /* HTTPClient+SubmitErrorLogFileTests.swift in Sources */,
 				BA7D178E25D55EB1006B9EBF /* DefaultDataDonationViewModelTests.swift in Sources */,
+				508266DA278DA60000091991 /* Archive+CBOR.swift in Sources */,
 				50C51CB625CDEA4300D4C33A /* HTTPClient+SubmitAnalyticsDataTests.swift in Sources */,
 				0127B09E272855D6008E30AF /* CoronaTestRestorationHandlerTests.swift in Sources */,
 				AB86B2B926033E8F007C77B3 /* CheckinSplittingServiceTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Extensions/__tests__/Archive+CBOR.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/__tests__/Archive+CBOR.swift
@@ -7,7 +7,7 @@ import ZIPFoundation
 
 extension Archive {
 	
-	public static func createArchiveData(with accessMode: AccessMode, of cborData: Data) throws -> Data {
+	public static func createArchiveData(accessMode: AccessMode, cborData: Data) throws -> Data {
 		guard let archive = Archive(accessMode: accessMode) else {
 			throw ArchivingError.creationError
 		}

--- a/src/xcode/ENA/ENA/Source/Extensions/__tests__/Archive+CBOR.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/__tests__/Archive+CBOR.swift
@@ -1,0 +1,42 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+import ZIPFoundation
+
+extension Archive {
+	
+	public static func createArchiveData(with accessMode: AccessMode, of cborData: Data) throws -> Data {
+		guard let archive = Archive(accessMode: accessMode) else {
+			throw ArchivingError.creationError
+		}
+		
+		try archive.addEntry(
+			with: "export.bin",
+			type: .file,
+			uncompressedSize: UInt32(cborData.count),
+			bufferSize: 4,
+			provider: { position, size -> Data in
+				return cborData.subdata(in: position..<position + size)
+			}
+		)
+		
+		try archive.addEntry(
+			with: "export.sig",
+			type: .file,
+			uncompressedSize: 12,
+			bufferSize: 4,
+			provider: { position, size -> Data in
+				return Data().subdata(in: position..<position + size)
+			}
+		)
+		
+		guard let archiveData = archive.data else {
+			throw ArchivingError.creationError
+		}
+		
+		return archiveData
+	}
+	
+}

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ReceiveResources/CBORReceiveResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ReceiveResources/CBORReceiveResource.swift
@@ -22,7 +22,7 @@ struct CBORReceiveResource<R>: ReceiveResource where R: CBORDecoding {
 	// MARK: - Init
 	
 	init(
-		signatureVerifier: SignatureVerifier = SignatureVerifier()
+		signatureVerifier: SignatureVerification = SignatureVerifier()
 	) {
 		self.signatureVerifier = signatureVerifier
 	}
@@ -52,6 +52,6 @@ struct CBORReceiveResource<R>: ReceiveResource where R: CBORDecoding {
 
 	// MARK: - Private
 
-	private let signatureVerifier: SignatureVerifier
+	private let signatureVerifier: SignatureVerification
 
 }

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ReceiveResources/ProtobufReceiveResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ReceiveResources/ProtobufReceiveResource.swift
@@ -16,7 +16,7 @@ struct ProtobufReceiveResource<R>: ReceiveResource where R: SwiftProtobuf.Messag
 	// MARK: - Init
 	
 	init(
-		signatureVerifier: SignatureVerifier = SignatureVerifier()
+		signatureVerifier: SignatureVerification = SignatureVerifier()
 	) {
 		self.signatureVerifier = signatureVerifier
 	}
@@ -46,6 +46,6 @@ struct ProtobufReceiveResource<R>: ReceiveResource where R: SwiftProtobuf.Messag
 
 	// MARK: - Private
 
-	private let signatureVerifier: SignatureVerifier
+	private let signatureVerifier: SignatureVerification
 
 }


### PR DESCRIPTION
## Description
To add unit tests for the new CBORReceiveResource: I need to create an Archive with cborData. Only for unit tests, so this extension is only for the test target.
I also changed the signature of the verifier to the protocol, it was wrongly the concrete implementation.