### PR TITLE
Feature/11890 cert revocation/12600 update UI 2

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -3321,9 +3321,11 @@ Die Angaben werden statistisch ausgewertet, sie werden nicht zu einem Profil ges
 
 "HealthCertificate_ValidityState_Invalid_description" = "Das Zertifikat wurde von einer nicht autorisierten Stelle oder fehlerhaft ausgestellt. Bitte lassen Sie das Zertifikat von einer autorisierten Stelle erneut ausstellen.";
 
-"HealthCertificate_ValidityState_Blocked" = "Zertifikat ungültig";
+"HealthCertificate_ValidityState_BlockedRevoked" = "Zertifikat ungültig";
 
-"HealthCertificate_ValidityState_Blocked_description" = "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
+"HealthCertificate_ValidityState_BlockedRevoked_description_de" = "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
+
+"HealthCertificate_ValidityState_BlockedRevoked_description_other" = "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.";
 
 /* Reissuance */
 

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/NotificationManager.swift
@@ -135,7 +135,7 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
 		}
 		
 		switch certificateIdentifier {
-		case .certificateExpired, .certificateExpiringSoon, .certificateBlocked, .certificateInvalid:
+		case .certificateExpired, .certificateExpiringSoon, .certificateBlocked, .certificateRevoked, .certificateInvalid:
 			extract(certificateIdentifier.rawValue, from: incomingIdentifier, completion: { [weak self] result in
 				if let (certifiedPerson, healthCertificate) = result {
 					let route = Route(

--- a/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
+++ b/src/xcode/ENA/ENA/Source/Extensions/UNNotificationCenter+Extension.swift
@@ -27,6 +27,7 @@ public enum LocalNotificationIdentifier: String, CaseIterable {
 	case certificateExpired = "HealthCertificateNotificationExpired"
 	case certificateInvalid = "HealthCertificateNotificationInvalid"
 	case certificateBlocked = "HealthCertificateNotificationBlocked"
+	case certificateRevoked = "HealthCertificateNotificationRevoked"
 	case boosterVaccination = "BoosterVaccinationNotification"
 	case certificateReissuance = "CertificateReissuanceNotification"
 	case admissionStateChange = "AdmissionStateChangeNotification"

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -66,11 +66,15 @@ struct HealthCertificateQRCodeCellViewModel {
 					self.validityStateDescription = nil
 				}
 				self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
-			case .blocked:
+			case .blocked, .revoked:
 				   self.validityStateIcon = UIImage(named: "Icon_ExpiredInvalid")
-				   self.validityStateTitle = AppStrings.HealthCertificate.ValidityState.blocked
+				   self.validityStateTitle = AppStrings.HealthCertificate.ValidityState.blockedRevoked
 				   if mode == .details {
-					   self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.blockedDescription
+					   if healthCertificate.cborWebTokenHeader.issuer == "DE" {
+						   self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.blockedRevokedDescriptionDE
+					   } else {
+						   self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.blockedRevokedDescriptionOther
+					   }
 				   } else {
 					   self.validityStateDescription = nil
 				   }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -42,29 +42,17 @@ struct HealthCertificateQRCodeCellViewModel {
 					DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .short, timeStyle: .none),
 					DateFormatter.localizedString(from: healthCertificate.expirationDate, dateStyle: .none, timeStyle: .short)
 				)
-				if mode == .details {
-					self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.expiringSoonDescription
-				} else {
-					self.validityStateDescription = nil
-				}
+				self.validityStateDescription = mode == .details ? AppStrings.HealthCertificate.ValidityState.expiringSoonDescription : nil
 				self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
 			case .expired:
 				self.validityStateIcon = UIImage(named: "Icon_ExpiredInvalid")
 				self.validityStateTitle = AppStrings.HealthCertificate.ValidityState.expired
-				if mode == .details {
-					self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.expiredDescription
-				} else {
-					self.validityStateDescription = nil
-				}
+				self.validityStateDescription = mode == .details ? AppStrings.HealthCertificate.ValidityState.expiredDescription : nil
 				self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
 			case .invalid:
 				self.validityStateIcon = UIImage(named: "Icon_ExpiredInvalid")
 				self.validityStateTitle = AppStrings.HealthCertificate.ValidityState.invalid
-				if mode == .details {
-					self.validityStateDescription = AppStrings.HealthCertificate.ValidityState.invalidDescription
-				} else {
-					self.validityStateDescription = nil
-				}
+				self.validityStateDescription = mode == .details ? AppStrings.HealthCertificate.ValidityState.invalidDescription : nil
 				self.isUnseenNewsIndicatorVisible = mode == .details && healthCertificate.isValidityStateNew
 			case .blocked, .revoked:
 				   self.validityStateIcon = UIImage(named: "Icon_ExpiredInvalid")

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/__tests__/HealthCertificateQRCodeCellViewModelTests.swift
@@ -666,7 +666,7 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
-	func testGIVEN_DetailsViewModelWithBlockedVaccinationCertificate_THEN_IsInitCorrect() throws {
+	func testGIVEN_DetailsViewModelWithBlockedGermanVaccinationCertificate_THEN_IsInitCorrect() throws {
 		// GIVEN
 		let viewModel = HealthCertificateQRCodeCellViewModel(
 			mode: .details,
@@ -676,7 +676,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						vaccinationEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked
 			),
@@ -692,7 +693,41 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedAustrianVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "AT")
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
 
@@ -709,7 +744,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						vaccinationEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked,
 				isValidityStateNew: true
@@ -726,11 +762,185 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
 
 		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithRevokedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake(
+								dateOfVaccination: "2021-06-01"
+							)
+						]
+					)
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyRevokedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake(
+								dateOfVaccination: "2021-06-01"
+							)
+						]
+					)
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedGermanVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedAustrianVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "AT")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyRevokedVaccinationCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						vaccinationEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Impfzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithValidTestCertificate_THEN_IsInitCorrect() throws {
@@ -1376,7 +1586,7 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
-	func testGIVEN_DetailsViewModelWithBlockedTestCertificate_THEN_IsInitCorrect() throws {
+	func testGIVEN_DetailsViewModelWithBlockedGermanTestCertificate_THEN_IsInitCorrect() throws {
 		// GIVEN
 		let viewModel = HealthCertificateQRCodeCellViewModel(
 			mode: .details,
@@ -1386,7 +1596,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						testEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked
 			),
@@ -1402,7 +1613,41 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedItalianTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "IT")
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
 
@@ -1419,7 +1664,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						testEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked,
 				isValidityStateNew: true
@@ -1436,11 +1682,181 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
 
 		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithRevokedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyRevokedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedGermanTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedItalianTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "IT")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyRevokedTestCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						testEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Testzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	func testGIVEN_OverviewViewModelWithValidRecoveryCertificate_THEN_IsInitCorrect() throws {
@@ -2088,7 +2504,7 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
-	func testGIVEN_DetailsViewModelWithBlockedRecoveryCertificate_THEN_IsInitCorrect() throws {
+	func testGIVEN_DetailsViewModelWithBlockedGermanRecoveryCertificate_THEN_IsInitCorrect() throws {
 		// GIVEN
 		let viewModel = HealthCertificateQRCodeCellViewModel(
 			mode: .details,
@@ -2098,7 +2514,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						recoveryEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked
 			),
@@ -2114,7 +2531,41 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithBlockedDutchRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "NL")
+				),
+				validityState: .blocked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
 
@@ -2131,7 +2582,8 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 						recoveryEntries: [
 							.fake()
 						]
-					)
+					),
+					webTokenHeader: .fake(issuer: "DE")
 				),
 				validityState: .blocked,
 				isValidityStateNew: true
