### PR TITLE
Fix/11839 wallet recalculation

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/ENATaskExecutionDelegate.swift
@@ -329,6 +329,6 @@ class TaskExecutionHandler: ENATaskExecutionDelegate {
 	}
 
 	private func checkCertificateValidityStates(completion: @escaping () -> Void) {
-		healthCertificateService.updateValidityStatesAndNotificationsWithFreshDSCList(shouldScheduleTimer: false, completion: completion)
+		healthCertificateService.updateValidityStatesAndNotificationsWithFreshDSCList(completion: completion)
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMNotificationsViewController.swift
@@ -56,7 +56,8 @@ final class DMNotificationsViewController: UITableViewController {
 		}
 
 		let df = DateFormatter()
-		df.dateFormat = "yyyy-MM-dd hh:mm:ss"
+		df.dateStyle = .short
+		df.timeStyle = .short
 
 		cell.detailTextLabel?.text = df.string(from: triggerDate)
 		return cell

--- a/src/xcode/ENA/ENA/Source/Services/CCLService/GetWalletInfoInput.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CCLService/GetWalletInfoInput.swift
@@ -71,33 +71,36 @@ extension SystemTime {
 
 	static var timeZone: TimeZone = TimeZone.autoupdatingCurrent
 
-	static var localDateFormatter: DateFormatter = {
+	static let localDateFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.timeZone = timeZone
 		formatter.dateFormat = "yyyy-MM-dd"
+		formatter.locale = Locale(identifier: "en_US_POSIX")
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
 	}()
 	
 	// 2021-12-30T10:00:00+01:00
-	static var localDateTimeFormatter: DateFormatter = {
+	static let localDateTimeFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.timeZone = timeZone
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssxxx"
+		formatter.locale = Locale(identifier: "en_US_POSIX")
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
 	}()
 	
 	// 2021-12-30T00:00:00+01:00
-	static var localDateMidnightTimeFormatter: DateFormatter = {
+	static let localDateMidnightTimeFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.timeZone = timeZone
 		formatter.dateFormat = "yyyy-MM-dd'T00:00:00'xxx"
+		formatter.locale = Locale(identifier: "en_US_POSIX")
 		formatter.calendar = Calendar(identifier: .gregorian)
 		return formatter
 	}()
 	
-	static var utcDateFormatter: DateFormatter = {
+	static let utcDateFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.dateFormat = "yyyy-MM-dd"
 		formatter.timeZone = TimeZone(abbreviation: "UTC")
@@ -107,7 +110,7 @@ extension SystemTime {
 	}()
 	
 	// 2021-12-30T09:00:00Z
-	static var utcDateTimeFormatter: DateFormatter = {
+	static let utcDateTimeFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 		formatter.timeZone = TimeZone(abbreviation: "UTC")
@@ -117,7 +120,7 @@ extension SystemTime {
 	}()
 	
 	// 2021-12-30T00:00:00Z
-	static var utcDateTimeMidnightFormatter: DateFormatter = {
+	static let utcDateTimeMidnightFormatter: DateFormatter = {
 		let formatter = DateFormatter()
 		formatter.dateFormat = "yyyy-MM-dd'T00:00:00Z'"
 		formatter.timeZone = TimeZone(abbreviation: "UTC")

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -516,7 +516,7 @@ class HealthCertificateService {
 		}
 	}
 
-	func updateValidityStatesAndNotificationsWithFreshDSCList(shouldScheduleTimer: Bool = true, completion: () -> Void) {
+	func updateValidityStatesAndNotificationsWithFreshDSCList(completion: () -> Void) {
 		Log.info("Update validity state and notifications with fresh dsc list.")
 
 		// .dropFirst: drops the first callback, which is called with default signing certificates.
@@ -526,7 +526,7 @@ class HealthCertificateService {
 			.dropFirst()
 			.first()
 			.sink { [weak self] _ in
-				self?.updateValidityStatesAndNotifications(shouldScheduleTimer: shouldScheduleTimer)
+				self?.updateValidityStatesAndNotifications()
 			}
 			.store(in: &subscriptions)
 	}
@@ -585,7 +585,7 @@ class HealthCertificateService {
 
 		Log.info("Schedule validity timer in \(fireDate.timeIntervalSinceNow) seconds")
 		nextValidityTimer = Timer.scheduledTimer(withTimeInterval: fireDate.timeIntervalSinceNow, repeats: false) { [weak self] _ in
-			self?.updateValidityStatesAndNotifications(shouldScheduleTimer: false)
+			self?.updateValidityStatesAndNotifications()
 			self?.nextValidityTimer = nil
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -631,10 +631,10 @@ class HealthCertificateService {
 		subscribeToNotifications()
 		updateGradients()
 		
-		// Validation Service
 		subscribeAppConfigUpdates()
 		subscribeDSCListChanges()
 		updateDCCWalletInfosIfNeeded()
+		scheduleTimer()
 	}
 
 	private func subscribeAppConfigUpdates() {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -301,7 +301,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 		NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
 		NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
 
-		guard let nextMostRelevantCertificateChangeDate = dccWalletInfo?.validUntil else {
+		guard let dccWalletInfoExpirationDate = dccWalletInfo?.validUntil else {
 			return
 		}
 
@@ -309,10 +309,10 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 		NotificationCenter.default.addObserver(self, selector: #selector(invalidateTimer), name: UIApplication.didEnterBackgroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(scheduleDCCWalletInfoUpdateTimer), name: UIApplication.didBecomeActiveNotification, object: nil)
 
-		dccWalletInfoUpdateTimer = Timer(fireAt: nextMostRelevantCertificateChangeDate, interval: 0, target: self, selector: #selector(updateDCCWalletInfo), userInfo: nil, repeats: false)
+		dccWalletInfoUpdateTimer = Timer(fireAt: dccWalletInfoExpirationDate, interval: 0, target: self, selector: #selector(updateDCCWalletInfo), userInfo: nil, repeats: false)
 
-		guard let mostRelevantCertificateTimer = dccWalletInfoUpdateTimer else { return }
-		RunLoop.main.add(mostRelevantCertificateTimer, forMode: .common)
+		guard let dccWalletInfoUpdateTimer = dccWalletInfoUpdateTimer else { return }
+		RunLoop.main.add(dccWalletInfoUpdateTimer, forMode: .common)
 	}
 
 	@objc

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -312,7 +312,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 		dccWalletInfoUpdateTimer = Timer(fireAt: nextMostRelevantCertificateChangeDate, interval: 0, target: self, selector: #selector(updateDCCWalletInfo), userInfo: nil, repeats: false)
 
 		guard let mostRelevantCertificateTimer = dccWalletInfoUpdateTimer else { return }
-		RunLoop.current.add(mostRelevantCertificateTimer, forMode: .common)
+		RunLoop.main.add(mostRelevantCertificateTimer, forMode: .common)
 	}
 
 	@objc


### PR DESCRIPTION
## Description
Fixes several update-related issues:
- Schedules the person-based update timer on the main loop to ensure its fired
- Initially schedules the validity timer in the service and reschedules it after firing
- Ensures all date formatters format the current hour correctly even if the user has configured their device to a 12-hour-clock by using a fixed local for non-user-facing date formats

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11839
