### PR TITLE
Feature/11890 cert revocation/12883 unit tests

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		017EE867267B4F2600CD18F6 /* CWATestCase+HealthCertificateConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017EE866267B3F0A00CD18F6 /* CWATestCase+HealthCertificateConvenience.swift */; };
 		018105D728115D1600C40268 /* DMRevocationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018105D528115C0300C40268 /* DMRevocationListViewController.swift */; };
 		018105D828115D1900C40268 /* DMRevocationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018105D628115C0300C40268 /* DMRevocationListViewModel.swift */; };
+		018105DA2816ED8A00C40268 /* MockRevocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018105D92816ED8A00C40268 /* MockRevocationProvider.swift */; };
 		0185DDDE25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0185DDDD25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift */; };
 		0186FB60268F35B900872D45 /* HealthCertificateValidationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186FB5F268F35B900872D45 /* HealthCertificateValidationViewController.swift */; };
 		0186FB62268F362200872D45 /* HealthCertificateValidationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0186FB61268F362100872D45 /* HealthCertificateValidationViewModel.swift */; };
@@ -1973,6 +1974,7 @@
 		017EE866267B3F0A00CD18F6 /* CWATestCase+HealthCertificateConvenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CWATestCase+HealthCertificateConvenience.swift"; sourceTree = "<group>"; };
 		018105D528115C0300C40268 /* DMRevocationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMRevocationListViewController.swift; sourceTree = "<group>"; };
 		018105D628115C0300C40268 /* DMRevocationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMRevocationListViewModel.swift; sourceTree = "<group>"; };
+		018105D92816ED8A00C40268 /* MockRevocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRevocationProvider.swift; sourceTree = "<group>"; };
 		0185DDDD25B77786001FBEA7 /* HomeStatisticsCellModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStatisticsCellModelTests.swift; sourceTree = "<group>"; };
 		0186FB5F268F35B900872D45 /* HealthCertificateValidationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCertificateValidationViewController.swift; sourceTree = "<group>"; };
 		0186FB61268F362100872D45 /* HealthCertificateValidationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCertificateValidationViewModel.swift; sourceTree = "<group>"; };
@@ -9451,6 +9453,7 @@
 		BA7DE4532805A9A00074BFE3 /* __tests__ */ = {
 			isa = PBXGroup;
 			children = (
+				018105D92816ED8A00C40268 /* MockRevocationProvider.swift */,
 				BA7DE4542805A9B90074BFE3 /* RevocationProviderTests.swift */,
 			);
 			path = __tests__;
@@ -12041,6 +12044,7 @@
 				BADBC86725D6C7FD00488DB7 /* SettingsDataDonationViewModelTests.swift in Sources */,
 				F2DC809424898CE600EDC40A /* DynamicTableViewControllerFooterTests.swift in Sources */,
 				50AF182427A3F20500BAA9DB /* CCLConfigurationResourceTests.swift in Sources */,
+				018105DA2816ED8A00C40268 /* MockRevocationProvider.swift in Sources */,
 				35358DD425A23169004FD0CB /* HTTPClientCertificatePinningTests.swift in Sources */,
 				01B72BA6258360FF00A3E3BC /* DiaryDayEmptyViewModelTest.swift in Sources */,
 				ABD430F127FB29950063666C /* KIDListResourceTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
@@ -768,8 +768,6 @@ class HealthCertificateServiceTests: CWATestCase {
 
 		XCTAssertEqual(healthCertificate.validityState, .revoked)
 		XCTAssertEqual(service.healthCertifiedPersons.first?.healthCertificates.first?.validityState, .revoked)
-
-		service.moveHealthCertificateToBin(healthCertificate)
 	}
 
 	func testAddingCertificateUpdatesRevocationListAndValidityStateAndSchedulesNotification() throws {

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Revocation/__tests__/MockRevocationProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Revocation/__tests__/MockRevocationProvider.swift
@@ -1,0 +1,29 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import XCTest
+@testable import ENA
+
+final class MockRevocationProvider: RevocationProviding {
+
+	// MARK: - Protocol RevocationProviding
+
+	func updateCache(with certificates: [HealthCertificate], completion: @escaping (Result<[HealthCertificate], RevocationProviderError>) -> Void) {
+		completion(updateCacheResult)
+	}
+
+	func isRevokedFromRevocationList(healthCertificate: HealthCertificate) -> Bool {
+		switch updateCacheResult {
+		case .success(let healthCertificates):
+			return healthCertificates.contains(healthCertificate)
+		case .failure:
+			return false
+		}
+	}
+
+	// MARK: - Internal
+
+	var updateCacheResult: Result<[HealthCertificate], RevocationProviderError> = .success([])
+
+}

--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Revocation/__tests__/RevocationProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/Revocation/__tests__/RevocationProviderTests.swift
@@ -112,6 +112,25 @@ class RevocationProviderTests: CWATestCase {
 		waitForExpectations(timeout: .greatestFiniteMagnitude)
 	}
 
+	func testIsRevokedFromRevocationList() throws {
+		let revokedVaccinationCertificate = try vaccinationCertificate()
+		let revokedRecoveryCertificate = try recoveryCertificate()
+		let unrevokedCertificate = try testCertificate()
+
+		let store = MockTestStore()
+		store.revokedCertificates = [revokedVaccinationCertificate.base45, revokedRecoveryCertificate.base45]
+
+		let revocationProvider = RevocationProvider(
+			restService: RestServiceProviderStub(),
+			store: store,
+			signatureVerifier: MockVerifier()
+		)
+
+		XCTAssertTrue(revocationProvider.isRevokedFromRevocationList(healthCertificate: revokedVaccinationCertificate))
+		XCTAssertTrue(revocationProvider.isRevokedFromRevocationList(healthCertificate: revokedRecoveryCertificate))
+		XCTAssertFalse(revocationProvider.isRevokedFromRevocationList(healthCertificate: unrevokedCertificate))
+	}
+
 	// MARK: - Helpers
 
 	private let testCertificateKeyIdentifier = "0123456789abcdef"

--- a/src/xcode/ENA/ENATests/Helper/XCTestCase+HealthCertificate.swift
+++ b/src/xcode/ENA/ENATests/Helper/XCTestCase+HealthCertificate.swift
@@ -35,6 +35,7 @@ extension XCTestCase {
 	
 	func recoveryCertificate(
 		daysOffset: Int = 0,
+		webTokenHeader: CBORWebTokenHeader = .fake(),
 		keyIdentifier: Data = Data(),
 		signature: Data? = nil
 	) throws -> HealthCertificate {
@@ -48,6 +49,7 @@ extension XCTestCase {
 						)
 					]
 				),
+				webTokenHeader: webTokenHeader,
 				keyIdentifier: keyIdentifier,
 				signature: signature
 			),
@@ -64,6 +66,7 @@ extension XCTestCase {
 		identifier: String = "01DE/84503/1119349007/DXSGWLWL40SU8ZFKIYIBK39A3#S",
 		name: Name = .fake(),
 		dateOfBirth: String = "1942-01-01",
+		webTokenHeader: CBORWebTokenHeader = .fake(),
 		keyIdentifier: Data = Data(),
 		signature: Data? = nil
 	) throws -> HealthCertificate {
@@ -83,6 +86,7 @@ extension XCTestCase {
 					vaccinationEntry
 				]
 			),
+			webTokenHeader: webTokenHeader,
 			keyIdentifier: keyIdentifier,
 			signature: signature
 		)
@@ -95,6 +99,7 @@ extension XCTestCase {
 		type: CoronaTestType = .antigen,
 		identifier: String = "01DE/84503/1119349007/DXSGWLWL40SU8ZFKIYIBK39A4#S",
 		dateOfBirth: String = "1942-01-01",
+		webTokenHeader: CBORWebTokenHeader = .fake(),
 		keyIdentifier: Data = Data(),
 		signature: Data? = nil
 	) throws -> HealthCertificate {
@@ -112,6 +117,7 @@ extension XCTestCase {
 					testEntry
 				]
 			),
+			webTokenHeader: webTokenHeader,
 			keyIdentifier: keyIdentifier,
 			signature: signature
 		)


### PR DESCRIPTION
## Description
Adds unit tests for revocation list updates from the health certificate service as well as updates of the validity state of the certificate and the notification scheduling. Also adds tests for the new revocation provider check method.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12883
