### PR TITLE
Exclude DCCUIText.stringsdict from translations

### DIFF
--- a/translation_v2.json
+++ b/translation_v2.json
@@ -9,7 +9,7 @@
             "*.strings","*.stringsdict"
           ],
           "excludedSourceFilters":[
-            "*.legal.*", "*.links.*"
+            "*.legal.*", "*.links.*", "DCCUIText.stringsdict"
           ],
            "targetFolderPath":"../[langCode].lproj/"
         }


### PR DESCRIPTION
## Description
Excluding the workaround DCCUIText stringsdict file from translation.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11701
