### PR TITLE
Fix/11655 no responding error

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -220,8 +220,13 @@ final class ENAExposureManager: NSObject, ExposureManager {
 	/// Activates `ENManager`
 	/// Needs to be called before `ExposureManager.enable()`
 	func activate(completion: @escaping CompletionHandler) {
+		guard manager.exposureNotificationStatus != .active else {
+			Log.error("ENF is already enabled - do not trigger it twice")
+			completion(nil)
+			return
+		}
+
 		Log.info("Trying to activate ENManager")
-		
 		var isActive = false
 		
 		manager.activate { activationError in


### PR DESCRIPTION
## Description
Enabling ENF multiple times will lead to an error. To avoid that f.e. while onboarding a call to activate ENF will result in a success if current state is already active-

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11655

