### PR TITLE
disable testing on dev branches on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,50 +274,6 @@ jobs:
 
 workflows:
   version: 2
-  build-and-test:
-    jobs:
-      - dependencies
-      - build-for-testing:
-          requires:
-            - dependencies
-      - test:
-          matrix:
-            parameters:
-              testplan: ["UnitTests", "AntigenTestProfileUITests", "AppInformationUITests", "CheckInsUITests", "ContactJournalUITests", "CreateHealthCertificateUITests", "DataDonationUITests", "DeltaOnboardingUITests", "ExposureDetectionUITests", "ExposureLoggingUITests", "ExposureSubmissionUITests", "FileScannerUITests", "HomeUITests", "OnBehalfCheckinSubmissionUITests", "OnboardingUITests", "QuickActionsUITests", "SettingsUITests", "StatisticsUITests", "TicketValidationUITests", "TraceLocationsUITests", "UniversalQRCodeScannerUITests", "UpdateOSUITests", "ValidateHealthCertificateUITests", "RecycleBinUITests", "ReissueHealthCertificateUITests"]
-          requires:
-            - build-for-testing
-          filters:
-            branches:
-              ignore:
-                - /release\/.*/
-      - test:
-          matrix:
-            parameters:
-              testplan: ["AllTests"]
-          requires:
-            - build-for-testing
-          filters:
-            branches:
-              only:
-                - /release\/.*/
-      - build-community:
-          requires:
-            - dependencies
-      - snapshot-test: # Create one set of screenshot on all branches
-          requires:
-            - dependencies
-          filters:
-            branches:
-              ignore:
-                - /release\/.*/
-      - update-docs:
-          requires:
-            - dependencies
-          filters:
-            branches:
-              only:
-                - main
-
   beta-release:
     jobs:
       - dependencies:


### PR DESCRIPTION
## Description
This PR disables CircleCI for normal development branches. Github Actions have already taken over.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12568

