### PR TITLE
Use multi-line comments as multi-line comments in Strings files

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/Localizable.strings
@@ -1,6 +1,9 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write \"z. B.\" always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
+
 /* General */
 "Alert_TitleGeneral" = "Възникна грешка.";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1,6 +1,8 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write "z. B." always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
 
 /* General */
 "Alert_TitleGeneral" = "Ein Fehler ist aufgetreten.";

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/Localizable.strings
@@ -1,6 +1,9 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write \"z. B.\" always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
+
 /* General */
 "Alert_TitleGeneral" = "An error occurred.";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/Localizable.strings
@@ -1,6 +1,9 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write \"z. B.\" always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
+
 /* General */
 "Alert_TitleGeneral" = "Wystąpił błąd.";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/Localizable.strings
@@ -1,6 +1,9 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write \"z. B.\" always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
+
 /* General */
 "Alert_TitleGeneral" = "A apărut o eroare.";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/Localizable.strings
@@ -1,6 +1,9 @@
-/* Hints */
-/* Use a non-breaking space (OPTION + SPACE) to avoid line breaks. */
-/* Write \"z. B.\" always with a non-breaking space (OPTION + SPACE). */
+/*
+  Hints
+  Use a non-breaking space (OPTION + SPACE) to avoid line breaks.
+  Write \"z. B.\" always with a non-breaking space (OPTION + SPACE).
+*/
+
 /* General */
 "Alert_TitleGeneral" = "Bir hata oluştu.";
 


### PR DESCRIPTION
## Description
This solves future potential issues with translation management tools that will only keep a single "file header comment". Currently, the multi-line style `/* comment */` was used, but instead of putting all header comments into one, a new comment was opened on each line. This PR merges these into one comment to be in line with Xcode default generated "header comment" style format.

## Link to Jira
N/A (this is such a small change, don't worth the overhead of reporting to me)

## Screenshots
Nothing changed in the apps UI.
