### PR TITLE
Move Screenshots into own Workflow

### DIFF
--- a/.github/workflows/Screenshots.yml
+++ b/.github/workflows/Screenshots.yml
@@ -2,7 +2,7 @@ name: Create Screenshots
 on: workflow_dispatch
 
 jobs:
-    dependencies:
+  dependencies:
     runs-on: self-hosted
     steps:
       - name: Check out repository code
@@ -31,80 +31,80 @@ jobs:
             src/xcode/.bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
         
-    buildForTesting:
-      runs-on: self-hosted
-      needs: dependencies
-      steps:
-        - name: Check out repository code
-          uses: actions/checkout@v2     
-        - name: Restore Dependencies
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-dependencies
-          with:
-            path: |
-              src/xcode/vendor
-              src/xcode/.bundle
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}     
-        - name: Build for testing
-          run: |
-            cd src/xcode && arch -arm64 bundle exec fastlane build_for_testing
-        - name: Save DerivedData folder
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-derived-data
-          with:
-            path: src/xcode/DerivedData
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-        - name: Save test_output folder
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-test-output
-          with:
-            path: src/xcode/fastlane/test_output
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-            
-    snapshot:
-      runs-on: self-hosted
-      needs: buildForTesting
-      strategy:
-        matrix:
-         language: ["de-DE", "en-EN"]
-         displaymode: ["dark", "light"]
-      steps:
-        - name: Check out repository code
-          uses: actions/checkout@v2            
-        - name: Restore Dependencies
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-dependencies
-          with:
-            path: |
-              src/xcode/vendor
-              src/xcode/.bundle
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
-        - name: Restore DerivedData folder
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-derived-data
-          with:
-            path: src/xcode/DerivedData
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-        - name: Restore test_output folder
-          uses: actions/cache@v2
-          env:
-            cache-name: cache-test-output
-          with:
-            path: src/xcode/fastlane/test_output
-            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                         
-        - name: Snapshot ${{ matrix.language }}-${{ matrix.displaymode }}
-          run: |
-            cd src/xcode && arch -arm64 bundle exec fastlane screenshot languages:${{ matrix.language }} mode:${{ matrix.displaymode }}
-        - name: Remove test_output folder
-          run: |
-            cd src/xcode/screenshots/screenshots-${{ matrix.language }}-${{ matrix.displaymode }}
-            rm -r test_output
-        - uses: actions/upload-artifact@v2
-          with:
-            name: screenshots-${{ github.sha }}
-            path: src/xcode/screenshots
+  buildForTesting:
+    runs-on: self-hosted
+    needs: dependencies
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2     
+      - name: Restore Dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}     
+      - name: Build for testing
+        run: |
+          cd src/xcode && arch -arm64 bundle exec fastlane build_for_testing
+      - name: Save DerivedData folder
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-derived-data
+        with:
+          path: src/xcode/DerivedData
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+      - name: Save test_output folder
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-test-output
+        with:
+          path: src/xcode/fastlane/test_output
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+          
+  snapshot:
+    runs-on: self-hosted
+    needs: buildForTesting
+    strategy:
+      matrix:
+       language: ["de-DE", "en-EN"]
+       displaymode: ["dark", "light"]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2            
+      - name: Restore Dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
+      - name: Restore DerivedData folder
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-derived-data
+        with:
+          path: src/xcode/DerivedData
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+      - name: Restore test_output folder
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-test-output
+        with:
+          path: src/xcode/fastlane/test_output
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                         
+      - name: Snapshot ${{ matrix.language }}-${{ matrix.displaymode }}
+        run: |
+          cd src/xcode && arch -arm64 bundle exec fastlane screenshot languages:${{ matrix.language }} mode:${{ matrix.displaymode }}
+      - name: Remove test_output folder
+        run: |
+          cd src/xcode/screenshots/screenshots-${{ matrix.language }}-${{ matrix.displaymode }}
+          rm -r test_output
+      - uses: actions/upload-artifact@v2
+        with:
+          name: screenshots-${{ github.sha }}
+          path: src/xcode/screenshots

--- a/.github/workflows/Screenshots.yml
+++ b/.github/workflows/Screenshots.yml
@@ -31,80 +31,80 @@ jobs:
             src/xcode/.bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
         
