### PR TITLE
Fix/11713 screen close

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
@@ -268,7 +268,7 @@ final class HealthCertificatesTabCoordinator {
 							}
 							self.healthCertificateService.moveHealthCertificateToBin(healthCertificate)
 							// Do not confirm deletion if we removed the last certificate of the person (this removes the person, too) because it would trigger a new reload of the table where no person can be shown. Instead, we dismiss the view controller.
-							if self.healthCertificateService.healthCertifiedPersons.contains(healthCertifiedPerson) {
+							if self.healthCertificateService.healthCertifiedPersons.contains(where: { $0 === healthCertifiedPerson }) {
 								confirmDeletion()
 							} else {
 								self.viewController.dismiss(animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
@@ -36,15 +36,14 @@ final class HealthCertifiedPersonViewModel {
 		constructHealthCertificateCellViewModels(for: healthCertifiedPerson)
 
 		healthCertifiedPerson.objectDidChange
+			.receive(on: DispatchQueue.main.ocombine)
 			.sink { [weak self] person in
 				self?.constructHealthCertificateCellViewModels(for: person)
 				
 				guard !person.healthCertificates.isEmpty else {
 					// Prevent trigger reload if we the person was removed before because we removed their last certificate.
 					self?.triggerReload = false
-					DispatchQueue.main.async {
-						dismiss()
-					}
+					dismiss()
 					return
 				}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -258,7 +258,7 @@ class HealthCertificateService {
 
 				if healthCertifiedPerson.healthCertificates.isEmpty {
 					healthCertifiedPersons = healthCertifiedPersons
-						.filter { $0 != healthCertifiedPerson }
+						.filter { $0 !== healthCertifiedPerson }
 						.sorted()
 					updateGradients()
 


### PR DESCRIPTION
## Description
Fixes an issue where the person screen is closed when a certificate is deleted even though the person has other certificates. 
Solution: Checks for person object identity instead of equality as the updated dccWalletInfo impacts equality

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11713
