### PR TITLE
Fix/12784 name textfield moves out of visible areas

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
@@ -21,7 +21,6 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 	// MARK: - Init
 
 	deinit {
-		subscriptions.forEach { $0.cancel() }
 		keyboardSubscriptions.forEach { $0.cancel() }
 	}
 	
@@ -84,8 +83,8 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 				bottomViewBottomConstraint
 			]
 		)
-		subscribeToKeyboardNotifications()
-		
+		 subscribeToKeyboardNotifications()
+
 		// if the the bottom view controller is FooterViewController we use it's viewModel here as well
 		if let viewModel = (bottomViewController as? FooterViewController)?.viewModel {
 			UIView.performWithoutAnimation {
@@ -130,10 +129,6 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 		guard let footerViewController = (bottomViewController as? FooterViewController) else {
 			return
 		}
-		// clear
-		
-		subscriptions.forEach { $0.cancel() }
-		subscriptions.removeAll()
 		
 		// setup
 		
@@ -150,7 +145,6 @@ class TopBottomContainerViewController<TopViewController: UIViewController, Bott
 	private let topViewController: TopViewController
 	private let bottomViewController: BottomViewController
 
-	private var subscriptions: [AnyCancellable] = []
 	private var keyboardSubscriptions: [AnyCancellable] = []
 	private var bottomViewBottomConstraint: NSLayoutConstraint!
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
@@ -8,9 +8,7 @@ import OpenCombine
 
 class DynamicTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
 	
-	var dynamicTableViewModel = DynamicTableViewModel([])
-
-	@IBOutlet private(set) lazy var tableView: UITableView! = self.view as? UITableView
+	// MARK: - Overrides
 
 	override func loadView() {
 		if nil != nibName {
@@ -48,9 +46,25 @@ class DynamicTableViewController: UIViewController, UITableViewDataSource, UITab
 		tableView.register(DynamicTableViewBulletPointCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.bulletPoint.rawValue)
 		tableView.register(DynamicTableViewHeadlineWithImageCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.headlineWithImage.rawValue)
 		tableView.register(DynamicTableViewDoubleLabelViewCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.doubleLabel.rawValue)
-
-		setupKeyboardAvoidance()
+		
+		if shouldHandleKeyboard {
+			setupKeyboardAvoidance()
+		}
 	}
+	
+	// MARK: - Internal
+	
+	var dynamicTableViewModel = DynamicTableViewModel([])
+	var shouldHandleKeyboard: Bool = true
+	
+	func removeKeyboardAvoidance() {
+		keyboardSubscriptions.forEach { $0.cancel() }
+	}
+
+	// MARK: - Private
+	
+	private var keyboardSubscriptions = Set<AnyCancellable>()
+	@IBOutlet private(set) lazy var tableView: UITableView! = self.view as? UITableView
 
 	private func setupKeyboardAvoidance() {
 		NotificationCenter.default.ocombine.publisher(for: UIApplication.keyboardWillShowNotification)
@@ -102,10 +116,6 @@ class DynamicTableViewController: UIViewController, UITableViewDataSource, UITab
 			}
 			.store(in: &keyboardSubscriptions)
 	}
-
-	// MARK: - Private
-
-	private var keyboardSubscriptions = Set<AnyCancellable>()
 
 }
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -548,6 +548,7 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 					self?.showDataPrivacy()
 				}
 			),
+			shouldHandleKeyboard: false,
 			dismiss: { [weak self] in
 				self?.dismiss()
 			}, didTapDataPrivacy: { [weak self] in
@@ -1148,6 +1149,7 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 					self?.showDataPrivacy()
 				}
 			),
+			shouldHandleKeyboard: false,
 			showCancelAlert: { [weak self] in
 				self?.showEndRegistrationAlert(
 					submitAction: UIAlertAction(

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/FamilyMemberConsent/FamilyMemberConsentViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/FamilyMemberConsent/FamilyMemberConsentViewController.swift
@@ -11,6 +11,7 @@ class FamilyMemberConsentViewController: DynamicTableViewController, DismissHand
 
 	init(
 		viewModel: FamilyMemberConsentViewModel,
+		shouldHandleKeyboard: Bool,
 		dismiss: @escaping () -> Void,
 		didTapDataPrivacy: @escaping () -> Void,
 		didTapSubmit: @escaping (String) -> Void
@@ -20,6 +21,8 @@ class FamilyMemberConsentViewController: DynamicTableViewController, DismissHand
 		self.didTapSubmit = didTapSubmit
 		
 		super.init(nibName: nil, bundle: nil)
+		
+		self.shouldHandleKeyboard = shouldHandleKeyboard
 	}
 
 	@available(*, unavailable)

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TestCertificate/ExposureSubmissionTestCertificateViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/TestCertificate/ExposureSubmissionTestCertificateViewController.swift
@@ -11,6 +11,7 @@ class ExposureSubmissionTestCertificateViewController: DynamicTableViewControlle
 
 	init(
 		_ viewModel: ExposureSubmissionTestCertificateViewModel,
+		shouldHandleKeyboard: Bool,
 		showCancelAlert: @escaping () -> Void,
 		didTapPrimaryButton: @escaping (String?, @escaping (Bool) -> Void) -> Void,
 		didTapSecondaryButton: @escaping (@escaping (Bool) -> Void) -> Void
@@ -20,6 +21,8 @@ class ExposureSubmissionTestCertificateViewController: DynamicTableViewControlle
 		self.didTapPrimaryButton = didTapPrimaryButton
 		self.didTapSecondaryButton = didTapSecondaryButton
 		super.init(nibName: nil, bundle: nil)
+		
+		self.shouldHandleKeyboard = shouldHandleKeyboard
 	}
 
 	@available(*, unavailable)


### PR DESCRIPTION
## Description
We re-adjust the layout based on keyboard notification **twice** once in the dynamicTableViewController and another in the TopBottomContainerViewController which causes the bug.
**The current solution**: introduces a flag to prevent keyboard subscription in the dynamicTableViewController if we know that the Viewcontroller will be part of a TopBottomContainerViewController

## Link to Jira
1. fix layout issue the textfield for the family member name
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12784

2. fix layout issue of the date picker for the date of birth
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11624

## Screenshots
Uploading RPReplay_Final1651216078.MP4…

