### PR TITLE
Fix/11283 rat personal data in log

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -558,7 +558,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			showHealthCertificate: { [weak self] route in
 				// We must NOT call self?.showHome(route) here because we do not target the home screen. Only set the route. The rest is done automatically by the startup process of the app.
 				// Works only for notifications tapped when the app is closed. When inside the app, the notification will trigger nothing.
-				Log.debug("new route is set: \(route)")
+				Log.debug("new route is set: \(route.routeInformation)")
 				self?.route = route
 			}, showHealthCertifiedPerson: { [weak self] route in
 				guard let self = self else { return }
@@ -571,7 +571,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 				if self.didSetupUI {
 					self.showHome(route)
 				} else {
-					Log.debug("new route is set: \(route)")
+					Log.debug("new route is set: \(route.routeInformation)")
 					self.route = route
 				}
 			}
@@ -860,7 +860,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	func showHome(_ route: Route? = nil) {
 		// On iOS 12.5 ENManager is already activated in didFinishLaunching (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8919)
-		Log.debug("showHome Flow is called with current route: \(String(describing: route))")
+		Log.debug("showHome Flow is called with current route: \(String(describing: route?.routeInformation)))")
 		if #available(iOS 13.5, *) {
 			if exposureManager.exposureManagerState.status == .unknown {
 				exposureManager.activate { [weak self] error in

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/Route.swift
@@ -111,5 +111,24 @@ enum Route {
 	case rapidAntigen(Result<CoronaTestRegistrationInformation, QRCodeError>)
 	case healthCertificateFromNotification(HealthCertifiedPerson, HealthCertificate)
 	case healthCertifiedPersonFromNotification(HealthCertifiedPerson)
+	
+	var routeInformation: RouteInformation {
+		switch self {
+		case .checkIn:
+			return .checkIn
+		case .rapidAntigen:
+			return .rapidAntigenTest
+		case .healthCertificateFromNotification:
+			return .healthCertificate
+		case .healthCertifiedPersonFromNotification:
+			return .healthCertifiedPerson
+		}
+	}
+}
 
+enum RouteInformation: String {
+	case checkIn = "Checkin"
+	case rapidAntigenTest = "RAT"
+	case healthCertificate = "HealthCertificate from notification"
+	case healthCertifiedPerson = "HealthCertifiedPerson from notification"
 }

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/RouteTests.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/RouteTests.swift
@@ -24,6 +24,7 @@ class RouteTests: CWATestCase {
 			return
 		}
 
+		XCTAssertEqual(route?.routeInformation, .rapidAntigenTest)
 		XCTAssertEqual(antigenTestQRCodeInformation.hash, "1ea4c222ff0c0e4ed7373f274caa7f75d10fccbdac56c632771cd9592102a555")
 		XCTAssertEqual(antigenTestQRCodeInformation.timestamp, 1619617269)
 		XCTAssertEqual(antigenTestQRCodeInformation.firstName, "Henry")
@@ -46,6 +47,7 @@ class RouteTests: CWATestCase {
 		}
 
 		// THEN
+		XCTAssertEqual(route?.routeInformation, .rapidAntigenTest)
 		switch result {
 		case .success:
 			XCTFail("Route parse success wasn't expected")
@@ -86,6 +88,7 @@ class RouteTests: CWATestCase {
 		let route = Route(url: url)
 
 		// THEN
+		XCTAssertEqual(route?.routeInformation, .rapidAntigenTest)
 		XCTAssertEqual(route, .rapidAntigen(.failure(.invalidTestCode(.invalidHash))))
 	}
 
@@ -110,6 +113,7 @@ class RouteTests: CWATestCase {
 		let route = Route(url: url)
 
 		// THEN
+		XCTAssertEqual(route?.routeInformation, .rapidAntigenTest)
 		XCTAssertEqual(route, .rapidAntigen(.failure(.invalidTestCode(.invalidTimeStamp))))
 	}
 
@@ -158,6 +162,7 @@ class RouteTests: CWATestCase {
 		let route = Route(url: url)
 
 		// THEN
+		XCTAssertEqual(route?.routeInformation, .rapidAntigenTest)
 		XCTAssertEqual(route, .rapidAntigen(.failure(.invalidTestCode(.invalidTestedPersonInformation))))
 	}
 
@@ -179,6 +184,7 @@ class RouteTests: CWATestCase {
 		let route = try XCTUnwrap(Route(url))
 
 		// THEN
+		XCTAssertEqual(route.routeInformation, .rapidAntigenTest)
 		switch route {
 		case .rapidAntigen(.success(let test)):
 			switch test {
@@ -200,6 +206,7 @@ class RouteTests: CWATestCase {
 		let route = try XCTUnwrap(Route(url))
 
 		// THEN
+		XCTAssertEqual(route.routeInformation, .rapidAntigenTest)
 		switch route {
 		case .rapidAntigen(.failure(.invalidTestCode(let error))):
 			XCTAssertEqual(error, .hashMismatch)
@@ -221,9 +228,46 @@ class RouteTests: CWATestCase {
 		)
 		
 		// THEN
+		XCTAssertEqual(route.routeInformation, .healthCertificate)
 		if case let .healthCertificateFromNotification(person, certificate) = route {
 			XCTAssertEqual(person, healthCertifiedPerson)
 			XCTAssertEqual(certificate, healthCertificate)
+		} else {
+			XCTFail("Test should not fail")
+		}
+	}
+	
+	func testGIVEN_HealthCertifiedPerson_WHEN_RouteIsCreated_THEN_PropertiesAreSetCorrect() {
+		
+		// GIVEN
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [])
+		
+		// WHEN
+		let route = Route(
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+		
+		// THEN
+		XCTAssertEqual(route.routeInformation, .healthCertifiedPerson)
+		if case let .healthCertifiedPersonFromNotification(person) = route {
+			XCTAssertEqual(person, healthCertifiedPerson)
+		} else {
+			XCTFail("Test should not fail")
+		}
+	}
+	
+	func testGIVEN_Checkin_WHEN_RouteIsCreated_THEN_PropertiesAreSetCorrect() throws {
+		
+		// GIVEN
+		let checkinURL = try XCTUnwrap(URL(string: "https://e.coronawarn.app"))
+		
+		// WHEN
+		let route = Route(url: checkinURL)
+		
+		// THEN
+		XCTAssertEqual(route?.routeInformation, .checkIn)
+		if case let .checkIn(checkin) = route {
+			XCTAssertEqual(checkin, checkinURL.absoluteString)
 		} else {
 			XCTFail("Test should not fail")
 		}


### PR DESCRIPTION
## Description
There can be personal data in the ELS Logs when opening the app from background by an badge (scanning RAT with native camera or receiving a notification e.g.).
To not loose the information in the logs from where the route came from, i created a property in which the information is capsulated. So no private information will be logged. 

## Link to Jira
(https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11283)

## Screenshots
Shows no more private information.
![Bildschirmfoto 2022-01-13 um 11 59 24](https://user-images.githubusercontent.com/75615785/149319751-39c5593a-adef-4fa0-a3ea-353c868d3f3f.png)

