### PR TITLE
Fix/12676 tap on notification when app is terminated opens home

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -143,7 +143,9 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 						healthCertificate: healthCertificate
 					)
 					Log.debug("Received \(certificateIdentifier.rawValue) notification")
-					self?.showHealthCertificate(route)
+					DispatchQueue.main.async { [weak self] in
+						self?.showHealthCertificate(route)
+					}
 				}
 			})
 		case .boosterVaccination, .certificateReissuance, .admissionStateChange:
@@ -151,7 +153,9 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 				if let certifiedPerson = result {
 					let route = Route(healthCertifiedPerson: certifiedPerson)
 					Log.debug("Received \(certificateIdentifier.rawValue) notification")
-					self?.showHealthCertifiedPerson(route)
+					DispatchQueue.main.async { [weak self] in
+						self?.showHealthCertifiedPerson(route)
+					}
 				}
 			})
 		case .checkout:

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -91,18 +91,16 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 	// MARK: - Internal
 	
 	// Internal for testing
-	func extract(_ prefix: String, from: String) -> (HealthCertifiedPerson, HealthCertificate)? {
-		guard from.hasPrefix(prefix) else {
-			return nil
-		}
-		return findHealthCertificate(String(from.dropFirst(prefix.count)))
+	func extract(_ prefix: String, from: String, completion: @escaping ((HealthCertifiedPerson, HealthCertificate)?) -> Void) {
+		findHealthCertificate(String(from.dropFirst(prefix.count)), completion: { result in
+			completion(result)
+		})
 	}
-	
-	func extractPerson(_ prefix: String, from: String) -> HealthCertifiedPerson? {
-		guard from.hasPrefix(prefix) else {
-			return nil
-		}
-			return findHealthCertifiedPerson(String(from.dropFirst(prefix.count)))
+
+	func extractPerson(_ prefix: String, from: String, completion: @escaping (HealthCertifiedPerson?) -> Void) {
+		return findHealthCertifiedPerson(String(from.dropFirst(prefix.count)), completion: { result in
+			completion(result)
+		})
 	}
 	// MARK: - Private
 	

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -126,65 +126,68 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 			showTestResultFromNotification(.testResultFromNotification(.antigen))
 		}
 	}
