### PR TITLE
Fix/12438 person screen order

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewController.swift
@@ -98,6 +98,11 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 			cell.configure(with: viewModel.headerCellViewModel)
 			return cell
 
+		case .admissionState:
+			let cell = tableView.dequeueReusableCell(cellType: AdmissionStateTableViewCell.self, for: indexPath)
+			cell.configure(with: viewModel.admissionStateCellModel)
+			return cell
+
 		case .certificateReissuance:
 			let cell = tableView.dequeueReusableCell(cellType: CertificateReissuanceTableViewCell.self, for: indexPath)
 			cell.configure(with: viewModel.certificateReissuanceCellModel)
@@ -106,11 +111,6 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 		case .boosterNotification:
 			let cell = tableView.dequeueReusableCell(cellType: BoosterNotificationTableViewCell.self, for: indexPath)
 			cell.configure(with: viewModel.boosterNotificationCellModel)
-			return cell
-
-		case .admissionState:
-			let cell = tableView.dequeueReusableCell(cellType: AdmissionStateTableViewCell.self, for: indexPath)
-			cell.configure(with: viewModel.admissionStateCellModel)
 			return cell
 
 		case .vaccinationState:
@@ -202,17 +202,17 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 			tableView.performBatchUpdates({
 				var deleteIndexPaths = [indexPath]
 				var insertIndexPaths = [IndexPath]()
-
-				if vaccinationStateWasVisible && !self.viewModel.vaccinationStateIsVisible {
-					deleteIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.vaccinationState.rawValue))
-				} else if !vaccinationStateWasVisible && self.viewModel.vaccinationStateIsVisible {
-					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.vaccinationState.rawValue))
-				}
 				
 				if admissionStateWasVisible && !self.viewModel.admissionStateIsVisible {
 					deleteIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.admissionState.rawValue))
 				} else if !admissionStateWasVisible && self.viewModel.admissionStateIsVisible {
 					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.admissionState.rawValue))
+				}
+
+				if certificateReissuanceWasVisible && !self.viewModel.certificateReissuanceIsVisible {
+					deleteIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificateReissuance.rawValue))
+				} else if !certificateReissuanceWasVisible && self.viewModel.certificateReissuanceIsVisible {
+					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificateReissuance.rawValue))
 				}
 
 				if boosterNotificationWasVisible && !self.viewModel.boosterNotificationIsVisible {
@@ -221,10 +221,10 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.boosterNotification.rawValue))
 				}
 
-				if certificateReissuanceWasVisible && !self.viewModel.certificateReissuanceIsVisible {
-					deleteIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificateReissuance.rawValue))
-				} else if !certificateReissuanceWasVisible && self.viewModel.certificateReissuanceIsVisible {
-					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificateReissuance.rawValue))
+				if vaccinationStateWasVisible && !self.viewModel.vaccinationStateIsVisible {
+					deleteIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.vaccinationState.rawValue))
+				} else if !vaccinationStateWasVisible && self.viewModel.vaccinationStateIsVisible {
+					insertIndexPaths.append(IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.vaccinationState.rawValue))
 				}
 
 				// For the case that a person splits after deleting a certificate, there could be some more certificates to be removed (because they are moved into a new person).
