### PR TITLE
Feature/fix certificate comparison

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
@@ -268,7 +268,7 @@ final class HealthCertificatesTabCoordinator {
 							}
 							self.healthCertificateService.moveHealthCertificateToBin(healthCertificate)
 							// Do not confirm deletion if we removed the last certificate of the person (this removes the person, too) because it would trigger a new reload of the table where no person can be shown. Instead, we dismiss the view controller.
-							if self.healthCertificateService.healthCertifiedPersons.contains(where: { $0 === healthCertifiedPerson }) {
+							if self.healthCertificateService.healthCertifiedPersons.contains(healthCertifiedPerson) {
 								confirmDeletion()
 							} else {
 								self.viewController.dismiss(animated: true)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
@@ -173,6 +173,7 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 		viewModel.canEditRow(at: indexPath)
 	}
 
+	// swiftlint:disable cyclomatic_complexity
 	func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
 		guard editingStyle == .delete, let healthCertificate = viewModel.healthCertificate(for: indexPath) else { return }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
@@ -180,7 +180,7 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 		let admissionStateWasVisible = viewModel.admissionStateIsVisible
 		let boosterNotificationWasVisible = viewModel.boosterNotificationIsVisible
 
-		let previousCertificates = viewModel.healthCertifiedPerson.healthCertificates
+		let previousCertificates = viewModel.healthCertifiedPerson.healthCertificates.sorted(by: >)
 
 		self.didSwipeToDelete(healthCertificate) { [weak self] in
 			guard let self = self else { return }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
@@ -180,6 +180,8 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 		let admissionStateWasVisible = viewModel.admissionStateIsVisible
 		let boosterNotificationWasVisible = viewModel.boosterNotificationIsVisible
 
+		let previousCertificates = viewModel.healthCertifiedPerson.healthCertificates
+
 		self.didSwipeToDelete(healthCertificate) { [weak self] in
 			guard let self = self else { return }
 
@@ -206,7 +208,14 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 				} else if !boosterNotificationWasVisible && self.viewModel.boosterNotificationIsVisible {
 					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.boosterNotification.rawValue))
 				}
-				
+
+				// For the case that a person splits after deleting a certificate, there could be some more certificates to be removed (because they are moved into a new person).
+				for (index, certificate) in previousCertificates.enumerated() where certificate != healthCertificate {
+					if !self.viewModel.healthCertifiedPerson.healthCertificates.contains(certificate) {
+						deleteIndexPaths.append(IndexPath(row: index, section: HealthCertifiedPersonViewModel.TableViewSection.certificates.rawValue))
+					}
+				}
+
 				tableView.deleteRows(at: deleteIndexPaths, with: .automatic)
 				tableView.insertRows(at: insertIndexPaths, with: .automatic)
 			}, completion: { _ in

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
@@ -89,6 +89,18 @@ final class HealthCertifiedPersonViewModel {
 		}
 	}
 
+	let healthCertifiedPerson: HealthCertifiedPerson
+
+	let boosterNotificationCellModel: BoosterNotificationCellModel
+	let admissionStateCellModel: AdmissionStateCellModel
+	let vaccinationStateCellModel: VaccinationStateCellModel
+
+	@OpenCombine.Published private(set) var gradientType: GradientView.GradientType = .lightBlue
+	@OpenCombine.Published private(set) var triggerReload: Bool = false
+	@OpenCombine.Published private(set) var updateError: Error?
+
+	private(set) var healthCertificateCellViewModels = [HealthCertificateCellViewModel]()
+
 	var headerCellViewModel: HealthCertificateSimpleTextCellViewModel {
 		let centerParagraphStyle = NSMutableParagraphStyle()
 		centerParagraphStyle.alignment = .center
@@ -122,16 +134,6 @@ final class HealthCertifiedPersonViewModel {
 			accessibilityTraits: .staticText
 		)
 	}
