### PR TITLE
Feature/xxx add logging for reissuance error handling

### DIFF
--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
@@ -102,6 +102,7 @@ struct DCCReissuanceResource: Resource {
 	}
 
 	private func unexpectedServerError(_ statusCode: Int) -> DCCReissuanceResourceError? {
+		Log.error("DCCReissuance error status code: \(statusCode)")
 		switch statusCode {
 		case 400:
 			return .DCC_RI_400

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
@@ -70,7 +70,7 @@ struct DCCReissuanceResource: Resource {
 	var sendResource: JSONSendResource<DCCReissuanceSendModel>
 	var receiveResource: JSONReceiveResource<DCCReissuanceReceiveModel>
 
-	func customError(for error: ServiceError<DCCReissuanceResourceError>) -> DCCReissuanceResourceError? {
+	func customError(for error: ServiceError<DCCReissuanceResourceError>, responseBody: Data?) -> DCCReissuanceResourceError? {
 		switch error {
 		case .trustEvaluationError(let trustError):
 			return trustEvaluationErrorHandling(trustError)

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
@@ -9,12 +9,12 @@ enum DCCReissuanceResourceError: LocalizedError {
 	case DCC_RI_PIN_MISMATCH
 	case DCC_RI_PARSE_ERR
 	case DCC_RI_NO_NETWORK
-	case DCC_RI_400
-	case DCC_RI_401
-	case DCC_RI_403
-	case DCC_RI_406
-	case DCC_RI_429
-	case DCC_RI_500
+	case DCC_RI_400(ErrorCode?)
+	case DCC_RI_401(ErrorCode?)
+	case DCC_RI_403(ErrorCode?)
+	case DCC_RI_406(ErrorCode?)
+	case DCC_RI_429(ErrorCode?)
+	case DCC_RI_500(ErrorCode?)
 	case DCC_RI_CLIENT_ERR
 	case DCC_RI_SERVER_ERR
 
@@ -110,26 +110,28 @@ struct DCCReissuanceResource: Resource {
 		_ statusCode: Int,
 		_ responseBody: Data?
 	) -> DCCReissuanceResourceError? {
+		var errorCode: ErrorCode?
 		if let data = responseBody,
-		   let errorCode = try? JSONDecoder().decode(ErrorCode.self, from: data) {
-			Log.error("DCCReissuance error status code: \(statusCode), with ErrorCode model: \(errorCode)")
+		   let customErrorCode = try? JSONDecoder().decode(ErrorCode.self, from: data) {
+			errorCode = customErrorCode
+			Log.error("DCCReissuance error status code: \(statusCode), with ErrorCode model: \(customErrorCode)")
 		}
 
 		switch statusCode {
 		case 400:
-			return .DCC_RI_400
+			return .DCC_RI_400(errorCode)
 		case 401:
-			return .DCC_RI_401
+			return .DCC_RI_401(errorCode)
 		case 403:
-			return .DCC_RI_403
+			return .DCC_RI_403(errorCode)
 		case 406:
-			return .DCC_RI_406
+			return .DCC_RI_406(errorCode)
 		case 429:
-			return .DCC_RI_429
+			return .DCC_RI_429(errorCode)
 		case 402, 404, 405, 407...428, 430...499:
 			return .DCC_RI_CLIENT_ERR
 		case 500:
-			return .DCC_RI_500
+			return .DCC_RI_500(errorCode)
 		case (501...599):
 			return .DCC_RI_SERVER_ERR
 		default:

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/DCCReissuanceResource.swift
@@ -26,18 +26,24 @@ enum DCCReissuanceResourceError: LocalizedError {
 			return "\(AppStrings.HealthCertificate.Reissuance.Errors.contactSupport) (DCC_RI_PARSE_ERR)"
 		case .DCC_RI_NO_NETWORK:
 			return "\(AppStrings.HealthCertificate.Reissuance.Errors.noNetwork) (DCC_RI_NO_NETWORK)"
-		case .DCC_RI_400:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_400)"
-		case .DCC_RI_401:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.notSupported) (DCC_RI_401)"
-		case .DCC_RI_403:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.notSupported) (DCC_RI_403)"
-		case .DCC_RI_406:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_406)"
-		case .DCC_RI_429:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_429)"
-		case .DCC_RI_500:
-			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_500)"
+		case .DCC_RI_400(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_400)" + description
+		case .DCC_RI_401(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.notSupported) (DCC_RI_401)" + description
+		case .DCC_RI_403(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.notSupported) (DCC_RI_403)" + description
+		case .DCC_RI_406(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_406)" + description
+		case .DCC_RI_429(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_429)" + description
+		case .DCC_RI_500(let errorCode):
+			let description = errorCode?.description ?? ""
+			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_500)" + description
 		case .DCC_RI_CLIENT_ERR:
 			return "\(AppStrings.HealthCertificate.Reissuance.Errors.tryAgain) (DCC_RI_CLIENT_ERR)"
 		case .DCC_RI_SERVER_ERR:
@@ -46,9 +52,13 @@ enum DCCReissuanceResourceError: LocalizedError {
 	}
 }
 
-struct ErrorCode: Decodable {
+struct ErrorCode: Decodable, CustomStringConvertible {
 	let errorCode: String
 	let message: String
+
+	var description: String {
+		"\n\(errorCode): \(message)"
+	}
 }
 
 struct DCCReissuanceResource: Resource {

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
@@ -164,6 +164,7 @@ final class DCCReissuanceResourceTests: CWATestCase {
 					XCTFail("DCC_RI_400 error expected. Instead error received: \(error)")
 					return
 				}
+				XCTAssertEqual(errorCode?.description, "\nRI400-1200: certificates not acceptable for action")
 				XCTAssertEqual(errorCode?.errorCode, "RI400-1200")
 				XCTAssertEqual(errorCode?.message, "certificates not acceptable for action")
 			}

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
@@ -131,6 +131,47 @@ final class DCCReissuanceResourceTests: CWATestCase {
 		waitForExpectations(timeout: .short)
 	}
 
+	func testGIVEN_Resource_WHEN_Response_400WithErrorCode_THEN_DCC_RI_400() throws {
+		let expectation = expectation(description: "Expect that we got an error")
+
+		let stack = MockNetworkStack(
+			httpStatus: 400,
+			responseData: "{\"errorCode\":\"RI400-1200\",\"message\":\"certificates not acceptable for action\"}".data(using: .utf8)
+		)
+
+		let restServiceProvider = RestServiceProvider(
+			session: stack.urlSession,
+			cache: KeyValueCacheFake()
+		)
+
+		let sendModel = DCCReissuanceSendModel(
+			certificates: [
+				"one"
+			]
+		)
+
+		let resource = DCCReissuanceResource(
+			sendModel: sendModel,
+			trustEvaluation: .fake()
+		)
+
+		restServiceProvider.load(resource) { result in
+			switch result {
+			case .success:
+				XCTFail("Failure expected.")
+			case .failure(let error):
+				guard case .receivedResourceError(.DCC_RI_400(let errorCode)) = error else {
+					XCTFail("DCC_RI_400 error expected. Instead error received: \(error)")
+					return
+				}
+				XCTAssertEqual(errorCode?.errorCode, "RI400-1200")
+				XCTAssertEqual(errorCode?.message, "certificates not acceptable for action")
+			}
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: .short)
+	}
+
 	func testGIVEN_Resource_WHEN_Response_400_THEN_DCC_RI_400() throws {
 		let expectation = expectation(description: "Expect that we got an error")
 

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCReissuance/__tests__/DCCReissuanceResourceTests.swift
@@ -135,7 +135,8 @@ final class DCCReissuanceResourceTests: CWATestCase {
 		let expectation = expectation(description: "Expect that we got an error")
 
 		let stack = MockNetworkStack(
-			httpStatus: 400
+			httpStatus: 400,
+			responseData: try JSONEncoder().encode("{\"errorCode\":\"RI400-1200\",\"message\":\"certificates not acceptable for action\"}")
 		)
 
 		let restServiceProvider = RestServiceProvider(

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCRules/DCCRulesResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/DCCRules/DCCRulesResource.swift
@@ -53,7 +53,10 @@ struct DCCRulesResource: Resource {
 	var sendResource: EmptySendResource
 	var receiveResource: CBORReceiveResource<DCCRulesReceiveModel>
 
-	func customError(for error: ServiceError<DCCDownloadRulesError>) -> DCCDownloadRulesError? {
+	func customError(
+		for error: ServiceError<DCCDownloadRulesError>,
+		responseBody: Data? = nil
+	) -> DCCDownloadRulesError? {
 		switch error {
 		case .transportationError:
 			return .NO_NETWORK

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/RegistrationToken/RegistrationTokenResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/RegistrationToken/RegistrationTokenResource.swift
@@ -47,7 +47,10 @@ struct RegistrationTokenResource: Resource {
 	var sendResource: PaddingJSONSendResource<RegistrationTokenSendModel>
 	var receiveResource: JSONReceiveResource<RegistrationTokenReceiveModel>
 	
-	func customError(for error: ServiceError<RegistrationTokenError>) -> RegistrationTokenError? {
+	func customError(
+		for error: ServiceError<RegistrationTokenError>,
+		responseBody: Data? = nil
+	) -> RegistrationTokenError? {
 		switch error {
 		case .unexpectedServerError(let statusCode):
 			switch statusCode {

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ServiceIdentityDocument/ServiceIdentityDocumentResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ServiceIdentityDocument/ServiceIdentityDocumentResource.swift
@@ -33,7 +33,10 @@ struct ServiceIdentityDocumentResource: Resource {
 	var sendResource: EmptySendResource
 	var receiveResource: JSONReceiveResource<TicketValidationServiceIdentityDocument>
 	
-	func customError(for error: ServiceError<ServiceIdentityDocumentResourceError>) -> ServiceIdentityDocumentResourceError? {
+	func customError(
+		for error: ServiceError<ServiceIdentityDocumentResourceError>,
+		responseBody: Data? = nil
+	) -> ServiceIdentityDocumentResourceError? {
 		switch error {
 		case .trustEvaluationError(let trustEvaluationError):
 			return trustEvaluationErrorHandling(trustEvaluationError)

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ServiceIdentityDocumentValidationDecorator/ServiceIdentityDocumentValidationDecoratorResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ServiceIdentityDocumentValidationDecorator/ServiceIdentityDocumentValidationDecoratorResource.swift
@@ -33,7 +33,10 @@ struct ServiceIdentityDocumentValidationDecoratorResource: Resource {
 	var sendResource: EmptySendResource
 	var receiveResource: JSONReceiveResource<TicketValidationServiceIdentityDocument>
 	
-	func customError(for error: ServiceError<ServiceIdentityResourceDecoratorError>) -> ServiceIdentityResourceDecoratorError? {
+	func customError(
+		for error: ServiceError<ServiceIdentityResourceDecoratorError>,
+		responseBody: Data? = nil
+	) -> ServiceIdentityResourceDecoratorError? {
 		switch error {
 		case .unexpectedServerError(let statusCode):
 			switch statusCode {

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TeleTan/TeleTanResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TeleTan/TeleTanResource.swift
@@ -37,7 +37,10 @@ struct TeleTanResource: Resource {
 	var sendResource: PaddingJSONSendResource<TeleTanSendModel>
 	var receiveResource: JSONReceiveResource<TeleTanReceiveModel>
 
-	func customError(for error: ServiceError<TeleTanError>) -> TeleTanError? {
+	func customError(
+		for error: ServiceError<TeleTanError>,
+		responseBody: Data? = nil
+	) -> TeleTanError? {
 		switch error {
 		case .unexpectedServerError(let statusCode):
 			switch (keyModel.keyType, statusCode) {

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TicketValidationAccessToken/TicketValidationAccessTokenResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TicketValidationAccessToken/TicketValidationAccessTokenResource.swift
@@ -34,7 +34,10 @@ struct TicketValidationAccessTokenResource: Resource {
 	var sendResource: JSONSendResource<TicketValidationAccessTokenSendModel>
 	var receiveResource: StringReceiveResource<TicketValidationAccessTokenReceiveModel>
 
-	func customError(for error: ServiceError<TicketValidationAccessTokenError>) -> TicketValidationAccessTokenError? {
+	func customError(
+		for error: ServiceError<TicketValidationAccessTokenError>,
+		responseBody: Data? = nil
+	) -> TicketValidationAccessTokenError? {
 		switch error {
 		case .trustEvaluationError(let trustEvaluationError):
 			return trustEvaluationErrorHandling(trustEvaluationError)

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TicketValidationResult/TicketValidationResultTokenResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/TicketValidationResult/TicketValidationResultTokenResource.swift
@@ -31,7 +31,10 @@ struct TicketValidationResultTokenResource: Resource {
 	var sendResource: JSONSendResource<TicketValidationResultTokenSendModel>
 	var receiveResource: StringReceiveResource<TicketValidationAccessTokenReceiveModel>
 
-	func customError(for error: ServiceError<TicketValidationResultTokenError>) -> TicketValidationResultTokenError? {
+	func customError(
+		for error: ServiceError<TicketValidationResultTokenError>,
+		responseBody: Data? = nil
+	) -> TicketValidationResultTokenError? {
 		switch error {
 		case .trustEvaluationError(let trustEvaluationError):
 			return trustEvaluationErrorHandling(trustEvaluationError)

--- a/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ValidationOnboardedCountries/ValidationOnboardedCountriesResource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClient/Resources/ValidationOnboardedCountries/ValidationOnboardedCountriesResource.swift
@@ -35,7 +35,10 @@ struct ValidationOnboardedCountriesResource: Resource {
 	var sendResource: EmptySendResource
 	var receiveResource: CBORReceiveResource<ValidationOnboardedCountriesReceiveModel>
 	
-	func customError(for error: ServiceError<ValidationOnboardedCountriesError>) -> ValidationOnboardedCountriesError? {
+	func customError(
+		for error: ServiceError<ValidationOnboardedCountriesError>,
+		responseBody: Data? = nil
+	) -> ValidationOnboardedCountriesError? {
 		switch error {
 		case .transportationError:
 			return .ONBOARDED_COUNTRIES_NO_NETWORK

--- a/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Resource/_Resource.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Resource/_Resource.swift
@@ -20,7 +20,7 @@ protocol Resource {
 	
 	var trustEvaluation: TrustEvaluating { get }
 	
-	func customError(for error: ServiceError<CustomError>) -> CustomError?
+	func customError(for error: ServiceError<CustomError>, responseBody: Data?) -> CustomError?
 	
 #if !RELEASE
 	/// Used to define a default mock Resource to be returned by the resource if needed (e.g. UITests)
@@ -37,7 +37,7 @@ extension Resource {
 		nil
 	}
 
-	func customError(for error: ServiceError<CustomError>) -> CustomError? {
+	func customError(for error: ServiceError<CustomError>, responseBody: Data?) -> CustomError? {
 		return nil
 	}
 }

--- a/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Services/_Service+Default.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Services/_Service+Default.swift
@@ -246,7 +246,7 @@ extension Service {
 		} else {
 			// We don't have a default value. And now check if we want to override the error by a custom error defined in the resource
 			Log.error("Found no default value. Will fail now.", log: .client, error: error)
-			return .failure(customError(in: resource, for: error))
+			return .failure(customError(in: resource, for: error, responseData))
 		}
 	}
 	

--- a/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Services/_Service+Default.swift
+++ b/src/xcode/ENA/ENA/Source/HTTPClientCore/Service/Services/_Service+Default.swift
@@ -125,7 +125,7 @@ extension Service {
 				case 304:
 					completion(cached(resource))
 				default:
-					completion(failureOrDefaultValueHandling(resource, .unexpectedServerError(response.statusCode)))
+					completion(failureOrDefaultValueHandling(resource, .unexpectedServerError(response.statusCode), bodyData))
 				}
 			}
 			
@@ -208,9 +208,10 @@ extension Service {
 	///   - serviceError: The error that would be thrown with the fail.
 	func customError<R>(
 		in resource: R,
-		for serviceError: ServiceError<R.CustomError>
+		for serviceError: ServiceError<R.CustomError>,
+		_ responseData: Data? = nil
 	) -> ServiceError<R.CustomError> where R: Resource {
-		if let customError = resource.customError(for: serviceError) {
+		if let customError = resource.customError(for: serviceError, responseBody: responseData) {
 			return .receivedResourceError(customError)
 		} else {
 			return serviceError
@@ -225,7 +226,8 @@ extension Service {
 	///   - completion: Swift-Result of loading. If successful, it contains the concrete object of our call.
 	func failureOrDefaultValueHandling<R>(
 		_ resource: R,
-		_ error: ServiceError<R.CustomError>
+		_ error: ServiceError<R.CustomError>,
+		_ responseData: Data? = nil
 	) -> Result<R.Receive.ReceiveModel, ServiceError<R.CustomError>> where R: Resource {
 		// Check if we have default value. If so, return it independent wich error we had
 		if let defaultModel = resource.defaultModel {

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Reissuance/ReissuanceConsent/__tests__/HealthCertificateReissuanceConsentViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Reissuance/ReissuanceConsent/__tests__/HealthCertificateReissuanceConsentViewModelTests.swift
@@ -403,7 +403,7 @@ class HealthCertificateReissuanceConsentViewModelTests: CWATestCase {
 			loadResources: [
 				   LoadResource(
 					result: .failure(
-						ServiceError.receivedResourceError(DCCReissuanceResourceError.DCC_RI_400)
+						ServiceError.receivedResourceError(DCCReissuanceResourceError.DCC_RI_400(nil))
 					),
 					   willLoadResource: nil
 				   )


### PR DESCRIPTION
## Description
Extended custom error handling of resources with response body data. The resource can decide what to do with it - at the moment we try to create an errorCode model and log the state.
Also the errorCode models description should appear inside an alert - not tested, because it's hard to setup that case.
Added a new Unittest to check if handling of ErrorCode models work.

## Link to Jira
No jira issue exists, only a change in the tech spec was given
https://github.com/corona-warn-app/cwa-app-tech-spec/pull/154/commits/e0302a180bfa9aad8693f3835171d711f3318898

## Screenshots
*Notice: The alert is faked, so the text is not matching the error*

![Screen Shot 2022-03-07 at 17 22 45](https://user-images.githubusercontent.com/2675578/157075150-d85b62bd-1687-4cd3-8f54-ce4538ccc1cc.png)

