### PR TITLE
Certificate Travel Infos - wrong text

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -2813,7 +2813,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_Validation_Info_byCar" = "Geben Sie die geplante lokale Ankunftszeit an der Grenze zu Ihrem Einreiseland ein.";
 
-"HealthCertificate_Validation_Info_byPlane" = "Wenn Sie auf dem Luftweg einreisen, wählen Sie die geplante Uhrzeit Ihres Abflugs aus.";
+"HealthCertificate_Validation_Info_byPlane" = "Wenn Sie auf dem Luftweg einreisen, geben Sie die geplante Uhrzeit Ihres Abflugs ein.";
 
 /* Health Certificate Overview */
 


### PR DESCRIPTION
Certificate Travel Infos - wrong text
WRONG: Wenn Sie auf dem Luftweg einreisen, wählen Sie die geplante Uhrzeit Ihres Abflugs aus.

RIGHT: Wenn Sie auf dem Luftweg einreisen, geben Sie die geplante Uhrzeit Ihres Abflugs ein.

--> https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11228

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

## Link to Jira
<!-- Please add the link to the related Jira issue -->

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
