### PR TITLE
Pass-updated-name-to-the-consent-screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/AntigenTestProfileViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/AntigenTestProfile/AntigenTestProfile/AntigenTestProfileViewController.swift
@@ -11,7 +11,7 @@ class AntigenTestProfileViewController: UIViewController, UITableViewDataSource,
 
 	init(
 		viewModel: AntigenTestProfileViewModel,
-		didTapContinue: @escaping (@escaping (Bool) -> Void) -> Void,
+		didTapContinue: @escaping ((@escaping (Bool) -> Void), AntigenTestProfile) -> Void,
 		didTapProfileInfo: @escaping () -> Void,
 		didTapEditProfile: @escaping (AntigenTestProfile) -> Void,
 		didTapDeleteProfile: @escaping () -> Void,
@@ -80,7 +80,7 @@ class AntigenTestProfileViewController: UIViewController, UITableViewDataSource,
 	func didTapFooterViewButton(_ type: FooterViewModel.ButtonType) {
 		switch type {
 		case .primary:
-			didTapContinue({ _ in Log.debug("is loading closure here") })
+			didTapContinue({ _ in Log.debug("is loading closure here") }, viewModel.antigenTestProfile)
 		case .secondary:
 			let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 			alertController.addAction(UIAlertAction(title: AppStrings.AntigenProfile.Profile.infoActionTitle, style: .default, handler: { [weak self] _ in
@@ -166,7 +166,7 @@ class AntigenTestProfileViewController: UIViewController, UITableViewDataSource,
 	// MARK: - Private
 	
 	private var viewModel: AntigenTestProfileViewModel
-	private let didTapContinue: (@escaping (Bool) -> Void) -> Void
+	private let didTapContinue: ((@escaping (Bool) -> Void), AntigenTestProfile) -> Void
 	private let didTapProfileInfo: () -> Void
 	private let didTapEditProfile: (AntigenTestProfile) -> Void
 	private let didTapDeleteProfile: () -> Void

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -1061,7 +1061,7 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 				antigenTestProfile: antigenTestProfile,
 				store: store
 			),
-			didTapContinue: { [weak self] isLoading in
+			didTapContinue: { [weak self] isLoading, antigenTestProfile  in
 				self?.model.coronaTestType = .antigen
 				self?.showQRScreen(
 					testRegistrationInformation: nil,


### PR DESCRIPTION
## Description
if we edit the test profile  and then scan a test the pre-filled consent screen is showing the old name and not the updated one.
Reason: the AntigenTestProfile is a struct "value type" so if we update it in the middle we need to pass a new version to the consent screen 
