### PR TITLE
Word "Uhr" missing in recycle bin note

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3435,7 +3435,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "RecycleBin_deleteAllButtonTitle" = "Alle endgültig löschen";
 
-"RecycleBin_expirationDateTime" = "wird am %@ um %@ endgültig gelöscht";
+"RecycleBin_expirationDateTime" = "wird am %@ um %@ Uhr endgültig gelöscht";
 
 /* - Vaccination Certificate */
 


### PR DESCRIPTION
in German language "Uhr" is missing after the time of date

--> https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11636