@@ -2148,11 +2600,181 @@ class HealthCertificateQRCodeCellViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
 		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
-		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde von der ausstellenden Behörde zurückgerufen. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
 
 		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
 
 		XCTAssertFalse(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithRevokedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_OverviewViewModelWithNewlyRevokedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .overview,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					)
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertNil(viewModel.validityStateDescription)
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedGermanRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithRevokedDutchRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "NL")
+				),
+				validityState: .revoked
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das Zertifikat wurde vom Zertifikataussteller aufgrund einer behördlichen Entscheidung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertFalse(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+	}
+
+	func testGIVEN_DetailsViewModelWithNewlyRevokedRecoveryCertificate_THEN_IsInitCorrect() throws {
+		// GIVEN
+		let viewModel = HealthCertificateQRCodeCellViewModel(
+			mode: .details,
+			healthCertificate: try HealthCertificate(
+				base45: try base45Fake(
+					digitalCovidCertificate: DigitalCovidCertificate.fake(
+						recoveryEntries: [
+							.fake()
+						]
+					),
+					webTokenHeader: .fake(issuer: "DE")
+				),
+				validityState: .revoked,
+				isValidityStateNew: true
+			),
+			accessibilityText: "accessibilityText",
+			onCovPassCheckInfoButtonTap: { }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.subtitle)
+		XCTAssertEqual(viewModel.qrCodeViewModel.accessibilityLabel, "accessibilityText")
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .top)
+
+		XCTAssertEqual(viewModel.validityStateIcon, UIImage(named: "Icon_ExpiredInvalid"))
+		XCTAssertEqual(viewModel.validityStateTitle, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.validityStateDescription, "Das RKI hat das Zertifikat aufgrund einer behördlichen Verfügung gesperrt. Bitte bemühen Sie sich darum, einen neuen digitalen Nachweis ausstellen zu lassen.")
+
+		XCTAssertTrue(viewModel.isUnseenNewsIndicatorVisible)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
 	}
 
 	// swiftlint:disable file_length

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
@@ -286,7 +286,7 @@ final class HealthCertificateCoordinator {
 				)
 			}
 		)
-		printAction.isEnabled = healthCertificate.validityState != .blocked
+		printAction.isEnabled = healthCertificate.validityState != .blocked && healthCertificate.validityState != .revoked
 		actionSheet.addAction(printAction)
 
 		let deleteButtonTitle: String

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateViewModel.swift
@@ -387,7 +387,7 @@ final class HealthCertificateViewModel {
 	}
 
 	private func updateFooterView() {
-		isPrimaryFooterButtonEnabled = healthCertificate.validityState != .blocked
+		isPrimaryFooterButtonEnabled = healthCertificate.validityState != .blocked && healthCertificate.validityState != .revoked
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
@@ -168,11 +168,15 @@ class HealthCertificateViewModelTests: CWATestCase {
 
 		XCTAssertTrue(viewModel.isPrimaryFooterButtonEnabled)
 
+		healthCertificate.validityState = .blocked
+
+		XCTAssertFalse(viewModel.isPrimaryFooterButtonEnabled)
+
 		healthCertificate.validityState = .invalid
 
 		XCTAssertTrue(viewModel.isPrimaryFooterButtonEnabled)
 
-		healthCertificate.validityState = .blocked
+		healthCertificate.validityState = .revoked
 
 		XCTAssertFalse(viewModel.isPrimaryFooterButtonEnabled)
 	}
@@ -181,6 +185,34 @@ class HealthCertificateViewModelTests: CWATestCase {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(from: .fake(vaccinationEntries: [.fake()])),
 			validityState: .blocked
+		)
+
+		let certifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let vaccinationValueSetsProvider = VaccinationValueSetsProvider(
+			client: CachingHTTPClientMock(),
+			store: MockTestStore()
+		)
+
+		let viewModel = HealthCertificateViewModel(
+			healthCertifiedPerson: certifiedPerson,
+			healthCertificate: healthCertificate,
+			vaccinationValueSetsProvider: vaccinationValueSetsProvider,
+			markAsSeenOnDisappearance: true,
+			showInfoHit: { }
+		)
+
+		XCTAssertFalse(viewModel.isPrimaryFooterButtonEnabled)
+
+		healthCertificate.validityState = .valid
+
+		XCTAssertTrue(viewModel.isPrimaryFooterButtonEnabled)
+	}
+
+	func testIsPrimaryFooterButtonEnabledInitiallyRevoked() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(from: .fake(vaccinationEntries: [.fake()])),
+			validityState: .revoked
 		)
 
 		let certifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/__tests__/HealthCertificateViewModelTests.swift
