### PR TITLE
Trigger CircleCI - MDC tests

### DIFF
--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -222,6 +222,12 @@ platform :ios do
       --header 'Authorization: Bearer #{ENV["TSI_CLOUD_TOKEN"]}' \
       --form 'file=@../ENA.ipa'"
     )
+
+    # Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)
+    sh("curl -u '#{ENV["CIRCLE_API_ADMIN_TOKEN"]}': \
+      -d 'build_parameters[CIRCLE_JOB]=android' \
+      https://circleci.com/api/v1.1/project/github/corona-warn-app/cwa-app-automation/tree/main"
+    )
   end
 
   desc "Update GitHub Pages"

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -225,7 +225,7 @@ platform :ios do
 
     # Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)
     sh("curl -u '#{ENV["CIRCLE_API_ADMIN_TOKEN"]}': \
-      -d 'build_parameters[CIRCLE_JOB]=android' \
+      -d 'build_parameters[CIRCLE_JOB]=ios' \
       https://circleci.com/api/v1.1/project/github/corona-warn-app/cwa-app-automation/tree/main"
     )
   end


### PR DESCRIPTION
Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)

see:
* https://github.com/corona-warn-app/cwa-app-android/pull/4923
* https://github.com/corona-warn-app/cwa-app-automation/pull/17