-  buildForTesting:
-    runs-on: self-hosted
-    needs: dependencies
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2     
-      - name: Restore Dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            src/xcode/vendor
-            src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}     
-      - name: Build for testing
-        run: |
-          cd src/xcode && arch -arm64 bundle exec fastlane build_for_testing
-      - name: Save DerivedData folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-derived-data
-        with:
-          path: src/xcode/DerivedData
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-      - name: Save test_output folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-test-output
-        with:
-          path: src/xcode/fastlane/test_output
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-          
-  snapshot:
-    runs-on: self-hosted
-    needs: buildForTesting
-    strategy:
-      matrix:
-       language: ["de-DE", "en-EN"]
-       displaymode: ["dark", "light"]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2            
-      - name: Restore Dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            src/xcode/vendor
-            src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
-      - name: Restore DerivedData folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-derived-data
-        with:
-          path: src/xcode/DerivedData
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-      - name: Restore test_output folder
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-test-output
-        with:
-          path: src/xcode/fastlane/test_output
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                         
-      - name: Snapshot ${{ matrix.language }}-${{ matrix.displaymode }}
-        run: |
-          cd src/xcode && arch -arm64 bundle exec fastlane screenshot languages:${{ matrix.language }} mode:${{ matrix.displaymode }}
-      - name: Remove test_output folder
-        run: |
-          cd src/xcode/screenshots/screenshots-${{ matrix.language }}-${{ matrix.displaymode }}
-          rm -r test_output
-      - uses: actions/upload-artifact@v2
-        with:
-          name: screenshots-${{ github.sha }}
-          path: src/xcode/screenshots
+    buildForTesting:
+      runs-on: self-hosted
+      needs: dependencies
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2     
+        - name: Restore Dependencies
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-dependencies
+          with:
+            path: |
+              src/xcode/vendor
+              src/xcode/.bundle
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}     
+        - name: Build for testing
+          run: |
+            cd src/xcode && arch -arm64 bundle exec fastlane build_for_testing
+        - name: Save DerivedData folder
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-derived-data
+          with:
+            path: src/xcode/DerivedData
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+        - name: Save test_output folder
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-test-output
+          with:
+            path: src/xcode/fastlane/test_output
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+            
+    snapshot:
+      runs-on: self-hosted
+      needs: buildForTesting
+      strategy:
+        matrix:
+         language: ["de-DE", "en-EN"]
+         displaymode: ["dark", "light"]
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2            
+        - name: Restore Dependencies
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-dependencies
+          with:
+            path: |
+              src/xcode/vendor
+              src/xcode/.bundle
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
+        - name: Restore DerivedData folder
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-derived-data
+          with:
+            path: src/xcode/DerivedData
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
+        - name: Restore test_output folder
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-test-output
+          with:
+            path: src/xcode/fastlane/test_output
+            key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                         
+        - name: Snapshot ${{ matrix.language }}-${{ matrix.displaymode }}
+          run: |
+            cd src/xcode && arch -arm64 bundle exec fastlane screenshot languages:${{ matrix.language }} mode:${{ matrix.displaymode }}
+        - name: Remove test_output folder
+          run: |
+            cd src/xcode/screenshots/screenshots-${{ matrix.language }}-${{ matrix.displaymode }}
+            rm -r test_output
+        - uses: actions/upload-artifact@v2
+          with:
+            name: screenshots-${{ github.sha }}
+            path: src/xcode/screenshots

--- a/.github/workflows/Screenshots.yml
+++ b/.github/workflows/Screenshots.yml
@@ -1,11 +1,8 @@
-name: Merge to Release Branch
-on:
-  push:
-    branches:
-      - 'release/**'
+name: Create Screenshots
+on: workflow_dispatch
 
 jobs:
-  dependencies:
+    dependencies:
     runs-on: self-hosted
     steps:
       - name: Check out repository code
@@ -33,8 +30,7 @@ jobs:
             src/xcode/vendor
             src/xcode/.bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
-
-          
+        
   buildForTesting:
     runs-on: self-hosted
     needs: dependencies
@@ -67,58 +63,17 @@ jobs:
         with:
           path: src/xcode/fastlane/test_output
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}
-  
-  swiftLint:
-    runs-on: self-hosted
-    needs: dependencies
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2       
-      - name: Restore Dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            src/xcode/vendor
-            src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
-      - name: swift Lint
-        run: |
-          cd src/xcode
-          arch -arm64 bundle exec fastlane lint
-      - name: Archive swiftlint report
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: swiftlint-${{ github.sha }}
-          path: src/xcode/swiftlint.html
           
-  communityBuild:
+  snapshot:
     runs-on: self-hosted
-    needs: dependencies
+    needs: buildForTesting
+    strategy:
+      matrix:
+       language: ["de-DE", "en-EN"]
+       displaymode: ["dark", "light"]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2            
-      - name: Restore Dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            src/xcode/vendor
-            src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
-      - name: Community Build
-        run: |
-          cd src/xcode && arch -arm64 bundle exec fastlane build_community
-              
-  runAllTests:
-    runs-on: self-hosted
-    needs: buildForTesting
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2          
       - name: Restore Dependencies
         uses: actions/cache@v2
         env:
@@ -141,10 +96,15 @@ jobs:
           cache-name: cache-test-output
         with:
           path: src/xcode/fastlane/test_output
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                       
-      - name: Run AllTests
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.sha }}                         
+      - name: Snapshot ${{ matrix.language }}-${{ matrix.displaymode }}
         run: |
-          cd src/xcode
-          arch -arm64 bundle exec fastlane test_without_building testplan:AllTests
-
-
+          cd src/xcode && arch -arm64 bundle exec fastlane screenshot languages:${{ matrix.language }} mode:${{ matrix.displaymode }}
+      - name: Remove test_output folder
+        run: |
+          cd src/xcode/screenshots/screenshots-${{ matrix.language }}-${{ matrix.displaymode }}
+          rm -r test_output
+      - uses: actions/upload-artifact@v2
+        with:
+          name: screenshots-${{ github.sha }}
+          path: src/xcode/screenshots

--- a/src/xcode/fastlane/Fastfile
+++ b/src/xcode/fastlane/Fastfile
@@ -141,7 +141,6 @@ platform :ios do
         output_directory: output_dir,
         result_bundle: true,
         skip_open_summary: true,
-        number_of_retries: 2,
         derived_data_path: "./DerivedData",
         test_without_building: options[:test_without_building] == true,
         skip_package_dependencies_resolution: true,


### PR DESCRIPTION
## Description
To not block the CI to much Screenshot will now only be created if the new Screenshot workflow is triggered manually. 
In the future the Screenshots will also be automatically created with a nightly as well.

Also the retrying of Screenshots had to be disabled since this leads to an endless loop :/
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12568

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
