### PR TITLE
without header it's not working correctly

### DIFF
--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -226,6 +226,7 @@ platform :ios do
     # Trigger Tests on Mobile Device Cloud via CircleCI (cwa-app-automation)
     sh("curl -u '#{ENV["CIRCLE_API_ADMIN_TOKEN"]}': \
       -d '{\"branch\":\"main\",\"parameters\":{\"mobile-os\":\"ios\"}}' \
+      -H 'content-type: application/json' \
       https://circleci.com/api/v2/project/github/corona-warn-app/cwa-app-automation/pipeline"
     )
   end


### PR DESCRIPTION
## Description
without header it's not working correctly - circleci API requires correct content-type