### PR TITLE
Migrate missing content hugging and compression resistance priorities

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/AdmissionState/RoundedLabeledView/RoundedLabeledView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/AdmissionState/RoundedLabeledView/RoundedLabeledView.swift
@@ -9,9 +9,18 @@ class RoundedLabeledView: UIView {
 	override init(frame: CGRect) {
 		super.init(frame: frame)
 
+		setContentHuggingPriority(.required, for: .horizontal)
+		setContentHuggingPriority(.required, for: .vertical)
+		setContentCompressionResistancePriority(.init(rawValue: 999), for: .horizontal)
+		setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+
 		gradientView.translatesAutoresizingMaskIntoConstraints = false
 		addSubview(gradientView)
 
+		titleLabel.setContentHuggingPriority(.required, for: .horizontal)
+		titleLabel.setContentHuggingPriority(.required, for: .vertical)
+		titleLabel.setContentCompressionResistancePriority(.init(rawValue: 999), for: .horizontal)
+		titleLabel.setContentCompressionResistancePriority(.init(rawValue: 760), for: .vertical)
 		titleLabel.translatesAutoresizingMaskIntoConstraints = false
 		gradientView.addSubview(titleLabel)
 


### PR DESCRIPTION
## Description
Adds back the missing content hugging and compression resistance priorities from the xib file we previously used for the admission state badge.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12335

## Screenshots
![IMG_A40BB3AF655C-1](https://user-images.githubusercontent.com/1157991/158990819-cfc3c569-f310-4e13-8c30-87fec807ee7c.jpeg)
![IMG_A40BB3AF655C-2](https://user-images.githubusercontent.com/1157991/158990829-0f70fb70-3914-4ebc-bc17-0ef91836f5cd.jpeg)

