### PR TITLE
Fix/11802 make failed certificates removable

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3045,7 +3045,7 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "DecodingFailedHealthCertificate_Alert_title" = "Wollen Sie das Zertifikat endgültig löschen?";
 
-"DecodingFailedHealthCertificate_Alert_message" = "Das Zertifikat konnte nicht dekodiert werden. Wenn Sie es löschen, können Sie es nicht mehr als Nachweis verwenden.";
+"DecodingFailedHealthCertificate_Alert_message" = "Das Zertifikat konnte nicht dekodiert werden, daher können keine Informationen dazu angezeigt werden. Wenn Sie es löschen, können Sie es nicht mehr als Nachweis verwenden.";
 
 "DecodingFailedHealthCertificate_Alert_deleteButton" = "Zertifikat endgültig löschen";
 

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3041,6 +3041,16 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "RecoveryCertificate_Alert_message" = "Das Zertifikat wird in den Papierkorb verschoben. Den Papierkorb finden Sie auf der „Mehr“-Kachel der Status-Registerkarte. Dort können Sie es endgültig löschen oder wiederherstellen. Nach 30 Tagen wird das Zertifikat automatisch gelöscht.";
 
+/* Decoding Failed Health Certificate Delete Alert */
+
+"DecodingFailedHealthCertificate_Alert_title" = "Wollen Sie das Zertifikat endgültig löschen?";
+
+"DecodingFailedHealthCertificate_Alert_message" = "Das Zertifikat konnte nicht dekodiert werden. Wenn Sie es löschen, können Sie es nicht mehr als Nachweis verwenden.";
+
+"DecodingFailedHealthCertificate_Alert_deleteButton" = "Zertifikat endgültig löschen";
+
+"DecodingFailedHealthCertificate_Alert_cancelButton" = "Abbrechen";
+
 /* Health Certificate Print PDF */
 
 "HealthCertificate_PrintPdf_showPrintableVersion" = "Druckversion anzeigen";

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
@@ -120,6 +120,17 @@ final class HealthCertificatesTabCoordinator {
 			},
 			onCovPassCheckInfoButtonTap: { [weak self] in
 				self?.presentCovPassInfoScreen()
+			},
+			onTapToDelete: { [weak self] decodingFailedHealthCertificate in
+				self?.showDecodingFailedDeleteAlert(
+					submitAction: UIAlertAction(
+						title: AppStrings.HealthCertificate.Alert.DecodingFailedCertificate.deleteButton,
+						style: .destructive,
+						handler: { _ in
+							self?.healthCertificateService.remove(decodingFailedHealthCertificate: decodingFailedHealthCertificate)
+						}
+					)
+				)
 			}
 		)
 	}()

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
@@ -361,6 +361,27 @@ final class HealthCertificatesTabCoordinator {
 		alert.addAction(submitAction)
 		modalNavigationController.present(alert, animated: true)
 	}
+
+	private func showDecodingFailedDeleteAlert(
+		submitAction: UIAlertAction
+	) {
+		let alert = UIAlertController(
+			title: AppStrings.HealthCertificate.Alert.DecodingFailedCertificate.title,
+			message: AppStrings.HealthCertificate.Alert.DecodingFailedCertificate.message,
+			preferredStyle: .alert
+		)
+
+		alert.addAction(
+			UIAlertAction(
+				title: AppStrings.HealthCertificate.Alert.DecodingFailedCertificate.cancelButton,
+				style: .cancel,
+				handler: nil
+			)
+		)
+		alert.addAction(submitAction)
+
+		viewController.present(alert, animated: true)
+	}
 	
 	private func showHealthCertificateFlow(
 		healthCertifiedPerson: HealthCertifiedPerson,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -60,11 +60,14 @@ class HealthCertifiedPersonCellModel {
 		} else {
 			switchableHealthCertificates = [:]
 		}
+
+		self.onTapToDelete = nil
 	}
 
 	init?(
 		decodingFailedHealthCertificate: DecodingFailedHealthCertificate,
-		onCovPassCheckInfoButtonTap: @escaping () -> Void
+		onCovPassCheckInfoButtonTap: @escaping () -> Void,
+		onTapToDelete: @escaping (DecodingFailedHealthCertificate) -> Void
 	) {
 		backgroundGradientType = .solidGrey
 
@@ -89,6 +92,10 @@ class HealthCertifiedPersonCellModel {
 		shortStatus = nil
 
 		switchableHealthCertificates = [:]
+
+		self.onTapToDelete = {
+			onTapToDelete(decodingFailedHealthCertificate)
+		}
 	}
 
 	// MARK: - Internal
@@ -111,6 +118,8 @@ class HealthCertifiedPersonCellModel {
 	let shortStatus: String?
 
 	let switchableHealthCertificates: OrderedDictionary<String, HealthCertificate>
+
+	let onTapToDelete: (() -> Void)?
 
 	func showHealthCertificate(at index: Int) {
 		qrCodeViewModel.updateImage(with: switchableHealthCertificates.elements[index].value)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonTableViewCell.swift
@@ -293,6 +293,13 @@ class HealthCertifiedPersonTableViewCell: UITableViewCell, ReuseIdentifierProvid
 		return captionLabel
 	}()
 
+	private lazy var tapGestureRecognizer: UITapGestureRecognizer = {
+		let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture))
+		gestureRecognizer.numberOfTapsRequired = 7
+
+		return gestureRecognizer
+	}()
+
 	private var cellModel: HealthCertifiedPersonCellModel?
 
 	private func setupAccessibility(
@@ -404,6 +411,8 @@ class HealthCertifiedPersonTableViewCell: UITableViewCell, ReuseIdentifierProvid
 				captionCountLabel.bottomAnchor.constraint(equalTo: captionCountView.bottomAnchor, constant: -2.0)
 			]
 		)
