### PR TITLE
Remove obsolete reload data that interferes with scrolling to top

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewController.swift
@@ -92,12 +92,6 @@ class HealthCertificateOverviewViewController: UITableViewController {
 
 		navigationController?.navigationBar.prefersLargeTitles = true
 		navigationController?.navigationBar.sizeToFit()
-
-		// delay reloadData because scrolling to top may take up to 0.35 sec
-		// otherwise the contentOffSet gets broken
-		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [tableView] in
-			tableView?.reloadData()
-		}
 	}
 
 	override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## Description
Removes the reload data call [originally introduced to update the permission cell](https://github.com/corona-warn-app/cwa-app-ios/pull/3124). It is now obsolete as the permission cell is not shown on this screen anymore. The reload interfered with the scroll-to-top feature on the second tab bar item tap (despite the previously attempted fix). Now the screen scrolls up smoothly again and doesn't over scroll.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12972
