### PR TITLE
Fix family member test crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/FamilyMemberCoronaTests/FamilyMemberCoronaTestsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/FamilyMemberCoronaTests/FamilyMemberCoronaTestsViewModel.swift
@@ -22,13 +22,11 @@ class FamilyMemberCoronaTestsViewModel {
 
 		familyMemberCoronaTestService.coronaTests
 			.sink { [weak self] in
-				guard !$0.isEmpty else {
-					self?.coronaTestCellModels = []
-					onLastDeletion()
-					return
-				}
-
 				self?.update(from: $0)
+
+				if $0.isEmpty {
+					onLastDeletion()
+				}
 			}
 			.store(in: &subscriptions)
 	}


### PR DESCRIPTION
## Description
Doesn't skip setting triggerReload to true for empty corona test array anymore. Now uses the same update mechanism as we do when the array is not empty. That way the table view and model don't get out of sync.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12786
