### PR TITLE
Use configurable amount of days for "risk status lowered" alert

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1377,7 +1377,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "Home_Alert_RiskStatusLowered_Title" = "Änderung Ihres Risikostatus";
 
-"Home_Alert_RiskStatusLowered_Message" = "Die Risiko-Begegnung, die zu einem erhöhten Risiko für Sie geführt hat, liegt mehr als 14 Tage zurück. Daher wird das Infektionsrisiko wieder als niedrig für Sie eingestuft.\n\nSo verhalten Sie sich richtig:\n Wenn Sie keine Symptome von COVID-19 aufweisen, halten Sie sich an die allgemein geltenden Verhaltensregeln zu Abstand und Hygiene.\n Wenn Sie Symptome von COVID-19 aufweisen, empfehlen wir, dass Sie Ihren Arzt aufsuchen und sich testen lassen.";
+"Home_Alert_RiskStatusLowered_Message" = "Die Risiko-Begegnung, die zu einem erhöhten Risiko für Sie geführt hat, liegt mehr als %i Tage zurück. Daher wird das Infektionsrisiko wieder als niedrig für Sie eingestuft.\n\nSo verhalten Sie sich richtig:\n Wenn Sie keine Symptome von COVID-19 aufweisen, halten Sie sich an die allgemein geltenden Verhaltensregeln zu Abstand und Hygiene.\n Wenn Sie Symptome von COVID-19 aufweisen, empfehlen wir, dass Sie Ihren Arzt aufsuchen und sich testen lassen.";
 
 "Home_Alert_RiskStatusLowered_PrimaryButtonTitle" = "OK";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -859,9 +859,11 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			return
 		}
 
+		let currentAppConfig = appConfigurationProvider.currentAppConfig.value
+
 		let alert = UIAlertController(
 			title: AppStrings.Home.riskStatusLoweredAlertTitle,
-			message: AppStrings.Home.riskStatusLoweredAlertMessage,
+			message: String(format: AppStrings.Home.riskStatusLoweredAlertMessage, currentAppConfig.riskCalculationParameters.defaultedMaxEncounterAgeInDays),
 			preferredStyle: .alert
 		)
 


### PR DESCRIPTION
## Description
Uses `maxEncounterAgeInDays` from the app configuration for the "risk status lowered" alert

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12361

## Screenshots
![IMG_05DEFB410A0A-1](https://user-images.githubusercontent.com/1157991/159003972-38d68827-da3b-48a5-ac66-03ed6ed3e505.jpeg)

