### PR TITLE
Fix/12433 is admission state changed false on update

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -179,7 +179,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 			if dccWalletInfo?.certificateReissuance != oldValue?.certificateReissuance {
 				isNewCertificateReissuance = dccWalletInfo?.certificateReissuance?.reissuanceDivision.visible == true
 			}
-			if oldValue?.admissionState != nil && dccWalletInfo?.admissionState.identifier != oldValue?.admissionState.identifier {
+			if oldValue?.admissionState.identifier != nil && dccWalletInfo?.admissionState.identifier != oldValue?.admissionState.identifier {
 				isAdmissionStateChanged = dccWalletInfo?.admissionState.identifier != nil
 			}
 


### PR DESCRIPTION
## Description
As the identifier field was newly introduced in 2.20 we need to check that the identifier is not nil when checking if the admission state has changed.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12433
