### PR TITLE
receive on main

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
@@ -159,6 +159,7 @@ class ExposureSubmissionTestResultViewController: DynamicTableViewController, Fo
 			.store(in: &bindings)
 		
 		viewModel.footerViewModelPublisher
+			.receive(on: DispatchQueue.main.ocombine)
 			.sink { [weak self] footerViewModel in
 				guard let self = self, let footerViewModel = footerViewModel else { return }
 				guard let topBottomViewController = self.parent as? TopBottomContainerViewController<ExposureSubmissionTestResultViewController, FooterViewController> else { return }


### PR DESCRIPTION
## Description
Not only manipulation of ui needs to be done on main-thread, also getting info about an ui object like parentviewcontroller needs to be done on main.

This Issue was revealed through a flaky UITest: `test_RegisterCoronaTestFromSubmitCardButton`

