### PR TITLE
Only update statistics on day change

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -119,7 +119,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		tableView.backgroundColor = .enaColor(for: .darkBackground)
 
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshUIAfterResumingFromBackground), name: UIApplication.willEnterForegroundNotification, object: nil)
-		NotificationCenter.default.addObserver(self, selector: #selector(refreshUI), name: NSNotification.Name.NSCalendarDayChanged, object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(updateStatistics), name: NSNotification.Name.NSCalendarDayChanged, object: nil)
 
 		refreshUI()
 	}
@@ -1015,7 +1015,6 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		showDeltaOnboardingAndAlertsIfNeeded()
 	}
 	
-	@objc
 	private func refreshUI() {
 		Log.info("Refresh UI.")
 
@@ -1024,5 +1023,15 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			self?.viewModel.state.updateStatistics()
 		}
 	}
+
+	@objc
+	private func updateStatistics() {
+		Log.info("Update statistics")
+
+		DispatchQueue.main.async { [weak self] in
+			self?.viewModel.state.updateStatistics()
+		}
+	}
+
 	// swiftlint:disable:next file_length
 }


### PR DESCRIPTION
## Description
Only updates statistics on day change, doesn't fetch test result anymore on the day change trigger. Otherwise the test result update without notification might be triggered on the first background task run of the day and the notification gets lost.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12977
