### PR TITLE
migration to circleci api v2

### DIFF
--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -225,8 +225,8 @@ platform :ios do
 
     # Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)
     sh("curl -u '#{ENV["CIRCLE_API_ADMIN_TOKEN"]}': \
-      -d 'build_parameters[CIRCLE_JOB]=ios' \
-      https://circleci.com/api/v1.1/project/github/corona-warn-app/cwa-app-automation/tree/main"
+      -d '{"branch":"main","parameters":{"mobile-os":"ios"}}' \
+      https://circleci.com/api/v2/project/github/corona-warn-app/cwa-app-automation/pipeline"
     )
   end
 

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -225,7 +225,7 @@ platform :ios do
 
     # Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)
     sh("curl -u '#{ENV["CIRCLE_API_ADMIN_TOKEN"]}': \
-      -d '{"branch":"main","parameters":{"mobile-os":"ios"}}' \
+      -d '{\"branch\":\"main\",\"parameters\":{\"mobile-os\":\"ios\"}}' \
       https://circleci.com/api/v2/project/github/corona-warn-app/cwa-app-automation/pipeline"
     )
   end


### PR DESCRIPTION
## Description
Trigger automatic tests via the new CircleCI API v2 - https://github.com/corona-warn-app/cwa-app-automation

API v1 doesn't allow us to use orbs, when we want to trigger it from another pipeline :-(