### PR TITLE
Align exposures text (Addresses cwa-documentation issue 578)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.stringsdict
@@ -39,15 +39,15 @@
 			<key>zero</key>
 			<string>Keine Risiko-Begegnungen</string>
 			<key>one</key>
-			<string>Begegnungen mit niedrigem Risiko an 1 Tag</string>
+			<string>Begegnungen an 1 Tag mit niedrigem Risiko</string>
 			<key>few</key>
-			<string>Begegnungen mit niedrigem Risiko an %u Tagen</string>
+			<string>Begegnungen an %u Tagen mit niedrigem Risiko</string>
 			<key>many</key>
-			<string>Begegnungen mit niedrigem Risiko an %u Tagen</string>
+			<string>Begegnungen an %u Tagen mit niedrigem Risiko</string>
 			<key>two</key>
-			<string>Begegnungen mit niedrigem Risiko an %u Tagen</string>
+			<string>Begegnungen an %u Tagen mit niedrigem Risiko</string>
 			<key>other</key>
-			<string>Begegnungen mit niedrigem Risiko an %u Tagen</string>
+			<string>Begegnungen an %u Tagen mit niedrigem Risiko</string>
 		</dict>
 	</dict>
 	<key>Home_Risk_High_Number_Contacts_Item_Title</key>


### PR DESCRIPTION
## Description
This PR aligns the low risk to the high risk wording.

## Link to Jira
- GitHub Issue https://github.com/corona-warn-app/cwa-documentation/issues/578
	- [EXPOSUREAPP-6264](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6264)

## Screenshots
Can't provide sorry, I tried using Launch arguments as @whiskey described in https://github.com/corona-warn-app/cwa-app-ios/issues/3804#issuecomment-963289065, however I was not successful to get the app to show low risk exposures.


---
Internal Tracking ID: [EXPOSUREAPP-6264](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6264)