+
+		addGestureRecognizer(tapGestureRecognizer)
 	}
 
 	private func updateBorderColors() {
@@ -414,6 +423,11 @@ class HealthCertifiedPersonTableViewCell: UITableViewCell, ReuseIdentifierProvid
 	@objc
 	func segmentedControlValueChanged(_ sender: UISegmentedControl) {
 		cellModel?.showHealthCertificate(at: sender.selectedSegmentIndex)
+	}
+
+	@objc
+	func handleTapGesture() {
+		cellModel?.onTapToDelete?()
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
@@ -15,7 +15,8 @@ class HealthCertificateOverviewViewController: UITableViewController {
 		onInfoBarButtonItemTap: @escaping () -> Void,
 		onCreateHealthCertificateTap: @escaping () -> Void,
 		onCertifiedPersonTap: @escaping (HealthCertifiedPerson) -> Void,
-		onCovPassCheckInfoButtonTap: @escaping () -> Void
+		onCovPassCheckInfoButtonTap: @escaping () -> Void,
+		onTapToDelete: @escaping (DecodingFailedHealthCertificate) -> Void
 	) {
 		self.viewModel = viewModel
 		self.cclService = cclService
@@ -23,6 +24,7 @@ class HealthCertificateOverviewViewController: UITableViewController {
 		self.onCreateHealthCertificateTap = onCreateHealthCertificateTap
 		self.onCertifiedPersonTap = onCertifiedPersonTap
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
+		self.onTapToDelete = onTapToDelete
 
 		super.init(style: .grouped)
 		
@@ -143,6 +145,7 @@ class HealthCertificateOverviewViewController: UITableViewController {
 	private let onCreateHealthCertificateTap: () -> Void
 	private let onCertifiedPersonTap: (HealthCertifiedPerson) -> Void
 	private let onCovPassCheckInfoButtonTap: () -> Void
+	private let onTapToDelete: (DecodingFailedHealthCertificate) -> Void
 
 	private var subscriptions = Set<AnyCancellable>()
 
@@ -244,6 +247,9 @@ class HealthCertificateOverviewViewController: UITableViewController {
 				decodingFailedHealthCertificate: decodingFailedHealthCertificate,
 				onCovPassCheckInfoButtonTap: { [weak self] in
 					self?.onCovPassCheckInfoButtonTap()
+				},
+				onTapToDelete: { [weak self] decodingFailedHealthCertificate in
+					self?.onTapToDelete(decodingFailedHealthCertificate)
 				}
 			  ) else {
 			return UITableViewCell()

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -604,6 +604,17 @@ class HealthCertificateService {
 		}
 	}
 
+	func remove(decodingFailedHealthCertificate: DecodingFailedHealthCertificate) {
+		healthCertifiedPersons
+			.first {
+				$0.decodingFailedHealthCertificates.contains(decodingFailedHealthCertificate)
+			}?
+			.decodingFailedHealthCertificates
+			.removeAll {
+				$0 == decodingFailedHealthCertificate
+			}
+	}
+
 	// MARK: - Private
 
 	private let store: HealthCertificateStoring

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2220,7 +2220,7 @@ enum AppStrings {
 
 			enum VaccinationCertificate {
 				static let title = NSLocalizedString("VaccinationCertificate_Alert_title", comment: "")
-			 static let message = NSLocalizedString("VaccinationCertificate_Alert_message", comment: "")
+				static let message = NSLocalizedString("VaccinationCertificate_Alert_message", comment: "")
 			}
 
 			enum TestCertificate {
@@ -2231,6 +2231,13 @@ enum AppStrings {
 			enum RecoveryCertificate {
 				static let title = NSLocalizedString("RecoveryCertificate_Alert_title", comment: "")
 				static let message = NSLocalizedString("RecoveryCertificate_Alert_message", comment: "")
+			}
+
+			enum DecodingFailedCertificate {
+				static let title = NSLocalizedString("DecodingFailedHealthCertificate_Alert_title", comment: "")
+				static let message = NSLocalizedString("DecodingFailedHealthCertificate_Alert_message", comment: "")
+				static let deleteButton = NSLocalizedString("DecodingFailedHealthCertificate_Alert_deleteButton", comment: "")
+				static let cancelButton = NSLocalizedString("DecodingFailedHealthCertificate_Alert_cancelButton", comment: "")
 			}
 		}
 


### PR DESCRIPTION
## Description
Introduces a (on purpose very hidden) delete function on certificates for which the decoding failed and which cannot be recovered, because we e.g. enforce stricter rules for the "iat" field in the meantime. This delete alert is reached by tapping on the certificate 7 times.
We want this delete functionality to be hidden so it can't be triggered accidentally and to encourage users to contact us when they find themselves with certificates that cannot be decoded, so we can detect issues with our decoding process.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11802

## Screenshots
![IMG_144B486948F8-1](https://user-images.githubusercontent.com/1157991/154300337-b69b2a1d-756a-4369-a0a7-2b86abdc8458.jpeg)

