### PR TITLE
Fix/12703 background task crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
@@ -23,6 +23,7 @@ class HealthCertificateNotificationService {
 		completion: @escaping () -> Void
 	) {
 		guard healthCertificate.type != .test else {
+			completion()
 			return
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
@@ -86,7 +86,7 @@ class HealthCertificateNotificationService {
 			healthCertificate.didShowBlockedNotification = true
 		}
 		
-		dispatchGroup.notify(queue: .main) {
+		dispatchGroup.notify(queue: .global()) {
 			completion()
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
@@ -242,6 +242,7 @@ class HealthCertificateNotificationService {
 	) {
 		guard let date = date else {
 			Log.error("Could not schedule expiring soon notification for certificate with id: \(private: healthCertificateIdentifier) because we have no expiringSoonDate.", log: .vaccination)
+			completion()
 			return
 		}
 		

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -495,14 +495,22 @@ class HealthCertificateService: HealthCertificateServiceServable {
 
 		attemptToRestoreDecodingFailedHealthCertificates()
 
+		let dispatchGroup = DispatchGroup()
 		healthCertifiedPersons.forEach { healthCertifiedPerson in
 			healthCertifiedPerson.healthCertificates.forEach { healthCertificate in
 				updateValidityState(for: healthCertificate, person: healthCertifiedPerson)
+				dispatchGroup.enter()
 				healthCertificateNotificationService.recreateNotifications(
 					for: healthCertificate,
-					completion: completion
+					completion: {
+						dispatchGroup.leave()
+					}
 				)
 			}
+		}
+
+		dispatchGroup.notify(queue: .global()) {
+			completion()
 		}
 
 		if shouldScheduleTimer {


### PR DESCRIPTION
## Description
Fixes a crash on the background task that occurred when multiple people had their certificate notifications rescheduled. The completion was called more than once which lead to the `leave()` on the dispatch group being called to often and the background task crashing.

Also adds missing completion calls that were found during the investigation and dispatches to the `global()` queue to stay consistent with the queue handling in the background task.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12703
