### PR TITLE
Downgrade OpenCombine

### DIFF
--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
         "state": {
           "branch": null,
-          "revision": "9cf67e363738dbab61b47fb5eaed78d3db31e5ee",
-          "version": "0.13.0"
+          "revision": "28993ae57de5a4ea7e164787636cafad442d568c",
+          "version": "0.12.0"
         }
       },
       {

--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -13039,7 +13039,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/OpenCombine/OpenCombine.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.12.0;
 			};
 		};


### PR DESCRIPTION
## Description
Since Xcode 13.2 and 13.2.1 will produce a crashing binary for iOS 12 if the code contains even a hint auf async/await apis, this downgrades OpenCombine to remove any async/await api calls
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12024

