### PR TITLE
Feature/12406 restore tests from recycle bin

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorModelTests.swift
@@ -23,7 +23,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertFalse(model.shouldShowOverrideTestNotice(for: .pcr))
@@ -41,7 +42,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertTrue(model.shouldShowOverrideTestNotice(for: .pcr))
@@ -72,7 +74,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertFalse(model.shouldShowOverrideTestNotice(for: .pcr))
@@ -107,7 +110,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertTrue(model.shouldShowOverrideTestNotice(for: .pcr))
@@ -121,7 +125,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertTrue(model.shouldShowTestCertificateScreen(with: .pcr(guid: "F1EE0D-F1EE0D4D-4346-4B63-B9CF-1522D9200915", qrCodeHash: "")))
@@ -132,7 +137,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let antigenTestQRCodeInformation = RapidTestQRCodeInformation(
@@ -154,7 +160,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let antigenTestQRCodeInformation = RapidTestQRCodeInformation(
@@ -176,7 +183,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let antigenTestQRCodeInformation = RapidTestQRCodeInformation(
@@ -198,7 +206,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		XCTAssertFalse(model.shouldShowTestCertificateScreen(with: .teleTAN(tan: "qwdzxcsrhe")))
@@ -211,7 +220,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.symptomsOptionSelected(.yes)
@@ -231,7 +241,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -258,7 +269,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -287,7 +299,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -316,7 +329,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -342,7 +356,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -369,7 +384,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -395,7 +411,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -421,7 +438,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -460,7 +478,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -499,7 +518,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -540,7 +560,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: exposureSubmissionService,
 			coronaTestService: MockCoronaTestService(),
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		model.coronaTestType = .pcr
@@ -579,7 +600,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -623,7 +645,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -666,7 +689,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -710,7 +734,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 		
 		let expectedIsLoadingValues = [true, false]
@@ -753,7 +778,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -796,7 +822,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -839,7 +866,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -883,7 +911,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -926,7 +955,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -970,7 +1000,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -1013,7 +1044,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -1057,7 +1089,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -1100,7 +1133,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]
@@ -1144,7 +1178,8 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 			exposureSubmissionService: MockExposureSubmissionService(),
 			coronaTestService: coronaTestService,
 			familyMemberCoronaTestService: familyMemberCoronaTestService,
-			eventProvider: MockEventStore()
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: MockTestStore())
 		)
 
 		let expectedIsLoadingValues = [true, false]

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorModelTests.swift
@@ -426,6 +426,110 @@ class ExposureSubmissionCoordinatorModelTests: CWATestCase {
 		waitForExpectations(timeout: .short)
 	}
 
+	// MARK: - Recycle Bin Item To Restore
+
+	func testRecycleBinItem_UserPCRTestIsInRecycleBin() {
+		let userPCRRecycleBinItem = RecycleBinItem(
+			recycledAt: Date(),
+			item: .userCoronaTest(.pcr(.mock(qrCodeHash: "userPCRQRCodeHash")))
+		)
+
+		let store = MockTestStore()
+		store.recycleBinItems = Set([
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: RecycledItem.certificate(HealthCertificate.mock())
+			),
+			userPCRRecycleBinItem
+		])
+
+		let model = ExposureSubmissionCoordinatorModel(
+			exposureSubmissionService: MockExposureSubmissionService(),
+			coronaTestService: MockCoronaTestService(),
+			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: store)
+		)
+
+		XCTAssertEqual(
+			model.recycleBinItemToRestore(for: .pcr(guid: "", qrCodeHash: "userPCRQRCodeHash")),
+			userPCRRecycleBinItem
+		)
+	}
+
+	func testRecycleBinItem_UserPCRTestIsNotInRecycleBin() {
+		let store = MockTestStore()
+		store.recycleBinItems = Set([
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: RecycledItem.certificate(HealthCertificate.mock())
+			)
+		])
+
+		let model = ExposureSubmissionCoordinatorModel(
+			exposureSubmissionService: MockExposureSubmissionService(),
+			coronaTestService: MockCoronaTestService(),
+			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: store)
+		)
+
+		XCTAssertNil(
+			model.recycleBinItemToRestore(for: .pcr(guid: "", qrCodeHash: "userPCRQRCodeHash"))
+		)
+	}
+
+	func testRecycleBinItem_FamilyMemberPCRTestIsInRecycleBin() {
+		let familyMemberPCRRecycleBinItem = RecycleBinItem(
+			recycledAt: Date(),
+			item: .familyMemberCoronaTest(.pcr(.mock(qrCodeHash: "familyMemberPCRQRCodeHash")))
+		)
+
+		let store = MockTestStore()
+		store.recycleBinItems = Set([
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: RecycledItem.certificate(HealthCertificate.mock())
+			),
+			familyMemberPCRRecycleBinItem
+		])
+
+		let model = ExposureSubmissionCoordinatorModel(
+			exposureSubmissionService: MockExposureSubmissionService(),
+			coronaTestService: MockCoronaTestService(),
+			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: store)
+		)
+
+		XCTAssertEqual(
+			model.recycleBinItemToRestore(for: .pcr(guid: "", qrCodeHash: "familyMemberPCRQRCodeHash")),
+			familyMemberPCRRecycleBinItem
+		)
+	}
+
+	func testRecycleBinItem_FamilyMemberPCRTestIsNotInRecycleBin() {
+		let store = MockTestStore()
+		store.recycleBinItems = Set([
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: RecycledItem.certificate(HealthCertificate.mock())
+			)
+		])
+
+		let model = ExposureSubmissionCoordinatorModel(
+			exposureSubmissionService: MockExposureSubmissionService(),
+			coronaTestService: MockCoronaTestService(),
+			familyMemberCoronaTestService: MockFamilyMemberCoronaTestService(),
+			eventProvider: MockEventStore(),
+			recycleBin: RecycleBin(store: store)
+		)
+
+		XCTAssertNil(
+			model.recycleBinItemToRestore(for: .pcr(guid: "", qrCodeHash: "userPCRQRCodeHash"))
+		)
+	}
+
 	// MARK: - Submit Exposure
 
 	func testSuccessfulSubmit() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/__tests__/ExposureSubmissionCoordinatorTests.swift
