### PR TITLE
Fix/12982 set up UI only once

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -896,6 +896,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	private func showUI() {
 		coordinator.showLoadingScreen()
+
+		appLaunchedFromUserActivityURL = false
+		didSetupUI = true
 		
 		cclService.setup { [weak self] in
 			guard let self = self else {
@@ -917,8 +920,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 							self.showOnboarding()
 						}
 
-						self.appLaunchedFromUserActivityURL = false
-						self.didSetupUI = true
 						self.route = nil
 
 						self.healthCertificateService.updateRevocationStates()

--- a/src/xcode/ENA/ENA/Source/Services/CCLService/CCLService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CCLService/CCLService.swift
@@ -102,13 +102,13 @@ class CCLService: CCLServable {
 		cclConfigurationResource: CCLConfigurationResource = CCLConfigurationResource(),
 		completion: @escaping () -> Void
 	) {
-		guard !isSetUp else {
-			completion()
-			return
-		}
-		
 		setupQueue.async { [weak self] in
 			guard let self = self else {
+				completion()
+				return
+			}
+
+			guard !self.isSetUp else {
 				completion()
 				return
 			}


### PR DESCRIPTION
## Description
If the app was put in background while the setup was still running and the loading screen showing, a second window was created in `setupUI()` and the UI got lost, showing a black screen instead. By setting `didSetupUI` immediately after showing the loading screen the window is kept and updated with the correct UI once the service setup is finished.

(Also puts the guard if the CCLService setup already happened on the serial queue to ensure the check happens after a possible previous setup finished.)

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12982
