### PR TITLE
wait for the screen to appear before tapping

### DIFF
--- a/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
@@ -575,9 +575,7 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		app.launch()
 
 		// Navigate to Certificates Tab.
-		let certificateTab = app.buttons[AccessibilityIdentifiers.TabBar.certificates]
-		XCTAssertTrue(certificateTab.waitForExistence(timeout: .medium))
-		certificateTab.waitAndTap()
+		app.buttons[AccessibilityIdentifiers.TabBar.certificates].waitAndTap(.medium)
 
 		// Navigate to Persons Tab.
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].waitAndTap()

--- a/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/ENAUITests_13_CreateHealthCertificate.swift
@@ -575,7 +575,9 @@ class ENAUITests_13_CreateHealthCertificate: CWATestCase {
 		app.launch()
 
 		// Navigate to Certificates Tab.
-		app.buttons[AccessibilityIdentifiers.TabBar.certificates].waitAndTap()
+		let certificateTab = app.buttons[AccessibilityIdentifiers.TabBar.certificates]
+		XCTAssertTrue(certificateTab.waitForExistence(timeout: .medium))
+		certificateTab.waitAndTap()
 
 		// Navigate to Persons Tab.
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].waitAndTap()


### PR DESCRIPTION
## Description
another attempt to fix the test, the test start and finishes while the launch screen is still loading so the tab bar button cant be tapped, now we wait for the button to appear before tapping
