### PR TITLE
Fix flaky date tests

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CCLService/GetWalletInfoInput.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CCLService/GetWalletInfoInput.swift
@@ -69,15 +69,11 @@ extension SystemTime {
 	
 	// MARK: - DateFormatters
 
-	#if !RELEASE
-	static var referenceTestTimeZone: TimeZone = TimeZone.current
-	#endif
+	static var timeZone: TimeZone = TimeZone.autoupdatingCurrent
 
 	static var localDateFormatter: DateFormatter = {
 		let formatter = DateFormatter()
-		#if !RELEASE
-		formatter.timeZone = referenceTestTimeZone
-		#endif
+		formatter.timeZone = timeZone
 		formatter.dateFormat = "yyyy-MM-dd"
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
@@ -86,10 +82,8 @@ extension SystemTime {
 	// 2021-12-30T10:00:00+01:00
 	static var localDateTimeFormatter: DateFormatter = {
 		let formatter = DateFormatter()
-		#if !RELEASE
-		formatter.timeZone = referenceTestTimeZone
-		#endif
-		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+		formatter.timeZone = timeZone
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxx"
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
 	}()
@@ -97,10 +91,8 @@ extension SystemTime {
 	// 2021-12-30T00:00:00+01:00
 	static var localDateMidnightTimeFormatter: DateFormatter = {
 		let formatter = DateFormatter()
-		#if !RELEASE
-		formatter.timeZone = referenceTestTimeZone
-		#endif
-		formatter.dateFormat = "yyyy-MM-dd'T00:00:00'ZZZZZ"
+		formatter.timeZone = timeZone
+		formatter.dateFormat = "yyyy-MM-dd'T00:00:00'xxx"
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
 	}()

--- a/src/xcode/ENA/ENA/Source/Services/CCLService/__tests__/GetWalletInfoInputTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CCLService/__tests__/GetWalletInfoInputTests.swift
@@ -10,7 +10,7 @@ import AnyCodable
 class GetWalletInfoInputTests: XCTestCase {
 	
 	func test_TimeStrings_WithoutDayChangeDueTimezone() throws {
-		SystemTime.referenceTestTimeZone = try XCTUnwrap(TimeZone(abbreviation: "CET"))
+		SystemTime.timeZone = try XCTUnwrap(TimeZone(abbreviation: "CET"))
 		
 		let dateString = "2022-01-28T15:30:00+01:00"
 		let date = try XCTUnwrap(SystemTime.localDateTimeFormatter.date(from: dateString))
@@ -30,10 +30,10 @@ class GetWalletInfoInputTests: XCTestCase {
 	}
 	
 	func test_TimeStrings_WithDayChangeDueTimezone() throws {
-		SystemTime.referenceTestTimeZone = try XCTUnwrap(TimeZone(abbreviation: "CET"))
+		SystemTime.timeZone = try XCTUnwrap(TimeZone(abbreviation: "CET"))
 
 		let dateString = "2022-01-28T00:30:00+01:00"
-		let date = try XCTUnwrap( SystemTime.localDateTimeFormatter.date(from: dateString))
+		let date = try XCTUnwrap(SystemTime.localDateTimeFormatter.date(from: dateString))
 		
 		let input = GetWalletInfoInput.make(with: date, language: "de", certificates: [], boosterNotificationRules: [])
 		guard let systemTime: SystemTime = input["now"]?.value as? SystemTime else {
@@ -50,6 +50,8 @@ class GetWalletInfoInputTests: XCTestCase {
 	}
 	
 	func test_OtherData() throws {
+		SystemTime.timeZone = try XCTUnwrap(TimeZone(abbreviation: "CET"))
+
 		let input = GetWalletInfoInput.make(with: Date(), language: "de", certificates: [], boosterNotificationRules: [])
 		
 		XCTAssertEqual(input["os"], AnyDecodable("ios"))
@@ -58,4 +60,6 @@ class GetWalletInfoInputTests: XCTestCase {
 		XCTAssertNotNil(input["certificates"])
 		XCTAssertNotNil(input["boosterNotificationRules"])
 	}
+	
+	// ⚠️⚠️⚠️ Please read this before adding tests here: For new tests involving GetWalletInfoInput, please set the timeZone of SystemTime to "CET". Otherwise all the tests in this test case will get flaky. This is because of the static dateformatters.
 }


### PR DESCRIPTION
Change format to use 'xxx' instead of 'ZZZZZ'. 'ZZZZZ' has a fallback to 'Z' when local time offset is 0, which is not what we want here.
Add TimeZone.current to the timezone to keep it updated.
Add timezone setting to unit tests to avoid flakyness due to static date formatters.