-
-	let healthCertifiedPerson: HealthCertifiedPerson
-
-	let boosterNotificationCellModel: BoosterNotificationCellModel
-	let admissionStateCellModel: AdmissionStateCellModel
-	let vaccinationStateCellModel: VaccinationStateCellModel
-
-	@OpenCombine.Published private(set) var gradientType: GradientView.GradientType = .lightBlue
-	@OpenCombine.Published private(set) var triggerReload: Bool = false
-	@OpenCombine.Published private(set) var updateError: Error?
 
 	var qrCodeCellViewModel: HealthCertificateQRCodeCellViewModel {
 		guard let mostRelevantHealthCertificate = healthCertifiedPerson.mostRelevantHealthCertificate
@@ -233,8 +235,6 @@ final class HealthCertifiedPersonViewModel {
 	private let showInfo: () -> Void
 	private var subscriptions = Set<AnyCancellable>()
 
-	private var healthCertificateCellViewModels = [HealthCertificateCellViewModel]()
-	
 	private func constructHealthCertificateCellViewModels(for person: HealthCertifiedPerson) {
 		let sortedHealthCertificates = person.healthCertificates.sorted(by: >)
 		healthCertificateCellViewModels = sortedHealthCertificates.map {

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
@@ -99,8 +99,6 @@ final class HealthCertifiedPersonViewModel {
 	@OpenCombine.Published private(set) var triggerReload: Bool = false
 	@OpenCombine.Published private(set) var updateError: Error?
 
-	private(set) var healthCertificateCellViewModels = [HealthCertificateCellViewModel]()
-
 	var headerCellViewModel: HealthCertificateSimpleTextCellViewModel {
 		let centerParagraphStyle = NSMutableParagraphStyle()
 		centerParagraphStyle.alignment = .center
@@ -233,7 +231,9 @@ final class HealthCertifiedPersonViewModel {
 	private let didTapBoosterNotification: (HealthCertifiedPerson) -> Void
 	private let didTapValidationButton: (HealthCertificate, @escaping (Bool) -> Void) -> Void
 	private let showInfo: () -> Void
+
 	private var subscriptions = Set<AnyCancellable>()
+	private var healthCertificateCellViewModels = [HealthCertificateCellViewModel]()
 
 	private func constructHealthCertificateCellViewModels(for person: HealthCertifiedPerson) {
 		let sortedHealthCertificates = person.healthCertificates.sorted(by: >)

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -248,7 +248,7 @@ class HealthCertificateService {
 				
 				if healthCertifiedPerson.healthCertificates.isEmpty {
 					healthCertifiedPersons = healthCertifiedPersons
-						.filter { $0 !== healthCertifiedPerson }
+						.filter { $0 != healthCertifiedPerson }
 						.sorted()
 					updateGradients()
 
@@ -468,7 +468,7 @@ class HealthCertificateService {
 		for person in newGroupedPersons {
 			for certificate in person.healthCertificates {
 				if certificate.belongsToSamePerson(newHealthCertificate) {
-					if !matchingPersons.contains(where: { $0 == person }) {
+					if !matchingPersons.contains(person) {
 						matchingPersons.append(person)
 					}
 				}
@@ -685,7 +685,7 @@ class HealthCertificateService {
 					if healthCertifiedPerson.isPreferredPerson {
 						// Set isPreferredPerson = false on all other persons to only have one preferred person
 						self.healthCertifiedPersons
-							.filter { $0 !== healthCertifiedPerson }
+							.filter { $0 != healthCertifiedPerson }
 							.forEach {
 								$0.isPreferredPerson = false
 							}
@@ -965,13 +965,13 @@ class HealthCertificateService {
 		// Find person and replace it by our regroupedPersons
 		// Use a copy of healthCertifiedPersons to avoid multiple changes to healthCertifiedPersons.
 		var mutatedHealthCertifiedPersons = healthCertifiedPersons
-		mutatedHealthCertifiedPersons.removeAll { $0 === healthCertifiedPerson }
+		mutatedHealthCertifiedPersons.remove(healthCertifiedPerson)
 		mutatedHealthCertifiedPersons.append(contentsOf: regroupedPersons)
 		healthCertifiedPersons = mutatedHealthCertifiedPersons
 		
 		// We only want to call updateDCCWalletInfo for new created persons.
 		// For the existing person it is called when the certificates changed.
-		let newlyPersons = healthCertifiedPersons.filter { $0 !== healthCertifiedPerson }
+		let newlyPersons = healthCertifiedPersons.filter { $0 != healthCertifiedPerson }
 		newlyPersons.forEach { updateDCCWalletInfo(for: $0) }
 		
 		healthCertifiedPersons.sort()
@@ -1008,7 +1008,7 @@ class HealthCertificateService {
 			
 			let allPersons = matchingPersons + matchingRegroupedPersons
 			var mergedPerson: HealthCertifiedPerson
-			if allPersons.contains(where: { $0 === healthCertifiedPerson }) {
+			if allPersons.contains(healthCertifiedPerson) {
 				mergedPerson = healthCertifiedPerson
 			} else {
 				guard let person = allPersons.first else {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -104,11 +104,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 	// MARK: - Protocol Equatable
 
 	static func == (lhs: HealthCertifiedPerson, rhs: HealthCertifiedPerson) -> Bool {
-		lhs.healthCertificates == rhs.healthCertificates &&
-		lhs.isPreferredPerson == rhs.isPreferredPerson &&
-		lhs.boosterRule == rhs.boosterRule &&
-		lhs.isNewBoosterRule == rhs.isNewBoosterRule &&
-		lhs.dccWalletInfo == rhs.dccWalletInfo
+		lhs === rhs
 	}
 
 	// MARK: - Protocol Comparable

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
@@ -7,6 +7,7 @@ import XCTest
 @testable import ENA
 import OpenCombine
 import HealthCertificateToolkit
+import class CertLogic.Rule
 
 class HealthCertifiedPersonTests: CWATestCase {
 
@@ -95,12 +96,16 @@ class HealthCertifiedPersonTests: CWATestCase {
 			isNew: true,
 			isValidityStateNew: true
 		)
+		let boosterRule = Rule.fake(identifier: "Booster Rule Identifier 0815")
+		let dccWallet = DCCWalletInfo.fake()
 
 		// GIVEN
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [firstHealthCertificate, secondHealthCertificate],
 			isPreferredPerson: true,
-			boosterRule: .fake(identifier: "Booster Rule Identifier 0815"),
+			dccWalletInfo: dccWallet,
+			mostRecentWalletInfoUpdateFailed: true,
+			boosterRule: boosterRule,
 			isNewBoosterRule: true
 		)
 
@@ -109,7 +114,12 @@ class HealthCertifiedPersonTests: CWATestCase {
 		let decodedHealthCertifiedPerson = try JSONDecoder().decode(HealthCertifiedPerson.self, from: jsonData)
 
 		// THEN
-		XCTAssertEqual(decodedHealthCertifiedPerson, healthCertifiedPerson)
+		XCTAssertTrue(decodedHealthCertifiedPerson.isPreferredPerson)
+		XCTAssertTrue(decodedHealthCertifiedPerson.isNewBoosterRule)
+		XCTAssertEqual(decodedHealthCertifiedPerson.boosterRule, boosterRule)
+		XCTAssertEqual(decodedHealthCertifiedPerson.dccWalletInfo, dccWallet)
+		XCTAssertTrue(decodedHealthCertifiedPerson.mostRecentWalletInfoUpdateFailed)
+		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates, [firstHealthCertificate, secondHealthCertificate])
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateService+GroupingAfterDeletionTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateService+GroupingAfterDeletionTests.swift
@@ -150,7 +150,7 @@ class HealthCertificateService_GroupingAfterDeletionTests: XCTestCase {
 		
 		// We should have now 3 persons. Person1 with three certificates, and Person2 and Person3 with each one certificate.
 		XCTAssertEqual(service.healthCertifiedPersons.count, 3)
-		XCTAssertTrue(service.healthCertifiedPersons.contains(where: { $0 === originalPerson }))
+		XCTAssertTrue(service.healthCertifiedPersons.contains(originalPerson))
 		
 		let donald = service.healthCertifiedPersons[0]
 		let quack = service.healthCertifiedPersons[1]

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
@@ -499,15 +499,15 @@ class HealthCertificateServiceTests: CWATestCase {
 
 		service.updatePublishersFromStore()
 
-		XCTAssertEqual(service.healthCertifiedPersons, [
-			HealthCertifiedPerson(healthCertificates: [
+		XCTAssertEqual(service.healthCertifiedPersons.map { $0.healthCertificates }, [
+			[
 				healthCertificate1, healthCertificate2
-			]),
-			HealthCertifiedPerson(healthCertificates: [
+			],
+			[
 				healthCertificate3
-			])
+			]
 		])
-		XCTAssertEqual(service.healthCertifiedPersons, store.healthCertifiedPersons)
+		XCTAssertEqual(service.healthCertifiedPersons.map { $0.healthCertificates }, store.healthCertifiedPersons.map { $0.healthCertificates })
 
 		// Removing one of multiple certificates
 
@@ -524,7 +524,7 @@ class HealthCertificateServiceTests: CWATestCase {
 				]
 			]
 		)
-		XCTAssertEqual(service.healthCertifiedPersons, store.healthCertifiedPersons)
+		XCTAssertEqual(service.healthCertifiedPersons.map { $0.healthCertificates }, store.healthCertifiedPersons.map { $0.healthCertificates })
 
 		// Removing last certificate of a person
 
@@ -538,7 +538,7 @@ class HealthCertificateServiceTests: CWATestCase {
 				]
 			]
 		)
-		XCTAssertEqual(service.healthCertifiedPersons, store.healthCertifiedPersons)
+		XCTAssertEqual(service.healthCertifiedPersons.map { $0.healthCertificates }, store.healthCertifiedPersons.map { $0.healthCertificates })
 
 		// Removing last certificate of last person
 


### PR DESCRIPTION
## Description
Main fix 1: Compare after swipe to delete on one certificate if we need to delete more certificates because the person splits afterwards. 
Main fix 2: Replaces equatable compare between healthCertifiedPersons on their attributes by their reference.
Fixes then every occurrence of the identity operator between persons and use the equal operator.
Fixes also some tests where we cannot longer check between persons and instead we check now their properties. 
