### PR TITLE
Fix/ 12195 certificate marked as new

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewController.swift
@@ -48,8 +48,8 @@ class HealthCertificateViewController: UIViewController, UITableViewDataSource, 
 		setupViewModel()
 	}
 
-	override func viewDidDisappear(_ animated: Bool) {
-		super.viewDidDisappear(animated)
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
 
 		viewModel.markAsSeen()
 	}


### PR DESCRIPTION
## Description
Fixing the issue of certificate marked as new after restoring from recycle bin

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12195

## Screenshots
https://user-images.githubusercontent.com/77438487/158394728-f750a7e8-2fd7-450b-b5f0-56a1a25e755f.mp4


