### PR TITLE
Remove outdated sentence reg. free test (Addresses cwa-documentation/877)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 
 "ExposureDetection_Guide_Vaccination_HighRisk" = "Sollten Sie bisher nicht geimpft sein, besprechen Sie nach der Testung die Impfung mit Ihrer Hausarztpraxis.";
 
-"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, auch wenn Sie keine Symptome haben. Bei einer Warnung über ein erhöhtes Risiko (\"Rote Kachel\") haben Sie Anspruch auf einen kostenlosen Test. Dies muss nicht notwendigerweise ein PCR-Test sein.";
+"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, auch wenn Sie keine Symptome haben.";
 
 "ExposureDetection_Guide_Point1" = "Testmöglichkeiten finden Sie hier. Sie können sich auch an Ihre Hausarztpraxis oder Apotheke wenden.";
 


### PR DESCRIPTION
## Description
This PR removes an outdated sentence reg. the legal entitlement to a free test if the CWA shows an increased risk encounter.

For more details take a look at https://github.com/corona-warn-app/cwa-documentation/issues/877.

## Link to Jira
- GitHub Issue https://github.com/corona-warn-app/cwa-documentation/issues/877
	- JIRA link: Internal Tracking ID: [EXPOSUREAPP-13209](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13209) 

## Screenshots
| Dark mode | Light mode |
|---|---|
| <img src="https://user-images.githubusercontent.com/67682506/160421490-36eaa7b4-f8c8-44bb-8188-8ee30d4bb58c.png" width="300"> | <img src="https://user-images.githubusercontent.com/67682506/160421500-3d6071ff-ddc4-4070-995d-292d0a6d0795.png" width="300"> |