### PR TITLE
Fix ValidateHealthCertificate ui-tests

### DIFF
--- a/src/xcode/ENA/ENAUITests/HealthCertificate/Validation/ENAUITests_14_ValidateHealthCertificate.swift
+++ b/src/xcode/ENA/ENAUITests/HealthCertificate/Validation/ENAUITests_14_ValidateHealthCertificate.swift
@@ -60,6 +60,8 @@ class ENAUITests_14_ValidateHealthCertificate: CWATestCase {
 		// Navigate to the person screen
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].firstMatch.waitAndTap()
 
+		app.swipeUp()
+		
 		// Open Validation Screen
 		app.buttons[AccessibilityIdentifiers.HealthCertificate.Person.validationButton].waitAndTap(.extraLong)
 
@@ -82,6 +84,8 @@ class ENAUITests_14_ValidateHealthCertificate: CWATestCase {
 
 		// Navigate to the person screen
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].waitAndTap()
+		
+		app.swipeUp()
 		
 		// Open Validation Screen
 		app.buttons[AccessibilityIdentifiers.HealthCertificate.Person.validationButton].waitAndTap(.extraLong)
@@ -108,7 +112,9 @@ class ENAUITests_14_ValidateHealthCertificate: CWATestCase {
 
 		// Navigate to the person screen
 		app.cells[AccessibilityIdentifiers.HealthCertificate.Overview.healthCertifiedPersonCell].firstMatch.waitAndTap()
-
+		
+		app.swipeUp()
+		
 		// Open Validation Screen
 		app.buttons[AccessibilityIdentifiers.HealthCertificate.Person.validationButton].waitAndTap(.extraLong)
 


### PR DESCRIPTION
## Description
This PR fixes some of the ValidateHealthCertificate screenshot/UITests. 
Normally `app.buttons[AccessibilityIdentifiers.HealthCertificate.Person.validationButton].waitAndTap(.extraLong)` should be enough for the system to scroll to the button. Somehow this does not happen. The UI-Test thinks it has tapped the button, which is btw also `hitable`. Somehow the `tap()` does not go through, only if we swipe up by "hand" the Test is running green.