@@ -126,7 +126,8 @@ class ExposureSubmissionCoordinatorTests: CWATestCase {
 			antigenTestProfileStore: store,
 			vaccinationValueSetsProvider: vaccinationValueSetsProvider,
 			healthCertificateValidationOnboardedCountriesProvider: healthCertificateValidationOnboardedCountriesProvider,
-			qrScannerCoordinator: qrScannerCoordinator
+			qrScannerCoordinator: qrScannerCoordinator,
+			recycleBin: RecycleBin(store: store)
 		)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeCoordinator.swift
@@ -312,7 +312,8 @@ class HomeCoordinator: RequiresAppDependencies {
 			antigenTestProfileStore: store,
 			vaccinationValueSetsProvider: vaccinationValueSetsProvider,
 			healthCertificateValidationOnboardedCountriesProvider: healthCertificateValidationOnboardedCountriesProvider,
-			qrScannerCoordinator: qrScannerCoordinator
+			qrScannerCoordinator: qrScannerCoordinator,
+			recycleBin: recycleBin
 		)
 
 		if let testInformationResult = testInformationResult {

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/UserAntigenTest+Mock.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/UserAntigenTest+Mock.swift
@@ -9,6 +9,7 @@ extension UserAntigenTest {
 
 	static func mock(
 		registrationToken: String? = nil,
+		qrCodeHash: String? = nil,
 		pointOfCareConsentDate: Date = Date(),
 		sampleCollectionDate: Date? = nil,
 		registrationDate: Date? = nil,
@@ -30,6 +31,7 @@ extension UserAntigenTest {
 			sampleCollectionDate: sampleCollectionDate,
 			registrationDate: registrationDate,
 			registrationToken: registrationToken,
+			qrCodeHash: qrCodeHash,
 			testedPerson: testedPerson,
 			testResult: testResult,
 			finalTestResultReceivedDate: finalTestResultReceivedDate,

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/UserPCRTest+Mock.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/UserPCRTest+Mock.swift
@@ -9,6 +9,7 @@ extension UserPCRTest {
 
 	static func mock(
 		registrationToken: String? = nil,
+		qrCodeHash: String? = nil,
 		registrationDate: Date = Date(),
 		testResult: TestResult = .pending,
 		finalTestResultReceivedDate: Date? = nil,
@@ -25,6 +26,7 @@ extension UserPCRTest {
 		UserPCRTest(
 			registrationDate: registrationDate,
 			registrationToken: registrationToken,
+			qrCodeHash: qrCodeHash,
 			testResult: testResult,
 			finalTestResultReceivedDate: finalTestResultReceivedDate,
 			positiveTestResultWasShown: positiveTestResultWasShown,

--- a/src/xcode/ENA/ENA/Source/Services/RecycleBin/RecycleBin.swift
+++ b/src/xcode/ENA/ENA/Source/Services/RecycleBin/RecycleBin.swift
@@ -26,6 +26,10 @@ class RecycleBin {
 	var familyMemberTestRestorationHandler: FamilyMemberTestRestorationHandling!
 	var certificateRestorationHandler: CertificateRestorationHandling!
 
+	var recycledItems: Set<RecycleBinItem> {
+		store.recycleBinItems
+	}
+
 	/// This function moves an item into the bin.
 	///
 	/// - Parameter item: The item which needs to be moved into the bin.

--- a/src/xcode/ENA/ENA/Source/Services/RecycleBin/__tests__/RecycleBinTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/RecycleBin/__tests__/RecycleBinTests.swift
@@ -7,6 +7,24 @@ import XCTest
 
 class RecycleBinTests: XCTestCase {
 
+	func test_recycledItems() {
+		let mockStore = MockTestStore()
+		mockStore.recycleBinItems = Set([
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: RecycledItem.certificate(HealthCertificate.mock())
+			),
+			RecycleBinItem(
+				recycledAt: Date(),
+				item: .userCoronaTest(.antigen(.mock()))
+			)
+		])
+
+		let recycleBin = RecycleBin(store: mockStore)
+
+		XCTAssertEqual(recycleBin.recycledItems, mockStore.recycleBinItems)
+	}
+
 	func test_moveToBin() {
 		let mockStore = MockTestStore()
 		let recycleBin = RecycleBin(store: mockStore)


### PR DESCRIPTION
## Description
So far restoring tests that already were in the recycle bin only worked from the universal QR code scanner for user tests. This PR adds support for family member tests from the universal QR code scanner as well as support for the external camera for both kinds of tests.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12406