### PR TITLE
Fix/12607 notification is not created after blocked certificate is scanned

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -163,6 +163,13 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 			let route = Route(healthCertifiedPerson: certifiedPerson)
 			Log.debug("Received admissionStateChange notification")
 			showHealthCertifiedPerson(route)
+		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateBlocked.rawValue, from: identifier) {
+			let route = Route(
+				healthCertifiedPerson: certifiedPerson,
+				healthCertificate: healthCertificate
+			)
+			Log.debug("Received Certificate blocked notification")
+			showHealthCertificate(route)
 		}
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -709,6 +709,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 			   $0.certificateRef.barcodeData == healthCertificate.base45
 		   }) {
 			healthCertificate.validityState = .blocked
+			healthCertificateNotificationService.createNotifications(for: healthCertificate)
 		} else {
 			let signatureVerificationResult = dccSignatureVerifier.verify(
 				certificate: healthCertificate.base45,

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -751,7 +751,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 			   $0.certificateRef.barcodeData == healthCertificate.base45
 		   }) {
 			healthCertificate.validityState = .blocked
-			healthCertificateNotificationService.createNotifications(for: healthCertificate)
+			healthCertificateNotificationService.createNotifications(for: healthCertificate, completion: {})
 		} else {
 			let signatureVerificationResult = dccSignatureVerifier.verify(
 				certificate: healthCertificate.base45,


### PR DESCRIPTION
## Description
the notification is not showing, we should reschedule it after scanning the certificate

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12607

## Screenshots
https://user-images.githubusercontent.com/15270737/161742846-9279a339-ff66-43c8-aac9-3e1928f17c71.mov


