### PR TITLE
Feature/12246 delta enf logic/12347 mark packages as checked for exposure

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -365,7 +365,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: traceWarningPackageDownload,
 			exposureDetectionExecutor: exposureDetectionExecutor,
-			coronaTestService: coronaTestService
+			coronaTestService: coronaTestService,
+			downloadedPackagesStore: downloadedPackagesStore
 		)
 		#else
 		return RiskProvider(

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
@@ -20,7 +20,9 @@ struct WrittenPackages {
 
 	// MARK: - Init
 
-	init() {
+	init(
+		_ packages: [PackageContainer] = []
+	) {
 		self.packages = []
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
@@ -5,16 +5,22 @@
 import Foundation
 
 struct WrittenPackages {
-	init(urls: [URL]) {
+
+	// MARK: - Init
+
+	init(
+		urls: [URL]
+	) {
 		self.urls = urls
 	}
 
-	var urls: [URL]
+	// MARK: - Internal
+
 	func cleanUp() {
 		guard let directoryURL = urls.first?.deletingLastPathComponent() else {
 			return
 		}
-			
+
 		let fileManager = FileManager()
 		Log.info("Removing: \(directoryURL)", log: .localData)
 
@@ -29,22 +35,26 @@ struct WrittenPackages {
 	mutating func add(_ url: URL) {
 		urls.append(url)
 	}
+
+	// MARK: - Internal
+
+	private(set) var urls: [URL]
+
 }
 
 final class AppleFilesWriter {
 
-	// MARK: Creating a Writer
+	// MARK: - Init
 
-	init(rootDir: URL) {
+	init(
+		rootDir: URL
+	) {
 		self.rootDir = rootDir
 	}
 
-	// MARK: Properties
+	// MARK: - Internal
 
 	private(set) var writtenPackages = WrittenPackages(urls: [])
-	let rootDir: URL
-
-	// MARK: Interacting with the Writer
 
 	func writePackage(_ keyPackage: SAPDownloadedPackage) -> Bool {
 		do {
@@ -59,6 +69,11 @@ final class AppleFilesWriter {
 			return false
 		}
 	}
+
+	// MARK: - Private
+
+	private let rootDir: URL
+
 }
 
 private extension SAPDownloadedPackage {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
@@ -49,7 +49,8 @@ struct WrittenPackages {
 	}
 
 	var fingerprints: [String] {
-		packages.map { $0.hash }
+		packages.filter { $0.type == .keys }
+			.map { $0.hash }
 	}
 
 	var urls: [URL] {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
@@ -46,6 +46,10 @@ struct WrittenPackages {
 		packages.append(container)
 	}
 
+	var fingerprints: [String] {
+		packages.map { $0.hash }
+	}
+
 	var urls: [URL] {
 		packages.map { $0.url }
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/AppleFilesWriter.swift
@@ -48,7 +48,7 @@ struct WrittenPackages {
 		packages.append(container)
 	}
 
-	var fingerprints: [String] {
+	var keyFingerprints: [String] {
 		packages.filter { $0.type == .keys }
 			.map { $0.hash }
 	}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -13,11 +13,13 @@ final class ExposureDetection {
 	init(
 		delegate: ExposureDetectionDelegate,
 		appConfiguration: SAP_Internal_V2_ApplicationConfigurationIOS,
-		deviceTimeCheck: DeviceTimeChecking
+		deviceTimeCheck: DeviceTimeChecking,
+		downloadedPackagesStore: DownloadedPackagesStore
 	) {
 		self.delegate = delegate
 		self.appConfiguration = appConfiguration
 		self.deviceTimeCheck = deviceTimeCheck
+		self.downloadedPackagesStore = downloadedPackagesStore
 	}
 
 	// MARK: - Internal
@@ -56,6 +58,7 @@ final class ExposureDetection {
 	// There was a decision not to use the 2 letter code "EU", but instead "EUR".
 	// Please see this story for more information: https://jira.itc.sap.com/browse/EXPOSUREBACK-151
 	private let country = "EUR"
+	private let downloadedPackagesStore: DownloadedPackagesStore
 
 	private weak var delegate: ExposureDetectionDelegate?
 	private var completion: Completion?
@@ -85,7 +88,11 @@ final class ExposureDetection {
 
 				switch result {
 				case .success(let exposureWindows):
-					keyPackageDownload.markPackagesAsCheckedForExposures(writtenPackages.fingerprints)
+					do {
+						try self?.downloadedPackagesStore.markPackagesAsCheckedForExposures(writtenPackages.fingerprints)
+					} catch {
+						Log.error("Failed to markPackagesAsCheckedForExposures")
+					}
 					self?.didDetectExposureWindows(exposureWindows)
 				case .failure(let error):
 					self?.endPrematurely(reason: .noExposureWindows(error))

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -50,20 +50,17 @@ final class ExposureDetection {
 		progress = delegate?.detectExposureWindows(
 			self,
 			detectSummaryWithConfiguration: exposureConfiguration,
-			writtenPackages: writtenPackages
-		) { [weak self] result in
-			writtenPackages.cleanUp()
-			self?.useExposureWindowsResult(result)
-		}
-	}
-
-	private func useExposureWindowsResult(_ result: Result<[ENExposureWindow], Error>) {
-		switch result {
-		case .success(let exposureWindows):
-			didDetectExposureWindows(exposureWindows)
-		case .failure(let error):
-			endPrematurely(reason: .noExposureWindows(error))
-		}
+			writtenPackages: writtenPackages,
+			completion: { [weak self] result in
+				writtenPackages.cleanUp()
+				switch result {
+				case .success(let exposureWindows):
+					self?.didDetectExposureWindows(exposureWindows)
+				case .failure(let error):
+					self?.endPrematurely(reason: .noExposureWindows(error))
+				}
+			}
+		)
 	}
 
 	typealias Completion = (Result<[ENExposureWindow], DidEndPrematurelyReason>) -> Void

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -8,18 +8,8 @@ import Foundation
 /// Every time the user wants to know the own risk the app creates an `ExposureDetection`.
 final class ExposureDetection {
 
-	// MARK: Properties
-	private weak var delegate: ExposureDetectionDelegate?
-	private var completion: Completion?
-	private var progress: Progress?
-	private let appConfiguration: SAP_Internal_V2_ApplicationConfigurationIOS
-	private let deviceTimeCheck: DeviceTimeChecking
+	// MARK: - Init
 
-	// There was a decision not to use the 2 letter code "EU", but instead "EUR".
-	// Please see this story for more information: https://jira.itc.sap.com/browse/EXPOSUREBACK-151
-	private let country = "EUR"
-
-	// MARK: Creating a Transaction
 	init(
 		delegate: ExposureDetectionDelegate,
 		appConfiguration: SAP_Internal_V2_ApplicationConfigurationIOS,
@@ -30,9 +20,46 @@ final class ExposureDetection {
 		self.deviceTimeCheck = deviceTimeCheck
 	}
 
+	// MARK: - Internal
+
+	typealias Completion = (Result<[ENExposureWindow], DidEndPrematurelyReason>) -> Void
+
+	func start(_ keyPackageDownload: KeyPackageDownloadProtocol, completion: @escaping Completion) {
+		self.completion = completion
+
+		Log.info("ExposureDetection: Start writing packages to file system.", log: .riskDetection)
+
+		writeKeyPackagesToFileSystem { [weak self] writtenPackages in
+			guard let self = self else { return }
+
+			Log.info("ExposureDetection: Completed writing packages to file system.", log: .riskDetection)
+
+			if !self.deviceTimeCheck.isDeviceTimeCorrect {
+				Log.warning("ExposureDetection: Detecting exposure windows skipped due to wrong device time.", log: .riskDetection)
+				self.endPrematurely(reason: .wrongDeviceTime)
+			} else {
+				Log.info("ExposureDetection: Start detecting exposure windows.", log: .riskDetection)
+				let exposureConfiguration = ENExposureConfiguration(from: appConfiguration.exposureConfiguration)
+				self.detectExposureWindows(keyPackageDownload, writtenPackages: writtenPackages, exposureConfiguration: exposureConfiguration)
+			}
+		}
+	}
+
 	func cancel() {
 		progress?.cancel()
 	}
+
+	// MARK: - Private
+
+	private let appConfiguration: SAP_Internal_V2_ApplicationConfigurationIOS
+	private let deviceTimeCheck: DeviceTimeChecking
+	// There was a decision not to use the 2 letter code "EU", but instead "EUR".
+	// Please see this story for more information: https://jira.itc.sap.com/browse/EXPOSUREBACK-151
+	private let country = "EUR"
+
+	private weak var delegate: ExposureDetectionDelegate?
+	private var completion: Completion?
+	private var progress: Progress?
 
 	private func writeKeyPackagesToFileSystem(completion: (WrittenPackages) -> Void) {
 		if let writtenPackages = self.delegate?.exposureDetectionWriteDownloadedPackages(country: country) {
@@ -42,7 +69,7 @@ final class ExposureDetection {
 		}
 	}
 
-	private func detectExposureWindows(writtenPackages: WrittenPackages, exposureConfiguration: ENExposureConfiguration) {
+	private func detectExposureWindows(_ keyPackageDownload: KeyPackageDownloadProtocol, writtenPackages: WrittenPackages, exposureConfiguration: ENExposureConfiguration) {
 		if progress != nil {
 			Log.error("previous running progress found, will try to cancel", log: .riskDetection)
 			progress?.cancel()
@@ -52,9 +79,13 @@ final class ExposureDetection {
 			detectSummaryWithConfiguration: exposureConfiguration,
 			writtenPackages: writtenPackages,
 			completion: { [weak self] result in
-				writtenPackages.cleanUp()
+				defer {
+					writtenPackages.cleanUp()
+				}
+
 				switch result {
 				case .success(let exposureWindows):
+					keyPackageDownload.markPackagesAsCheckedForExposures(writtenPackages.fingerprints)
 					self?.didDetectExposureWindows(exposureWindows)
 				case .failure(let error):
 					self?.endPrematurely(reason: .noExposureWindows(error))
@@ -62,31 +93,6 @@ final class ExposureDetection {
 			}
 		)
 	}
-
-	typealias Completion = (Result<[ENExposureWindow], DidEndPrematurelyReason>) -> Void
-
-    func start(completion: @escaping Completion) {
-        self.completion = completion
-
-        Log.info("ExposureDetection: Start writing packages to file system.", log: .riskDetection)
-
-        writeKeyPackagesToFileSystem { [weak self] writtenPackages in
-            guard let self = self else { return }
-
-            Log.info("ExposureDetection: Completed writing packages to file system.", log: .riskDetection)
-
-			if !self.deviceTimeCheck.isDeviceTimeCorrect {
-				Log.warning("ExposureDetection: Detecting exposure windows skipped due to wrong device time.", log: .riskDetection)
-				self.endPrematurely(reason: .wrongDeviceTime)
-			} else {
-				Log.info("ExposureDetection: Start detecting exposure windows.", log: .riskDetection)
-				let exposureConfiguration = ENExposureConfiguration(from: appConfiguration.exposureConfiguration)
-				self.detectExposureWindows(writtenPackages: writtenPackages, exposureConfiguration: exposureConfiguration)
-			}
-        }
-    }
-	
-	// MARK: Working with the Completion Handler
 
 	// Ends the transaction prematurely with a given reason.
 	private func endPrematurely(reason: DidEndPrematurelyReason) {

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/ExposureDetection.swift
@@ -89,7 +89,7 @@ final class ExposureDetection {
 				switch result {
 				case .success(let exposureWindows):
 					do {
-						try self?.downloadedPackagesStore.markPackagesAsCheckedForExposures(writtenPackages.fingerprints)
+						try self?.downloadedPackagesStore.markPackagesAsCheckedForExposures(writtenPackages.keyFingerprints)
 					} catch {
 						Log.error("Failed to markPackagesAsCheckedForExposures")
 					}

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -79,9 +79,15 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
 			appConfiguration: config,
-			deviceTimeCheck: DeviceTimeCheck(store: store, appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(store: store, config: config))
+			deviceTimeCheck: DeviceTimeCheck(
+				store: store,
+				appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(
+					store: store,
+					config: config
+				)
+			),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
-
 		_ = sut.detectExposureWindows(
 			exposureDetection,
 			detectSummaryWithConfiguration: ENExposureConfiguration(),
@@ -115,7 +121,14 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
 			appConfiguration: config,
-			deviceTimeCheck: DeviceTimeCheck(store: store, appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(store: store, config: config))
+			deviceTimeCheck: DeviceTimeCheck(
+				store: store,
+				appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(
+					store: store,
+					config: config
+				)
+			),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		_ = sut.detectExposureWindows(
@@ -171,7 +184,14 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		let exposureDetection = ExposureDetection(
 			delegate: sut,
 			appConfiguration: config,
-			deviceTimeCheck: DeviceTimeCheck(store: store, appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(store: store, config: config))
+			deviceTimeCheck: DeviceTimeCheck(
+				store: store,
+				appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(
+					store: store,
+					config: config
+				)
+			),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		XCTAssertNotEqual(packageStore.allDays(country: "DE").count, 0)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionExecutorTests.swift
@@ -85,7 +85,7 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		_ = sut.detectExposureWindows(
 			exposureDetection,
 			detectSummaryWithConfiguration: ENExposureConfiguration(),
-			writtenPackages: WrittenPackages(urls: []),
+			writtenPackages: WrittenPackages(),
 			completion: { result in
 				defer { completionExpectation.fulfill() }
 
@@ -121,7 +121,7 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		_ = sut.detectExposureWindows(
 			exposureDetection,
 			detectSummaryWithConfiguration: ENExposureConfiguration(),
-			writtenPackages: WrittenPackages(urls: []),
+			writtenPackages: WrittenPackages(),
 			completion: { result in
 				defer { completionExpectation.fulfill() }
 
@@ -180,7 +180,7 @@ final class ExposureDetectionExecutorTests: CWATestCase {
 		_ = sut.detectExposureWindows(
 			exposureDetection,
 			detectSummaryWithConfiguration: ENExposureConfiguration(),
-			writtenPackages: WrittenPackages(urls: []),
+			writtenPackages: WrittenPackages(),
 			completion: { _ in
 				XCTAssertEqual(packageStore.allDays(country: "DE").count, 0)
 				XCTAssertNil(store.appConfigMetadata)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Transaction/__tests__/ExposureDetectionTests.swift
@@ -56,7 +56,14 @@ final class ExposureDetectionTransactionTests: CWATestCase {
 		let detection = ExposureDetection(
 			delegate: delegate,
 			appConfiguration: config,
-			deviceTimeCheck: DeviceTimeCheck(store: store, appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(store: store, config: config))
+			deviceTimeCheck: DeviceTimeCheck(
+				store: store,
+				appFeatureProvider: AppFeatureDeviceTimeCheckDecorator.mock(
+					store: store,
+					config: config
+				)
+			),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		detection.start(
 			keyPackageDownload,

--- a/src/xcode/ENA/ENA/Source/Services/Risk/KeyPackageDownload/KeyPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/KeyPackageDownload/KeyPackageDownload.swift
@@ -9,8 +9,6 @@ protocol KeyPackageDownloadProtocol {
 
 	func startDayPackagesDownload(completion: @escaping (Result<Void, KeyPackageDownloadError>) -> Void)
 	func startHourPackagesDownload(completion: @escaping (Result<Void, KeyPackageDownloadError>) -> Void)
-
-	func markPackagesAsCheckedForExposures(_ fingerprints: [String])
 }
 
 enum KeyPackageDownloadError: Error {
@@ -118,14 +116,6 @@ class KeyPackageDownload: KeyPackageDownloadProtocol {
 				Log.error("KeyPackageDownload: Completed processing hour packages with error: \(error).", log: .riskDetection)
 				completion(.failure(error))
 			}
-		}
-	}
-
-	func markPackagesAsCheckedForExposures(_ fingerprints: [String]) {
-		do {
-			try downloadedPackagesStore.markPackagesAsCheckedForExposures(fingerprints)
-		} catch {
-			Log.error("Failed to markPackagesAsCheckedForExposures ")
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/KeyPackageDownload/KeyPackageDownload.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/KeyPackageDownload/KeyPackageDownload.swift
@@ -9,6 +9,8 @@ protocol KeyPackageDownloadProtocol {
 
 	func startDayPackagesDownload(completion: @escaping (Result<Void, KeyPackageDownloadError>) -> Void)
 	func startHourPackagesDownload(completion: @escaping (Result<Void, KeyPackageDownloadError>) -> Void)
+
+	func markPackagesAsCheckedForExposures(_ fingerprints: [String])
 }
 
 enum KeyPackageDownloadError: Error {
@@ -116,6 +118,14 @@ class KeyPackageDownload: KeyPackageDownloadProtocol {
 				Log.error("KeyPackageDownload: Completed processing hour packages with error: \(error).", log: .riskDetection)
 				completion(.failure(error))
 			}
+		}
+	}
+
+	func markPackagesAsCheckedForExposures(_ fingerprints: [String]) {
+		do {
+			try downloadedPackagesStore.markPackagesAsCheckedForExposures(fingerprints)
+		} catch {
+			Log.error("Failed to markPackagesAsCheckedForExposures ")
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -22,7 +22,8 @@ final class RiskProvider: RiskProviding {
 		keyPackageDownload: KeyPackageDownloadProtocol,
 		traceWarningPackageDownload: TraceWarningPackageDownloading,
 		exposureDetectionExecutor: ExposureDetectionDelegate,
-		coronaTestService: CoronaTestServiceProviding
+		coronaTestService: CoronaTestServiceProviding,
+		downloadedPackagesStore: DownloadedPackagesStore
 	) {
 		self.riskProvidingConfiguration = configuration
 		self.store = store
@@ -38,6 +39,7 @@ final class RiskProvider: RiskProviding {
 		self.keyPackageDownloadStatus = .idle
 		self.traceWarningDownloadStatus = .idle
 		self.rateLimitLogger = RateLimitLogger(store: store)
+		self.downloadedPackagesStore = downloadedPackagesStore
 
 		self.registerForPackagesDownloadStatusUpdates()
 	}
@@ -161,6 +163,7 @@ final class RiskProvider: RiskProviding {
 	
 	private let queue = DispatchQueue(label: "com.sap.RiskProvider")
 	private let consumersQueue = DispatchQueue(label: "com.sap.RiskProvider.consumer")
+	private let downloadedPackagesStore: DownloadedPackagesStore
 
 	private var keyPackageDownload: KeyPackageDownloadProtocol
 	private var traceWarningPackageDownload: TraceWarningPackageDownloading
@@ -392,7 +395,8 @@ final class RiskProvider: RiskProviding {
 		exposureDetection = ExposureDetection(
 			delegate: exposureDetectionExecutor,
 			appConfiguration: appConfiguration,
-			deviceTimeCheck: appConfigurationProvider.deviceTimeCheck
+			deviceTimeCheck: appConfigurationProvider.deviceTimeCheck,
+			downloadedPackagesStore: downloadedPackagesStore
 		)
 
 		exposureDetection?.start(

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderError13Tests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderError13Tests.swift
@@ -58,7 +58,8 @@ final class RiskProviderError13Tests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		let consumer = RiskConsumer()
@@ -143,7 +144,8 @@ final class RiskProviderError13Tests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		let consumer = RiskConsumer()
@@ -229,7 +231,8 @@ final class RiskProviderError13Tests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		let consumer = RiskConsumer()
@@ -314,7 +317,8 @@ final class RiskProviderError13Tests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 
 		let consumer = RiskConsumer()

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/__tests__/RiskProviderTests.swift
@@ -48,7 +48,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: traceWarningPackageDownload,
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -124,7 +125,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: traceWarningPackageDownload,
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -200,7 +202,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: traceWarningPackageDownload,
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -263,7 +266,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let didCalculateRiskCalled = expectation(description: "expect didCalculateRisk to be called once")
@@ -313,7 +317,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let didCalculateRiskCalled = expectation(description: "expect didCalculateRisk to be called")
@@ -389,7 +394,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let requestRiskExpectation = expectation(description: "")
@@ -432,7 +438,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -487,7 +494,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -549,7 +557,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -612,7 +621,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: coronaTestService
+			coronaTestService: coronaTestService,
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let consumer = RiskConsumer()
@@ -895,7 +905,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: makeKeyPackageDownloadMock(with: store),
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 	}
@@ -961,7 +972,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: appConfigurationProvider),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 	}
 	
@@ -1037,7 +1049,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let requestRiskExpectation = expectation(description: "")
@@ -1123,7 +1136,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let requestRiskExpectation = expectation(description: "")
@@ -1211,7 +1225,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let requestRiskExpectation = expectation(description: "")
@@ -1297,7 +1312,8 @@ class RiskProviderTests: CWATestCase {
 			keyPackageDownload: keyPackageDownload,
 			traceWarningPackageDownload: makeTraceWarningPackageDownloadMock(with: store, appConfig: cachedAppConfig),
 			exposureDetectionExecutor: exposureDetectionDelegateStub,
-			coronaTestService: MockCoronaTestService()
+			coronaTestService: MockCoronaTestService(),
+			downloadedPackagesStore: DownloadedPackagesSQLLiteStore.inMemory()
 		)
 		
 		let requestRiskExpectation = expectation(description: "")


### PR DESCRIPTION
## Description
Keep fingerprints, inject keyPackageDownloader and mark packages as processed in store
Note that the written files will rebuild completely if a package is not marked as processed, so we can delete all of them

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12347