@@ -211,7 +211,7 @@ class HealthCertificateViewModelTests: CWATestCase {
 
 	func testIsPrimaryFooterButtonEnabledInitiallyRevoked() throws {
 		let healthCertificate = try HealthCertificate(
-			base45: try base45Fake(from: .fake(vaccinationEntries: [.fake()])),
+			base45: try base45Fake(digitalCovidCertificate: .fake(vaccinationEntries: [.fake()])),
 			validityState: .revoked
 		)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -128,8 +128,8 @@ final class HealthCertificateCellViewModel {
 					return AppStrings.HealthCertificate.ValidityState.expired
 				case .invalid:
 					return AppStrings.HealthCertificate.ValidityState.invalid
-				case .blocked:
-					return AppStrings.HealthCertificate.ValidityState.blocked
+				case .blocked, .revoked:
+					return AppStrings.HealthCertificate.ValidityState.blockedRevoked
 				}
 			} else if healthCertificate.isNew {
 				return AppStrings.HealthCertificate.Person.newlyAddedCertificate

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/HealthCertificate/HealthCertificateCellViewModel.swift
@@ -199,7 +199,7 @@ final class HealthCertificateCellViewModel {
 	}()
 
 	lazy var isValidationButtonEnabled: Bool = {
-		healthCertificate.validityState != .blocked
+		healthCertificate.validityState != .blocked && healthCertificate.validityState != .revoked
 	}()
 	
 	func didTapValidationButton(loadingStateHandler: @escaping (Bool) -> Void) {

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
@@ -337,6 +337,44 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
 	}
 
+	func testAllDetailsViewModelWithRevokedIncompleteVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [
+						VaccinationEntry.fake(
+							doseNumber: 1,
+							totalSeriesOfDoses: 2,
+							dateOfVaccination: "2021-06-01"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetails
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Impfung 1 von 2")
+		XCTAssertEqual(viewModel.detail, "Geimpft am 01.06.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
 	func testAllDetailsViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -634,6 +672,43 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
 	}
 
+	func testAllDetailsViewModelWithRevokedAntigenTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [
+						TestEntry.fake(
+							typeOfTest: "LP217198-3",
+							dateTimeOfSampleCollection: "2021-05-29T14:36:00.000Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetails
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Testzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Schnelltest")
+		XCTAssertEqual(viewModel.detail, "Probenahme am 29.05.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
 	func testAllDetailsViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -834,6 +909,42 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetails
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertNil(viewModel.subheadline)
+		XCTAssertEqual(viewModel.detail, "Positiver Test vom 01.03.22")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertTrue(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
+	func testAllDetailsViewModelWithRevokedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [
+						RecoveryEntry.fake(
+							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
 			isNew: true
 		)
 
@@ -1258,6 +1369,44 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
 	}
 
+	func testAllDetailsWithoutValidationButtonViewModelWithRevokedIncompleteVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [
+						VaccinationEntry.fake(
+							doseNumber: 1,
+							totalSeriesOfDoses: 2,
+							dateOfVaccination: "2021-06-01"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetailsWithoutValidationButton
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Impfung 1 von 2")
+		XCTAssertEqual(viewModel.detail, "Geimpft am 01.06.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
 	func testAllDetailsWithoutValidationButtonViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -1555,6 +1704,43 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonEnabled)
 	}
 
+	func testAllDetailsWithoutValidationButtonViewModelWithRevokedAntigenTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [
+						TestEntry.fake(
+							typeOfTest: "LP217198-3",
+							dateTimeOfSampleCollection: "2021-05-29T14:36:00.000Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetailsWithoutValidationButton
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Testzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Schnelltest")
+		XCTAssertEqual(viewModel.detail, "Probenahme am 29.05.21")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
 	func testAllDetailsWithoutValidationButtonViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -1755,6 +1941,42 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .allDetailsWithoutValidationButton
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .solidGrey)
+		XCTAssertEqual(viewModel.headline, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertNil(viewModel.subheadline)
+		XCTAssertEqual(viewModel.detail, "Positiver Test vom 01.03.22")
+		XCTAssertEqual(viewModel.validityStateInfo, "Zertifikat ungültig")
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertEqual(viewModel.currentlyUsedImage, UIImage(named: "Icon_CurrentlyUsedCertificate_grey"))
+		XCTAssertTrue(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+		XCTAssertFalse(viewModel.isValidationButtonEnabled)
+	}
+
+	func testAllDetailsWithoutValidationButtonViewModelWithRevokedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [
+						RecoveryEntry.fake(
+							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
 			isNew: true
 		)
 
@@ -2155,6 +2377,42 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 	}
 
+	func testOverviewViewModelWithRevokedIncompleteVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					vaccinationEntries: [
+						VaccinationEntry.fake(
+							doseNumber: 1,
+							totalSeriesOfDoses: 2,
+							dateOfVaccination: "2021-06-01"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overview
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Impfung 1 von 2")
+		XCTAssertEqual(viewModel.detail, "Geimpft am 01.06.21")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
 	func testOverviewViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -2436,6 +2694,41 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 	}
 
+	func testOverviewViewModelWithRevokedAntigenTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					testEntries: [
+						TestEntry.fake(
+							typeOfTest: "LP217198-3",
+							dateTimeOfSampleCollection: "2021-05-29T14:36:00.000Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overview
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Testzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertEqual(viewModel.subheadline, "Schnelltest")
+		XCTAssertEqual(viewModel.detail, "Probenahme am 29.05.21")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
 	func testOverviewViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -2619,6 +2912,40 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overview
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Genesenenzertifikat")
+		XCTAssertNil(viewModel.name)
+		XCTAssertNil(viewModel.subheadline)
+		XCTAssertEqual(viewModel.detail, "Positiver Test vom 01.03.22")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testOverviewViewModelWithRevokedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					recoveryEntries: [
+						RecoveryEntry.fake(
+							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
 			isNew: true
 		)
 
@@ -3041,6 +3368,43 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 	}
 
+	func testOverviewPlusNameViewModelWithRevokedIncompleteVaccinationCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					name: .fake(familyName: "Scherer", givenName: "Marcus"),
+					vaccinationEntries: [
+						VaccinationEntry.fake(
+							doseNumber: 1,
+							totalSeriesOfDoses: 2,
+							dateOfVaccination: "2021-06-01"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overviewPlusName
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Impfzertifikat")
+		XCTAssertEqual(viewModel.name, "Marcus Scherer")
+		XCTAssertEqual(viewModel.subheadline, "Impfung 1 von 2")
+		XCTAssertEqual(viewModel.detail, "Geimpft am 01.06.21")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
 	func testOverviewPlusNameViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -3330,6 +3694,42 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		XCTAssertFalse(viewModel.isValidationButtonVisible)
 	}
 
+	func testOverviewPlusNameViewModelWithRevokedAntigenTestCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					name: .fake(familyName: "Friesen", givenName: "Artur"),
+					testEntries: [
+						TestEntry.fake(
+							typeOfTest: "LP217198-3",
+							dateTimeOfSampleCollection: "2021-05-29T14:36:00.000Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overviewPlusName
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Testzertifikat")
+		XCTAssertEqual(viewModel.name, "Artur Friesen")
+		XCTAssertEqual(viewModel.subheadline, "Schnelltest")
+		XCTAssertEqual(viewModel.detail, "Probenahme am 29.05.21")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
 	func testOverviewPlusNameViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
@@ -3519,6 +3919,41 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked,
+			isNew: true
+		)
+
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+
+		let viewModel = HealthCertificateCellViewModel(
+			healthCertificate: healthCertificate,
+			healthCertifiedPerson: healthCertifiedPerson,
+			details: .overviewPlusName
+		)
+
+		XCTAssertEqual(viewModel.gradientType, .lightBlue)
+		XCTAssertEqual(viewModel.headline, "Genesenenzertifikat")
+		XCTAssertEqual(viewModel.name, "Marcus Scherer")
+		XCTAssertNil(viewModel.subheadline)
+		XCTAssertEqual(viewModel.detail, "Positiver Test vom 01.03.22")
+		XCTAssertNil(viewModel.validityStateInfo)
+		XCTAssertEqual(viewModel.image, UIImage(imageLiteralResourceName: "Icon_WarningTriangle_small"))
+		XCTAssertFalse(viewModel.isCurrentlyUsedCertificateHintVisible)
+		XCTAssertFalse(viewModel.isValidationButtonVisible)
+	}
+
+	func testOverviewPlusNameViewModelWithRevokedRecoveryCertificate() throws {
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				from: DigitalCovidCertificate.fake(
+					name: .fake(familyName: "Scherer", givenName: "Marcus"),
+					recoveryEntries: [
+						RecoveryEntry.fake(
+							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
+						)
+					]
+				)
+			),
+			validityState: .revoked,
 			isNew: true
 		)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertificateCellViewModelTests.swift
@@ -14,7 +14,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -50,7 +50,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithNewValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -180,7 +180,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -226,7 +226,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithExpiredIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -264,7 +264,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithInvalidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -302,7 +302,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithBlockedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -340,7 +340,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithRevokedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -378,7 +378,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -414,7 +414,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithNewValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -451,7 +451,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithSoonExpiringAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -489,7 +489,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithSoonExpiringNewAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -527,7 +527,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithExpiredTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -564,7 +564,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithExpiredNewTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -601,7 +601,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithInvalidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -638,7 +638,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithBlockedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -675,7 +675,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithRevokedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -712,7 +712,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -747,7 +747,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithNewValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -784,7 +784,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -828,7 +828,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithExpiredRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -864,7 +864,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithInvalidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -900,7 +900,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithBlockedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -936,7 +936,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsViewModelWithRevokedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1046,7 +1046,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1082,7 +1082,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithNewValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1212,7 +1212,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1258,7 +1258,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithExpiredIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1296,7 +1296,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithInvalidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1334,7 +1334,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithBlockedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1372,7 +1372,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithRevokedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -1410,7 +1410,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -1446,7 +1446,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithNewValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -1483,7 +1483,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithSoonExpiringAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -1521,7 +1521,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithSoonExpiringNewAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -1559,7 +1559,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithExpiredTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -1596,7 +1596,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithExpiredNewTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -1633,7 +1633,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithInvalidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -1670,7 +1670,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithBlockedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -1707,7 +1707,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithRevokedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -1744,7 +1744,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1779,7 +1779,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithNewValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1816,7 +1816,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1860,7 +1860,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithExpiredRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1896,7 +1896,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithInvalidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1932,7 +1932,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithBlockedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -1968,7 +1968,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testAllDetailsWithoutValidationButtonViewModelWithRevokedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2078,7 +2078,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2113,7 +2113,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithNewValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2235,7 +2235,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2272,7 +2272,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithExpiredIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2308,7 +2308,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithInvalidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2344,7 +2344,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithBlockedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2380,7 +2380,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithRevokedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					vaccinationEntries: [
 						VaccinationEntry.fake(
 							doseNumber: 1,
@@ -2416,7 +2416,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -2450,7 +2450,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithNewValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -2485,7 +2485,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithSoonExpiringAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -2521,7 +2521,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithSoonExpiringNewAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -2557,7 +2557,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithExpiredTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -2592,7 +2592,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithExpiredNewTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP123456-7",
@@ -2627,7 +2627,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithInvalidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP6464-4",
@@ -2662,7 +2662,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithBlockedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -2697,7 +2697,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithRevokedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					testEntries: [
 						TestEntry.fake(
 							typeOfTest: "LP217198-3",
@@ -2732,7 +2732,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2765,7 +2765,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithNewValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2800,7 +2800,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2835,7 +2835,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithExpiredRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2869,7 +2869,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithInvalidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2903,7 +2903,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithBlockedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -2937,7 +2937,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewViewModelWithRevokedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					recoveryEntries: [
 						RecoveryEntry.fake(
 							dateOfFirstPositiveNAAResult: "2022-03-01T07:12:45.132Z"
@@ -3045,7 +3045,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Guendling", givenName: "Nick"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3081,7 +3081,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithNewValidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Teuber", givenName: "Kai-Marcel"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3222,7 +3222,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Ahmed", givenName: "Omar Abdelaziz Hanafy Abdelaziz"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3260,7 +3260,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithExpiredIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Guendling", givenName: "Nick"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3297,7 +3297,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithInvalidIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Teuber", givenName: "Kai-Marcel"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3334,7 +3334,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithBlockedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Scherer", givenName: "Marcus"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3371,7 +3371,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithRevokedIncompleteVaccinationCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Scherer", givenName: "Marcus"),
 					vaccinationEntries: [
 						VaccinationEntry.fake(
@@ -3408,7 +3408,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Friesen", givenName: "Artur"),
 					testEntries: [
 						TestEntry.fake(
@@ -3443,7 +3443,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithNewValidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Brause", givenName: "Pascal"),
 					testEntries: [
 						TestEntry.fake(
@@ -3479,7 +3479,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithSoonExpiringAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Khalid", givenName: "Naveed"),
 					testEntries: [
 						TestEntry.fake(
@@ -3516,7 +3516,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithSoonExpiringNewAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Ahmed", givenName: "Omar Abdelaziz Hanafy Abdelaziz"),
 					testEntries: [
 						TestEntry.fake(
@@ -3553,7 +3553,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithExpiredTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Guendling", givenName: "Nick"),
 					testEntries: [
 						TestEntry.fake(
@@ -3589,7 +3589,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithExpiredNewTestCertificateOfUnknownType() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Teuber", givenName: "Kai-Marcel"),
 					testEntries: [
 						TestEntry.fake(
@@ -3625,7 +3625,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithInvalidPCRTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Scherer", givenName: "Marcus"),
 					testEntries: [
 						TestEntry.fake(
@@ -3661,7 +3661,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithBlockedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Friesen", givenName: "Artur"),
 					testEntries: [
 						TestEntry.fake(
@@ -3697,7 +3697,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithRevokedAntigenTestCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Friesen", givenName: "Artur"),
 					testEntries: [
 						TestEntry.fake(
@@ -3733,7 +3733,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Brause", givenName: "Pascal"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3767,7 +3767,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithNewValidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Khalid", givenName: "Naveed"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3803,7 +3803,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 		let expirationDate = Date(timeIntervalSince1970: 1627987295)
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Ahmed", givenName: "Omar Abdelaziz Hanafy Abdelaziz"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3839,7 +3839,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithExpiredRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Guendling", givenName: "Nick"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3874,7 +3874,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithInvalidRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Teuber", givenName: "Kai-Marcel"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3909,7 +3909,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithBlockedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				digitalCovidCertificate: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Scherer", givenName: "Marcus"),
 					recoveryEntries: [
 						RecoveryEntry.fake(
@@ -3944,7 +3944,7 @@ class HealthCertificateCellViewModelTests: XCTestCase {
 	func testOverviewPlusNameViewModelWithRevokedRecoveryCertificate() throws {
 		let healthCertificate = try HealthCertificate(
 			base45: try base45Fake(
-				from: DigitalCovidCertificate.fake(
+				digitalCovidCertificate: .fake(
 					name: .fake(familyName: "Scherer", givenName: "Marcus"),
 					recoveryEntries: [
 						RecoveryEntry.fake(

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -161,10 +161,10 @@ class HealthCertifiedPersonCellModel {
 				image: UIImage(named: "Icon_ExpiredInvalid"),
 				description: AppStrings.HealthCertificate.ValidityState.invalid
 			)
-		case .blocked:
+		case .blocked, .revoked:
 			return .validityState(
 				image: UIImage(named: "Icon_ExpiredInvalid"),
-				description: AppStrings.HealthCertificate.ValidityState.blocked
+				description: AppStrings.HealthCertificate.ValidityState.blockedRevoked
 			)
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/__tests__/HealthCertifiedPersonCellModelTests.swift
@@ -236,6 +236,51 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 		}
 	}
 
+	func testHealthCertifiedPersonWithRevokedVaccinationCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				digitalCovidCertificate: DigitalCovidCertificate.fake(
+					vaccinationEntries: [.fake()]
+				)
+			),
+			validityState: .revoked
+		)
+
+		let cclService = FakeCCLService()
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+		healthCertifiedPerson.dccWalletInfo = .fake(
+			verification: .fake(
+				certificates: [.fake(certificateRef: .fake(barcodeData: healthCertificate.base45))]
+			)
+		)
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				cclService: cclService,
+				onCovPassCheckInfoButtonTap: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+
+		XCTAssertFalse(viewModel.isStatusTitleVisible)
+		XCTAssertNil(viewModel.shortStatus)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .bottom)
+
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
 	func testHealthCertifiedPersonWithValidTestCertificate() throws {
 		// GIVEN
 		let healthCertificate = try HealthCertificate(
@@ -401,6 +446,51 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked
+		)
+
+		let cclService = FakeCCLService()
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+		healthCertifiedPerson.dccWalletInfo = .fake(
+			verification: .fake(
+				certificates: [.fake(certificateRef: .fake(barcodeData: healthCertificate.base45))]
+			)
+		)
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				cclService: cclService,
+				onCovPassCheckInfoButtonTap: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+
+		XCTAssertFalse(viewModel.isStatusTitleVisible)
+		XCTAssertNil(viewModel.shortStatus)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .bottom)
+
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
+	func testHealthCertifiedPersonWithRevokedTestCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				digitalCovidCertificate: DigitalCovidCertificate.fake(
+					testEntries: [.fake()]
+				)
+			),
+			validityState: .revoked
 		)
 
 		let cclService = FakeCCLService()
@@ -626,6 +716,47 @@ class HealthCertifiedPersonCellModelTests: XCTestCase {
 				)
 			),
 			validityState: .blocked
+		)
+
+		let cclService = FakeCCLService()
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [healthCertificate])
+		// Not setting dccWalletInfo.verification here to check that the fallback certificate is used if it's not set
+
+		let viewModel = try XCTUnwrap(
+			HealthCertifiedPersonCellModel(
+				healthCertifiedPerson: healthCertifiedPerson,
+				cclService: cclService,
+				onCovPassCheckInfoButtonTap: { }
+			)
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.title, AppStrings.HealthCertificate.Overview.covidTitle)
+		XCTAssertEqual(viewModel.name, healthCertifiedPerson.name?.fullName)
+
+		XCTAssertFalse(viewModel.isStatusTitleVisible)
+		XCTAssertNil(viewModel.shortStatus)
+
+		XCTAssertTrue(viewModel.qrCodeViewModel.shouldBlockCertificateCode)
+		XCTAssertEqual(viewModel.qrCodeViewModel.covPassCheckInfoPosition, .bottom)
+
+		if case let .validityState(image: image, description: description) = viewModel.caption {
+			XCTAssertEqual(image, UIImage(named: "Icon_ExpiredInvalid"))
+			XCTAssertEqual(description, "Zertifikat ungültig")
+		} else {
+			XCTFail("Expected caption to be set to validityState")
+		}
+	}
+
+	func testHealthCertifiedPersonWithRevokedRecoveryCertificate() throws {
+		// GIVEN
+		let healthCertificate = try HealthCertificate(
+			base45: try base45Fake(
+				digitalCovidCertificate: DigitalCovidCertificate.fake(
+					recoveryEntries: [.fake()]
+				)
+			),
+			validityState: .revoked
 		)
 
 		let cclService = FakeCCLService()

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateNotificationService.swift
@@ -75,7 +75,6 @@ class HealthCertificateNotificationService {
 
 		// Schedule a 'blocked' notification, if it was not scheduled before.
 		if healthCertificate.validityState == .blocked && !healthCertificate.didShowBlockedNotification {
-			
 			dispatchGroup.enter()
 			scheduleBlockedNotification(
 				healthCertificateIdentifier: healthCertificateIdentifier,
@@ -84,6 +83,18 @@ class HealthCertificateNotificationService {
 				}
 			)
 			healthCertificate.didShowBlockedNotification = true
+		}
+
+		// Schedule a 'revoked' notification, if it was not scheduled before.
+		if healthCertificate.validityState == .revoked && !healthCertificate.didShowRevokedNotification {
+			dispatchGroup.enter()
+			scheduleRevokedNotification(
+				healthCertificateIdentifier: healthCertificateIdentifier,
+				completion: {
+					dispatchGroup.leave()
+				}
+			)
+			healthCertificate.didShowRevokedNotification = true
 		}
 		
 		dispatchGroup.notify(queue: .global()) {
@@ -339,6 +350,29 @@ class HealthCertificateNotificationService {
 
 		let request = UNNotificationRequest(
 			identifier: LocalNotificationIdentifier.certificateBlocked.rawValue + "\(healthCertificateIdentifier)",
+			content: content,
+			trigger: nil
+		)
+
+		addNotification(
+			request: request,
+			completion: completion
+		)
+	}
+
+	private func scheduleRevokedNotification(
+		healthCertificateIdentifier: String,
+		completion: @escaping () -> Void
+	) {
+		Log.info("Schedule revoked notification for certificate with id: \(private: healthCertificateIdentifier)", log: .vaccination)
+
+		let content = UNMutableNotificationContent()
+		content.title = AppStrings.LocalNotifications.certificateGenericTitle
+		content.body = AppStrings.LocalNotifications.certificateValidityBody
+		content.sound = .default
+
+		let request = UNNotificationRequest(
+			identifier: LocalNotificationIdentifier.certificateRevoked.rawValue + "\(healthCertificateIdentifier)",
 			content: content,
 			trigger: nil
 		)

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -803,7 +803,6 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	}
 
 	private func updateTimeBasedValidityState(for healthCertificate: HealthCertificate) {
-
 		let currentAppConfiguration = appConfiguration.currentAppConfig.value
 		let expirationThresholdInDays = currentAppConfiguration.dgcParameters.expirationThresholdInDays
 		let expiringSoonDate = Calendar.current.date(

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -15,6 +15,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		validityState: HealthCertificateValidityState = .valid,
 		didShowInvalidNotification: Bool = false,
 		didShowBlockedNotification: Bool = false,
+		didShowRevokedNotification: Bool = false,
 		isNew: Bool = false,
 		isValidityStateNew: Bool = false,
 		revocationEntries: HealthCertificateRevocationEntries? = nil
@@ -23,6 +24,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		self.validityState = validityState
 		self.didShowInvalidNotification = didShowInvalidNotification
 		self.didShowBlockedNotification = didShowBlockedNotification
+		self.didShowRevokedNotification = didShowRevokedNotification
 		self.isNew = isNew
 		self.isValidityStateNew = isValidityStateNew
 
@@ -53,6 +55,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		isNew = try container.decodeIfPresent(Bool.self, forKey: .isNew) ?? false
 		didShowInvalidNotification = try container.decodeIfPresent(Bool.self, forKey: .didShowInvalidNotification) ?? false
 		didShowBlockedNotification = try container.decodeIfPresent(Bool.self, forKey: .didShowBlockedNotification) ?? false
+		didShowRevokedNotification = try container.decodeIfPresent(Bool.self, forKey: .didShowRevokedNotification) ?? false
 		
 		let certificateComponents = try Self.extractCertificateComponents(from: base45)
 		cborWebTokenHeader = certificateComponents.header
@@ -88,6 +91,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		case isValidityStateNew
 		case didShowInvalidNotification
 		case didShowBlockedNotification
+		case didShowRevokedNotification
 		case revocationEntries
 	}
 
@@ -98,7 +102,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		try container.encode(validityState, forKey: .validityState)
 		try container.encode(isNew, forKey: .isNew)
 		try container.encode(isValidityStateNew, forKey: .isValidityStateNew)
-		try container.encode(didShowInvalidNotification, forKey: .didShowInvalidNotification)
+		try container.encode(didShowRevokedNotification, forKey: .didShowRevokedNotification)
 		try container.encode(didShowBlockedNotification, forKey: .didShowBlockedNotification)
 		try container.encode(revocationEntries, forKey: .revocationEntries)
 	}
@@ -159,6 +163,14 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 	@DidSetPublished var didShowBlockedNotification: Bool {
 		didSet {
 			if didShowBlockedNotification != oldValue {
+				objectDidChange.send(self)
+			}
+		}
+	}
+
+	@DidSetPublished var didShowRevokedNotification: Bool {
+		didSet {
+			if didShowRevokedNotification != oldValue {
 				objectDidChange.send(self)
 			}
 		}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -276,7 +276,7 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		validityState == .valid || validityState == .expiringSoon || (type == .test && validityState == .expired)
 	}
 
-	/// On test certificates only `.valid`, `.invalid`, and `.blocked` states are shown, the `.expiringSoon` and `.expired` states are considered valid as well
+	/// On test certificates only `.valid`, `.invalid`,  `.blocked`, and `.revoked` states are shown, the `.expiringSoon` and `.expired` states are considered valid as well
 	var isConsideredValid: Bool {
 		validityState == .valid || type == .test && (validityState == .expiringSoon || validityState == .expired)
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -102,8 +102,9 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		try container.encode(validityState, forKey: .validityState)
 		try container.encode(isNew, forKey: .isNew)
 		try container.encode(isValidityStateNew, forKey: .isValidityStateNew)
-		try container.encode(didShowRevokedNotification, forKey: .didShowRevokedNotification)
+		try container.encode(didShowInvalidNotification, forKey: .didShowInvalidNotification)
 		try container.encode(didShowBlockedNotification, forKey: .didShowBlockedNotification)
+		try container.encode(didShowRevokedNotification, forKey: .didShowRevokedNotification)
 		try container.encode(revocationEntries, forKey: .revocationEntries)
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateDecodingContainer.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateDecodingContainer.swift
@@ -16,6 +16,7 @@ final class HealthCertificateDecodingContainer: Codable {
 	let validityState: HealthCertificateValidityState?
 	let didShowInvalidNotification: Bool?
 	let didShowBlockedNotification: Bool?
+	let didShowRevokedNotification: Bool?
 	let isNew: Bool?
 	let isValidityStateNew: Bool?
 	let revocationEntries: HealthCertificateRevocationEntries?
@@ -30,6 +31,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 		validityState: HealthCertificateValidityState,
 		didShowInvalidNotification: Bool,
 		didShowBlockedNotification: Bool,
+		didShowRevokedNotification: Bool,
 		isNew: Bool,
 		isValidityStateNew: Bool,
 		revocationEntries: HealthCertificateRevocationEntries?,
@@ -39,6 +41,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 		self.validityState = validityState
 		self.didShowInvalidNotification = didShowInvalidNotification
 		self.didShowBlockedNotification = didShowBlockedNotification
+		self.didShowRevokedNotification = didShowRevokedNotification
 		self.isNew = isNew
 		self.isValidityStateNew = isValidityStateNew
 		self.revocationEntries = revocationEntries
@@ -52,6 +55,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 		case validityState
 		case didShowInvalidNotification
 		case didShowBlockedNotification
+		case didShowRevokedNotification
 		case isNew
 		case isValidityStateNew
 		case revocationEntries
@@ -65,6 +69,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 		validityState = try container.decode(HealthCertificateValidityState.self, forKey: .validityState)
 		didShowInvalidNotification = try container.decode(Bool.self, forKey: .didShowInvalidNotification)
 		didShowBlockedNotification = try container.decode(Bool.self, forKey: .didShowBlockedNotification)
+		didShowRevokedNotification = try container.decode(Bool.self, forKey: .didShowRevokedNotification)
 		isNew = try container.decode(Bool.self, forKey: .isNew)
 		isValidityStateNew = try container.decode(Bool.self, forKey: .isValidityStateNew)
 		revocationEntries = try container.decodeIfPresent(HealthCertificateRevocationEntries.self, forKey: .revocationEntries)
@@ -78,6 +83,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 		try container.encode(validityState, forKey: .validityState)
 		try container.encode(didShowInvalidNotification, forKey: .didShowInvalidNotification)
 		try container.encode(didShowBlockedNotification, forKey: .didShowBlockedNotification)
+		try container.encode(didShowRevokedNotification, forKey: .didShowRevokedNotification)
 		try container.encode(isNew, forKey: .isNew)
 		try container.encode(isValidityStateNew, forKey: .isValidityStateNew)
 		try container.encode(revocationEntries, forKey: .revocationEntries)
@@ -95,6 +101,7 @@ class DecodingFailedHealthCertificate: Codable, Equatable {
 	let validityState: HealthCertificateValidityState
 	let didShowInvalidNotification: Bool
 	let didShowBlockedNotification: Bool
+	let didShowRevokedNotification: Bool
 	let isNew: Bool
 	let isValidityStateNew: Bool
 	let revocationEntries: HealthCertificateRevocationEntries?

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateMapping.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateMapping.swift
@@ -17,6 +17,8 @@ extension HealthCertificateValidityState {
 			return "INVALID"
 		case .blocked:
 			return "BLOCKED"
+		case .revoked:
+			return "REVOKED"
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateValidityState.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificateValidityState.swift
@@ -10,4 +10,5 @@ enum HealthCertificateValidityState: Int, Codable {
 	case expired
 	case invalid
 	case blocked
+	case revoked
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -69,6 +69,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 					validityState: decodingContainer.validityState ?? .valid,
 					didShowInvalidNotification: decodingContainer.didShowInvalidNotification ?? false,
 					didShowBlockedNotification: decodingContainer.didShowBlockedNotification ?? false,
+					didShowRevokedNotification: decodingContainer.didShowRevokedNotification ?? false,
 					isNew: decodingContainer.isNew ?? false,
 					isValidityStateNew: decodingContainer.isValidityStateNew ?? false,
 					revocationEntries: decodingContainer.revocationEntries
@@ -83,6 +84,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 					validityState: decodingContainer.validityState ?? .valid,
 					didShowInvalidNotification: decodingContainer.didShowInvalidNotification ?? false,
 					didShowBlockedNotification: decodingContainer.didShowBlockedNotification ?? false,
+					didShowRevokedNotification: decodingContainer.didShowRevokedNotification ?? false,
 					isNew: decodingContainer.isNew ?? false,
 					isValidityStateNew: decodingContainer.isValidityStateNew ?? false,
 					revocationEntries: decodingContainer.revocationEntries,
@@ -300,6 +302,7 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 					validityState: certificate.validityState,
 					didShowInvalidNotification: certificate.didShowInvalidNotification,
 					didShowBlockedNotification: certificate.didShowBlockedNotification,
+					didShowRevokedNotification: certificate.didShowRevokedNotification,
 					isNew: certificate.isNew,
 					isValidityStateNew: certificate.isValidityStateNew
 				)

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
@@ -125,6 +125,7 @@ class HealthCertifiedPersonTests: CWATestCase {
 		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates.map { $0.isValidityStateNew }, [firstHealthCertificate, secondHealthCertificate].map { $0.isValidityStateNew })
 		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates.map { $0.didShowInvalidNotification }, [firstHealthCertificate, secondHealthCertificate].map { $0.didShowInvalidNotification })
 		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates.map { $0.didShowBlockedNotification }, [firstHealthCertificate, secondHealthCertificate].map { $0.didShowBlockedNotification })
+		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates.map { $0.didShowRevokedNotification }, [firstHealthCertificate, secondHealthCertificate].map { $0.didShowRevokedNotification })
 	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
@@ -82,7 +82,10 @@ class HealthCertifiedPersonTests: CWATestCase {
 					digitalCovidCertificate: DigitalCovidCertificate.fake(vaccinationEntries: [.fake()]
 				)
 			),
+			validityState: .valid,
 			didShowInvalidNotification: false,
+			didShowBlockedNotification: false,
+			didShowRevokedNotification: false,
 			isNew: false,
 			isValidityStateNew: false
 		)
@@ -92,7 +95,10 @@ class HealthCertifiedPersonTests: CWATestCase {
 					digitalCovidCertificate: DigitalCovidCertificate.fake(vaccinationEntries: [.fake()]
 				)
 			),
+			validityState: .invalid,
 			didShowInvalidNotification: true,
+			didShowBlockedNotification: true,
+			didShowRevokedNotification: true,
 			isNew: true,
 			isValidityStateNew: true
 		)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -2247,8 +2247,9 @@ enum AppStrings {
 			static let expiredDescription = NSLocalizedString("HealthCertificate_ValidityState_Expired_description", comment: "")
 			static let invalid = NSLocalizedString("HealthCertificate_ValidityState_Invalid", comment: "")
 			static let invalidDescription = NSLocalizedString("HealthCertificate_ValidityState_Invalid_description", comment: "")
-			static let blocked = NSLocalizedString("HealthCertificate_ValidityState_Blocked", comment: "")
-			static let blockedDescription = NSLocalizedString("HealthCertificate_ValidityState_Blocked_description", comment: "")
+			static let blockedRevoked = NSLocalizedString("HealthCertificate_ValidityState_BlockedRevoked", comment: "")
+			static let blockedRevokedDescriptionDE = NSLocalizedString("HealthCertificate_ValidityState_BlockedRevoked_description_de", comment: "")
+			static let blockedRevokedDescriptionOther = NSLocalizedString("HealthCertificate_ValidityState_BlockedRevoked_description_other", comment: "")
 		}
 
 		enum FamilyMemberConsent {


### PR DESCRIPTION
## Description
- Adds `revoked` state to health certificates
- Triggers a notification if health certificate becomes `revoked`
- Implement and update texts, QR code presentation and button states for `blocked` and `revoked` states
- Add some unit tests, and some more, and then even more of them 😁 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12597
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12598
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12599
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12600

## Screenshots
![Simulator Screen Shot - iPhone 13 Pro - 2022-04-20 at 13 43 52](https://user-images.githubusercontent.com/1157991/164232397-d06956f2-1d75-466c-9333-4ca10af6cee6.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-04-20 at 13 45 17](https://user-images.githubusercontent.com/1157991/164232390-415b74cc-4b75-4e02-806f-e7effd385e64.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-04-20 at 13 45 25](https://user-images.githubusercontent.com/1157991/164232384-71bd9eb8-6082-43d3-8e0e-784c2d718b79.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-04-20 at 13 45 28](https://user-images.githubusercontent.com/1157991/164232378-f78b0df9-c296-4ade-ae28-3fafeda26c95.png)