@@ -321,16 +321,16 @@ class HealthCertifiedPersonViewController: UIViewController, UITableViewDataSour
 			forCellReuseIdentifier: HealthCertificateSimpleTextCell.reuseIdentifier
 		)
 		tableView.register(
+			AdmissionStateTableViewCell.self,
+			forCellReuseIdentifier: AdmissionStateTableViewCell.reuseIdentifier
+		)
+		tableView.register(
 			CertificateReissuanceTableViewCell.self,
 			forCellReuseIdentifier: CertificateReissuanceTableViewCell.reuseIdentifier
 		)
 		tableView.register(
 			BoosterNotificationTableViewCell.self,
 			forCellReuseIdentifier: BoosterNotificationTableViewCell.reuseIdentifier
-		)
-		tableView.register(
-			AdmissionStateTableViewCell.self,
-			forCellReuseIdentifier: AdmissionStateTableViewCell.reuseIdentifier
 		)
 		tableView.register(
 			VaccinationStateTableViewCell.self,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/HealthCertifiedPersonViewModel.swift
@@ -73,9 +73,9 @@ final class HealthCertifiedPersonViewModel {
 
 	enum TableViewSection: Int, CaseIterable {
 		case header
+		case admissionState
 		case certificateReissuance
 		case boosterNotification
-		case admissionState
 		case vaccinationState
 		case person
 		case certificates
@@ -161,12 +161,12 @@ final class HealthCertifiedPersonViewModel {
 	}
 	
 	var topMostCell: TableViewSection {
-		if certificateReissuanceIsVisible {
+		if admissionStateIsVisible {
+			return .admissionState
+		} else if certificateReissuanceIsVisible {
 			return .certificateReissuance
 		} else if boosterNotificationIsVisible {
 			return .boosterNotification
-		} else if admissionStateIsVisible {
-			return .admissionState
 		} else if vaccinationStateIsVisible {
 			return .vaccinationState
 		} else {
@@ -178,12 +178,12 @@ final class HealthCertifiedPersonViewModel {
 		switch section {
 		case .header:
 			return 1
+		case .admissionState:
+			return admissionStateIsVisible ? 1 : 0
 		case .certificateReissuance:
 			return certificateReissuanceIsVisible ? 1 : 0
 		case .boosterNotification:
 			return boosterNotificationIsVisible ? 1 : 0
-		case .admissionState:
-			return admissionStateIsVisible ? 1 : 0
 		case .vaccinationState:
 			return vaccinationStateIsVisible ? 1 : 0
 		case .person:

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertifiedPersonViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/HealthCertifiedPersonViewModelTests.swift
@@ -37,26 +37,26 @@ class HealthCertifiedPersonViewModelTests: XCTestCase {
 		
 		// THEN
 		XCTAssertEqual(viewModel.numberOfItems(in: .header), 1)
+		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 0)
 		XCTAssertEqual(viewModel.numberOfItems(in: .certificateReissuance), 0)
 		XCTAssertEqual(viewModel.numberOfItems(in: .boosterNotification), 0)
-		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 0)
 		XCTAssertEqual(viewModel.numberOfItems(in: .vaccinationState), 0)
 		XCTAssertEqual(viewModel.numberOfItems(in: .person), 1)
 		XCTAssertEqual(viewModel.numberOfItems(in: .certificates), 1)
 		
 		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.header.rawValue)))
+		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.admissionState.rawValue)))
 		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificateReissuance.rawValue)))
 		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.boosterNotification.rawValue)))
-		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.admissionState.rawValue)))
 		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.vaccinationState.rawValue)))
 		XCTAssertFalse(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.person.rawValue)))
 		XCTAssertTrue(viewModel.canEditRow(at: IndexPath(row: 0, section: HealthCertifiedPersonViewModel.TableViewSection.certificates.rawValue)))
 		
 		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.numberOfSections, 7)
 		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(0), .header)
-		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(1), .certificateReissuance)
-		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(2), .boosterNotification)
-		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(3), .admissionState)
+		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(1), .admissionState)
+		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(2), .certificateReissuance)
+		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(3), .boosterNotification)
 		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(4), .vaccinationState)
 		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(5), .person)
 		XCTAssertEqual(HealthCertifiedPersonViewModel.TableViewSection.map(6), .certificates)