-
-	private func checkForLocalNotificationsActions(_ identifier: String) {
-		if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateExpired.rawValue, from: identifier) {
-			let route = Route(
-				healthCertifiedPerson: certifiedPerson,
-				healthCertificate: healthCertificate
-			)
-			Log.debug("Received certificateExpired notification")
-			showHealthCertificate(route)
-		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateExpiringSoon.rawValue, from: identifier) {
-			let route = Route(
-				healthCertifiedPerson: certifiedPerson,
-				healthCertificate: healthCertificate
-			)
-			Log.debug("Received certificateExpiringSoon notification")
-			showHealthCertificate(route)
-		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateInvalid.rawValue, from: identifier) {
-			let route = Route(
-				healthCertifiedPerson: certifiedPerson,
-				healthCertificate: healthCertificate
-			)
-			Log.debug("Received certificateInvalid notification")
-			showHealthCertificate(route)
-		} else if let (certifiedPerson) = extractPerson(LocalNotificationIdentifier.boosterVaccination.rawValue, from: identifier) {
-			let route = Route(healthCertifiedPerson: certifiedPerson)
-			Log.debug("Received boosterVaccination notification")
-			showHealthCertifiedPerson(route)
-		} else if let (certifiedPerson) = extractPerson(LocalNotificationIdentifier.certificateReissuance.rawValue, from: identifier) {
-			let route = Route(healthCertifiedPerson: certifiedPerson)
-			Log.debug("Received certificateReissuance notification")
-			showHealthCertifiedPerson(route)
-		} else if let (certifiedPerson) = extractPerson(LocalNotificationIdentifier.admissionStateChange.rawValue, from: identifier) {
-			let route = Route(healthCertifiedPerson: certifiedPerson)
-			Log.debug("Received admissionStateChange notification")
-			showHealthCertifiedPerson(route)
-		} else if let (certifiedPerson, healthCertificate) = extract(LocalNotificationIdentifier.certificateBlocked.rawValue, from: identifier) {
-			let route = Route(
-				healthCertifiedPerson: certifiedPerson,
-				healthCertificate: healthCertificate
-			)
-			Log.debug("Received Certificate blocked notification")
-			showHealthCertificate(route)
+		
+	private func checkForLocalNotificationsActions(_ incomingIdentifier: String) {
+		guard let certificateIdentifier = LocalNotificationIdentifier.allCases.first(where: {
+			incomingIdentifier.hasPrefix($0.rawValue)
+		}) else {
+			return
+		}
+		
+		switch certificateIdentifier {
+		case .certificateExpired, .certificateExpiringSoon, .certificateBlocked, .certificateInvalid:
+			extract(certificateIdentifier.rawValue, from: incomingIdentifier, completion: { [weak self] result in
+				if let (certifiedPerson, healthCertificate) = result {
+					let route = Route(
+						healthCertifiedPerson: certifiedPerson,
+						healthCertificate: healthCertificate
+					)
+					Log.debug("Received \(certificateIdentifier.rawValue) notification")
+					self?.showHealthCertificate(route)
+				}
+			})
+		case .boosterVaccination, .certificateReissuance, .admissionStateChange:
+			extractPerson(certificateIdentifier.rawValue, from: incomingIdentifier, completion: { [weak self] result in
+				if let certifiedPerson = result {
+					let route = Route(healthCertifiedPerson: certifiedPerson)
+					Log.debug("Received \(certificateIdentifier.rawValue) notification")
+					self?.showHealthCertifiedPerson(route)
+				}
+			})
+		case .checkout:
+			break
 		}
 	}
 	
-	private func findHealthCertificate(_ identifier: String) -> (HealthCertifiedPerson, HealthCertificate)? {
-		for person in healthCertificateService.healthCertifiedPersons {
-			if let certificate = person.$healthCertificates.value
-				.first(where: { $0.uniqueCertificateIdentifier == identifier }) {
-				return (person, certificate)
+	private func findHealthCertificate(_ identifier: String, completion: @escaping((HealthCertifiedPerson, HealthCertificate)?) -> Void) {
+		healthCertificateService.setup(updatingWalletInfos: true) { [weak self] in
+			guard let self = self else {
+				completion(nil)
+				return
 			}
+			for person in self.healthCertificateService.healthCertifiedPersons {
+				if let certificate = person.$healthCertificates.value
+					.first(where: { $0.uniqueCertificateIdentifier == identifier }) {
+					completion((person, certificate))
+					return
+				}
+			}
+			completion(nil)
 		}
-		return nil
 	}
 	
-	private func findHealthCertifiedPerson(_ identifier: String) -> (HealthCertifiedPerson)? {
-		return healthCertificateService.healthCertifiedPersons
-			.first {
-				$0.identifier == identifier
+	
+	private func findHealthCertifiedPerson(_ identifier: String, completion: @escaping(HealthCertifiedPerson?) -> Void) {
+		healthCertificateService.setup(updatingWalletInfos: true) { [weak self] in
+			guard let self = self else {
+				completion(nil)
+				return
 			}
+			let person = self.healthCertificateService.healthCertifiedPersons
+				.first {
+					$0.identifier == identifier
+				}
+			completion(person)
+		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
@@ -21,7 +21,7 @@ public enum ActionableNotificationIdentifier: String {
 	}
 }
 
-public enum LocalNotificationIdentifier: String {
+public enum LocalNotificationIdentifier: String, CaseIterable {
 	case checkout = "EventCheckoutNotification"
 	case certificateExpiringSoon = "HealthCertificateNotificationExpireSoon"
 	case certificateExpired = "HealthCertificateNotificationExpired"


### PR DESCRIPTION
## Description

- With the new setup function inside the healthCertificatesService the service is required to call this to handle migration and fetch persons from the store, this operation is async

- The notification manager needs to be updated with a call this setup function in the health service so we can compare the incoming notification identifier with the available certificates, so the structure of the functions was adapted to handle this async call

- Repleced the if/else syntax with a switch statment for better performance and readability

- Update the unit tests 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12676

## Screenshots
https://user-images.githubusercontent.com/15270737/162391012-6e3b8127-49bd-4d82-a83b-00cfc531ab9a.MP4


