### PR TITLE
Fix/12784 prevent double registration of keyboard notifications

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Containers/TopBottomContainerViewController.swift
@@ -5,6 +5,9 @@
 import UIKit
 import OpenCombine
 
+// Just a dummy protocol to compare TopBottomContainerViewController without the generics
+protocol ComparableTopBottomContainerViewControlling {}
+
 protocol FooterViewUpdating {
 	var footerViewHandler: FooterViewHandling? { get }
 
@@ -16,7 +19,7 @@ protocol FooterViewUpdating {
 
 /** a simple container view controller to combine to view controllers vertically (top / bottom) */
 
-class TopBottomContainerViewController<TopViewController: UIViewController, BottomViewController: UIViewController>: UIViewController, DismissHandling, FooterViewUpdating {
+class TopBottomContainerViewController<TopViewController: UIViewController, BottomViewController: UIViewController>: UIViewController, ComparableTopBottomContainerViewControlling, DismissHandling, FooterViewUpdating {
 
 	// MARK: - Init
 

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewController.swift
@@ -49,6 +49,10 @@ class DynamicTableViewController: UIViewController, UITableViewDataSource, UITab
 		tableView.register(DynamicTableViewHeadlineWithImageCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.headlineWithImage.rawValue)
 		tableView.register(DynamicTableViewDoubleLabelViewCell.self, forCellReuseIdentifier: DynamicCell.CellReuseIdentifier.doubleLabel.rawValue)
 
+		// Only set up the keyboard notifications when this class is not embedded into a TopBottomContainerViewController, because the TopBottomContainerViewController is also registering for keyboard notifications.
+		if parent is ComparableTopBottomContainerViewControlling {
+			return
+		}
 		setupKeyboardAvoidance()
 	}
 


### PR DESCRIPTION
## Description
We re-adjust the layout based on keyboard notification **twice** once in the dynamicTableViewController and another in the TopBottomContainerViewController which causes the bug.
**The current solution**: Checks now in the `DynamicTableViewController`, if he is embedded in a `TopBottomContainerViewController` and if so, skips the keyboard notification registration.

## Link to Jira
1. fix layout issue the textfield for the family member name
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12784

2. fix layout issue of the date picker for the date of birth
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11624

##Screenshots

https://user-images.githubusercontent.com/75615785/166433157-e359fc00-736f-4b68-987e-64548f14b409.mov