### PR TITLE
Fix/correct vaccination state and image

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -134,7 +134,7 @@ final class HealthCertificateCellViewModel {
 		}
 
 		switch healthCertificate.entry {
-		case .vaccination(let vaccinationEntry) where vaccinationEntry.isLastDoseInASeries:
+		case .vaccination(let vaccinationEntry) where vaccinationEntry.isLastDoseInASeries || vaccinationEntry.isBoosterVaccination:
 			if case .completelyProtected = healthCertifiedPerson.vaccinationState {
 				return UIImage(imageLiteralResourceName: "VaccinationCertificate_CompletelyProtected_Icon")
 			} else {

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
@@ -114,6 +114,44 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
 	}
 
+	func testViewModelWithJust3of3BoosterVaccinationCertificateWithCompleteProtection() throws {
+		let healthCertificate = try vaccinationCertificate(daysOffset: 0, doseNumber: 3, totalSeriesOfDoses: 3)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+		healthCertifiedPerson.gradientType = .darkBlue
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .darkBlue)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertEqual(viewModel.subheadline, "Impfung 3 von 3")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "VaccinationCertificate_CompletelyProtected_Icon"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_dark"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+	}
+
+	func testViewModelWithJust2of1BoosterVaccinationCertificateWithCompleteProtection() throws {
+		let healthCertificate = try vaccinationCertificate(daysOffset: 0, doseNumber: 2, totalSeriesOfDoses: 1)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+		healthCertifiedPerson.gradientType = .darkBlue
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .darkBlue)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertEqual(viewModel.subheadline, "Impfung 2 von 1")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "VaccinationCertificate_CompletelyProtected_Icon"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_dark"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+	}
+
 	func testViewModelWithSeriesCompletingVaccinationCertificateWithCompleteProtection() throws {
 		let healthCertificate = try vaccinationCertificate(daysOffset: -15, doseNumber: 2, totalSeriesOfDoses: 2)
 		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -289,8 +289,8 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 		}
 	}
 
-	private var vaccinationExpirationDate: Date? {
-		guard let lastVaccination = vaccinationCertificates.last(where: { $0.vaccinationEntry?.isLastDoseInASeries ?? false }) else {
+	private var protectionExpirationDate: Date? {
+		guard let lastVaccination = vaccinationCertificates.last(where: { $0.vaccinationEntry?.isLastDoseInASeries ?? false || $0.vaccinationEntry?.isBoosterVaccination ?? false }) else {
 			return nil
 		}
 
@@ -327,7 +327,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 
 	private func updateVaccinationState() {
 		if let completeVaccinationProtectionDate = completeVaccinationProtectionDate,
-		   let vaccinationExpirationDate = vaccinationExpirationDate {
+		   let protectionExpirationDate = protectionExpirationDate {
 			if completeVaccinationProtectionDate > Date() {
 				let startOfToday = Calendar.autoupdatingCurrent.startOfDay(for: Date())
 				guard let daysUntilCompleteProtection = Calendar.autoupdatingCurrent.dateComponents([.day], from: startOfToday, to: completeVaccinationProtectionDate).day else {
@@ -336,7 +336,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 
 				vaccinationState = .fullyVaccinated(daysUntilCompleteProtection: daysUntilCompleteProtection)
 			} else {
-				vaccinationState = .completelyProtected(expirationDate: vaccinationExpirationDate)
+				vaccinationState = .completelyProtected(expirationDate: protectionExpirationDate)
 			}
 		} else if !vaccinationCertificates.isEmpty {
 			vaccinationState = .partiallyVaccinated


### PR DESCRIPTION
## Description
Shows the correct image for booster vaccinations using the new booster notation (e.g. 2/1).

## Screenshots
![IMG_0251](https://user-images.githubusercontent.com/1157991/150119491-5e25ed99-32d0-4b53-bf19-c82f07f3649f.jpg)

