### PR TITLE
fix failing test

### DIFF
--- a/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
@@ -580,7 +580,6 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		// Navigate to Persons Tab.
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].waitAndTap()
 
-		app.swipeUp(velocity: .slow)
 		XCTAssertTrue(app.otherElements[AccessibilityIdentifiers.HealthCertificate.AdmissionState.unseenNewsIndicator].waitForExistence(timeout: .short))
 	}
 }


### PR DESCRIPTION
## Description
fix test_AdmissionStateChanges_Then_StateChangeIndicatorIsVisible.

Reason for failure: at the time the test was written the **QRCode was still in the screen** so we had to scroll to see the admission state, but now the admission state is always visible so scrolling will cause the view to be hidden from the screen that is why it should be removed