@@ -183,9 +183,80 @@ class HealthCertifiedPersonViewModelTests: XCTestCase {
 		
 		// THEN
 		XCTAssertEqual(viewModel.heightForFooter(in: .header), 0)
+		XCTAssertEqual(viewModel.heightForFooter(in: .admissionState), 0)
+		XCTAssertEqual(viewModel.heightForFooter(in: .certificateReissuance), 0)
+		XCTAssertEqual(viewModel.heightForFooter(in: .boosterNotification), 0)
 		XCTAssertEqual(viewModel.heightForFooter(in: .vaccinationState), 0)
 		XCTAssertEqual(viewModel.heightForFooter(in: .person), 0)
 		XCTAssertEqual(viewModel.heightForFooter(in: .certificates), 12)
+	}
+
+	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_AdmissionStateIsSetToVisible_THEN_CellIsVisible() {
+		// GIVEN
+		let cclService = FakeCCLService()
+		let service = HealthCertificateService(
+			store: MockTestStore(),
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			appConfiguration: CachedAppConfigurationMock(),
+			cclService: cclService,
+			recycleBin: .fake(),
+			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
+		)
+
+		let viewModel = HealthCertifiedPersonViewModel(
+			cclService: cclService,
+			healthCertificateService: service,
+			healthCertifiedPerson: HealthCertifiedPerson(
+				healthCertificates: [HealthCertificate.mock()],
+				dccWalletInfo: .fake(
+					admissionState: .fake(visible: true)
+				)
+			),
+			healthCertificateValueSetsProvider: VaccinationValueSetsProvider(client: CachingHTTPClientMock(), store: MockTestStore()),
+			dismiss: {},
+			didTapBoosterNotification: { _ in },
+			didTapValidationButton: { _, _ in },
+			showInfoHit: { },
+			didTapCertificateReissuance: { _ in }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 1)
+	}
+
+	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_AdmissionStateIsSetToNotVisible_THEN_CellIsNotVisible() {
+		// GIVEN
+		let cclService = FakeCCLService()
+		let service = HealthCertificateService(
+			store: MockTestStore(),
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			appConfiguration: CachedAppConfigurationMock(),
+			cclService: cclService,
+			recycleBin: .fake(),
+			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
+		)
+
+		let viewModel = HealthCertifiedPersonViewModel(
+			cclService: cclService,
+			healthCertificateService: service,
+			healthCertifiedPerson: HealthCertifiedPerson(
+				healthCertificates: [HealthCertificate.mock()],
+				dccWalletInfo: .fake(
+					admissionState: .fake(visible: false)
+				)
+			),
+			healthCertificateValueSetsProvider: VaccinationValueSetsProvider(client: CachingHTTPClientMock(), store: MockTestStore()),
+			dismiss: {},
+			didTapBoosterNotification: { _ in },
+			didTapValidationButton: { _, _ in },
+			showInfoHit: { },
+			didTapCertificateReissuance: { _ in }
+		)
+
+		// THEN
+		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 0)
 	}
 	
 	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_CertificateReissuanceIsSetToVisible_THEN_CellIsVisible() {
@@ -326,74 +397,6 @@ class HealthCertifiedPersonViewModelTests: XCTestCase {
 		
 		// THEN
 		XCTAssertEqual(viewModel.numberOfItems(in: .boosterNotification), 0)
-	}
-	
-	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_AdmissionStateIsSetToVisible_THEN_CellIsVisible() {
-		// GIVEN
-		let cclService = FakeCCLService()
-		let service = HealthCertificateService(
-			store: MockTestStore(),
-			dccSignatureVerifier: DCCSignatureVerifyingStub(),
-			dscListProvider: MockDSCListProvider(),
-			appConfiguration: CachedAppConfigurationMock(),
-			cclService: cclService,
-			recycleBin: .fake(),
-			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
-		)
-		
-		let viewModel = HealthCertifiedPersonViewModel(
-			cclService: cclService,
-			healthCertificateService: service,
-			healthCertifiedPerson: HealthCertifiedPerson(
-				healthCertificates: [HealthCertificate.mock()],
-				dccWalletInfo: .fake(
-					admissionState: .fake(visible: true)
-				)
-			),
-			healthCertificateValueSetsProvider: VaccinationValueSetsProvider(client: CachingHTTPClientMock(), store: MockTestStore()),
-			dismiss: {},
-			didTapBoosterNotification: { _ in },
-			didTapValidationButton: { _, _ in },
-			showInfoHit: { },
-			didTapCertificateReissuance: { _ in }
-		)
-		
-		// THEN
-		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 1)
-	}
-	
-	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_AdmissionStateIsSetToNotVisible_THEN_CellIsNotVisible() {
-		// GIVEN
-		let cclService = FakeCCLService()
-		let service = HealthCertificateService(
-			store: MockTestStore(),
-			dccSignatureVerifier: DCCSignatureVerifyingStub(),
-			dscListProvider: MockDSCListProvider(),
-			appConfiguration: CachedAppConfigurationMock(),
-			cclService: cclService,
-			recycleBin: .fake(),
-			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
-		)
-		
-		let viewModel = HealthCertifiedPersonViewModel(
-			cclService: cclService,
-			healthCertificateService: service,
-			healthCertifiedPerson: HealthCertifiedPerson(
-				healthCertificates: [HealthCertificate.mock()],
-				dccWalletInfo: .fake(
-					admissionState: .fake(visible: false)
-				)
-			),
-			healthCertificateValueSetsProvider: VaccinationValueSetsProvider(client: CachingHTTPClientMock(), store: MockTestStore()),
-			dismiss: {},
-			didTapBoosterNotification: { _ in },
-			didTapValidationButton: { _, _ in },
-			showInfoHit: { },
-			didTapCertificateReissuance: { _ in }
-		)
-		
-		// THEN
-		XCTAssertEqual(viewModel.numberOfItems(in: .admissionState), 0)
 	}
 	
 	func testGIVEN_HealthCertifiedPersonViewModel_WHEN_VaccinationStateIsSetToVisible_THEN_CellIsVisible() {


### PR DESCRIPTION
## Description
Fixes the order of cards on the person screen, putting the admission state on top and the reissuance and booster cards below.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12438

## Screenshots
![IMG_AF29278D90DA-1](https://user-images.githubusercontent.com/1157991/168590457-8c683041-b0b9-44ce-b9b2-8b4cd8dd27b4.jpeg)