### PR TITLE
Move RCs creation from CircleCI to Github Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,37 +318,6 @@ workflows:
               only:
                 - main
 
-  beta-release:
-    jobs:
-      - dependencies:
-          filters:
-            tags:
-              only:
-                - /^v.*/
-            branches:
-              ignore: /.*/
-      - build-for-testing:
-          requires:
-            - dependencies
-      - test:
-          requires:
-            - build-for-testing
-          filters:
-            tags:
-              only:
-                - /^v.*/
-            branches:
-              ignore: /.*/
-      - testflight-release:
-          requires:
-            - dependencies
-          filters:
-            tags:
-              only:
-                - /^v.*/
-            branches:
-              ignore: /.*/
-
   sonar-workflow:
     triggers:
       - schedule:

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -50,7 +50,13 @@ jobs:
           path: |
             src/xcode/vendor
             src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
+      - name: swtich to testing environment
+        env:
+            ENVIRONMENTS_FILE_URL: '${{ secrets.ENVIRONMENTS_FILE_URL }}'
+            GITHUB_ACCESS_TOKEN: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
+        run: |
+          ./scripts/switch_to_dev_env.sh       
       - name: fastlane testflight
         env:
             MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-    branches:
-      - 'admin/rc_workflow' #REMOVE ME WHEN PR
 
 jobs:
   dependencies:

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -80,7 +80,20 @@ jobs:
           path: |
             src/xcode/vendor
             src/xcode/.bundle
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
+      - name: swtich to testing environment
+        env:
+            ENVIRONMENTS_FILE_URL: '${{ secrets.ENVIRONMENTS_FILE_URL }}'
+            GITHUB_ACCESS_TOKEN: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
+        run: |
+          ./scripts/switch_to_dev_env.sh           
       - name: fastlane appcenter and Mobile Device Cloud
+        env:
+            MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'
+            FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
+            MATCH_GIT_BASIC_AUTHORIZATION: '${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}'
+            TSI_CLOUD_URL: '${{ secrets.TSI_CLOUD_URL }}'
+            TSI_CLOUD_TOKEN: '${{ secrets.TSI_CLOUD_TOKEN }}'
+            CIRCLE_API_ADMIN_TOKEN: '${{ secrets.CIRCLE_API_ADMIN_TOKEN }}'
         run: |
           cd src/xcode && bundle exec fastlane adHocDistribution

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -55,7 +55,7 @@ jobs:
         env:
             MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'
             FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
-            MATCH_GIT_BASIC_AUTHORIZATION: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
+            MATCH_GIT_BASIC_AUTHORIZATION: '${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}'
 
         run: |
           cd src/xcode && bundle exec fastlane betaRelease --env TestFlight

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+      - 'admin/rc_workflow' #REMOVE ME WHEN PR
 
 jobs:
   dependencies:
@@ -50,6 +52,10 @@ jobs:
             src/xcode/.bundle
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
       - name: fastlane testflight
+        env:
+            MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'
+            FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
+
         run: |
           cd src/xcode && bundle exec fastlane betaRelease --env TestFlight
 

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -55,6 +55,7 @@ jobs:
         env:
             MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'
             FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
+            GIT_AUTHORIZATION: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
 
         run: |
           cd src/xcode && bundle exec fastlane betaRelease --env TestFlight

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -55,7 +55,7 @@ jobs:
         env:
             MATCH_PASSWORD: '${{ secrets.MATCH_PASSWORD }}'
             FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: '${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}'
-            GIT_AUTHORIZATION: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
+            MATCH_GIT_BASIC_AUTHORIZATION: '${{ secrets.ACCESS_TOKEN_GITHUB }}'
 
         run: |
           cd src/xcode && bundle exec fastlane betaRelease --env TestFlight

--- a/.github/workflows/ReleaseCandidate.yml
+++ b/.github/workflows/ReleaseCandidate.yml
@@ -1,0 +1,73 @@
+name: Create Release Candidate
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  dependencies:
+    runs-on: self-hosted
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2     
+      - name: Save Dependencies
+        uses: actions/cache@v2
+        id: cache-dependencies
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}        
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: cd src/xcode && arch -arm64 bundle install --path=vendor
+      - name: Save Dependencies
+        uses: actions/cache@v2
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}
+          
+  testFlight:
+    runs-on: self-hosted
+    needs: dependencies
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2            
+      - name: Restore Dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
+      - name: fastlane testflight
+        run: |
+          cd src/xcode && bundle exec fastlane betaRelease --env TestFlight
+
+  adHocDistribution:
+    runs-on: self-hosted
+    needs: dependencies
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2            
+      - name: Restore Dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            src/xcode/vendor
+            src/xcode/.bundle
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('src/xcode/Gemfile.lock') }}       
+      - name: fastlane appcenter and Mobile Device Cloud
+        run: |
+          cd src/xcode && bundle exec fastlane adHocDistribution

--- a/src/xcode/fastlane/Matchfile
+++ b/src/xcode/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("git@github.com:corona-warn-app/cwa-certificates.git")
+git_url("https://github.com/corona-warn-app/cwa-certificates.git")
 
 storage_mode("git")
 


### PR DESCRIPTION
## Description
Adds a Workflow that will be triggered when a release tag is created, which builds the app and uploads to TestFlight and Mobile Device Cloud.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12568
