### PR TITLE
Text changes for Schnelltest-Profil

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1050,7 +1050,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmission_Antigen_Profile_DateOfBirth_Format" = "Geboren %@";
 
-"ExposureSubmission_Antigen_Profile_Primary_Button" = "Weiter";
+"ExposureSubmission_Antigen_Profile_Primary_Button" = "Test scannen";
 
 "ExposureSubmission_Antigen_Profile_Secondary_Button" = "Bearbeiten";
 
@@ -1709,9 +1709,9 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 /* Version 2.22 */
 
-"NewVersionFeature_222_family_members_RAT_profile_Title" = "Schnelltestprofile für Familie";
+"NewVersionFeature_222_family_members_RAT_profile_Title" = "Schnelltest-Profile für Familie";
 
-"NewVersionFeature_222_family_members_RAT_profile_description" = "Sie können jetzt Schnelltestprofile für die Mitglieder Ihrer Familie anlegen. Sie können damit die Registrierung an einer Teststelle beschleunigen. Für die Erfasssung der persönlichen Daten muss dann nur der jeweilige QR-Code des Schnelltestprofils gescannt werden.";
+"NewVersionFeature_222_family_members_RAT_profile_description" = "Sie können jetzt Schnelltest-Profile für die Mitglieder Ihrer Familie anlegen. Sie können damit die Registrierung an einer Teststelle beschleunigen. Für die Erfasssung der persönlichen Daten muss dann nur der jeweilige QR-Code des Schnelltest-Profils gescannt werden.";
 
 /* Delta Onboarding */
 "DeltaOnboarding_AccessibilityImageLabel" = "Länderübergreifende Risiko-Ermittlung";


### PR DESCRIPTION
Button text changed from „Weiter“ to “Test scannen”.
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12885

Consistent spelling of “Schnelltest-Profil”
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12923

