### PR TITLE
Fix/13133 update wallet info on validity state changes

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -854,6 +854,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 		if healthCertificate.validityState != previousValidityState {
 			// Only validity states that are not shown as `.valid` should be marked as new for the user.
 			healthCertificate.isValidityStateNew = !healthCertificate.isConsideredValid
+			updateDCCWalletInfo(for: person)
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -577,25 +577,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 						person: person
 					)
 				}
-				self.updateValidityStatesAndNotifications(
-					for: certificateTuples,
-					completion: { [weak self] in
-						guard let self = self else { return }
-						
-						let dispatchGroup = DispatchGroup()
-						
-						for tuple in certificateTuples {
-							dispatchGroup.enter()
-							self.updateDCCWalletInfo(for: tuple.person) {
-								dispatchGroup.leave()
-							}
-						}
-						
-						dispatchGroup.notify(queue: .main, execute: {
-							completion?()
-						})
-					}
-				)
+				self.updateValidityStatesAndNotifications(for: certificateTuples, completion: completion ?? {})
 			}
 		)
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
@@ -938,7 +938,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testDCCWalletInfoUpdate_InitialWithoutDCCWalletInfo() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .seriesCompletingOrBooster, ageInDays: 2)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .seriesCompletingOrBooster,
+			ageInDays: 2,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: nil
@@ -985,7 +989,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testDCCWalletInfoUpdate_StillValidButMostRecentWalletInfoUpdateFailed() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .seriesCompletingOrBooster, ageInDays: 2)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .seriesCompletingOrBooster,
+			ageInDays: 2,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: .fake(validUntil: Date(timeIntervalSinceNow: 100)),
@@ -1033,7 +1041,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testDCCWalletInfoUpdate_MostRecentWalletInfoUpdateFailedIsSet() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .seriesCompletingOrBooster, ageInDays: 2)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .seriesCompletingOrBooster,
+			ageInDays: 2,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: nil,
@@ -1077,7 +1089,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testDCCWalletInfoUpdate_ExpiredWalletInfo() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .seriesCompletingOrBooster, ageInDays: 2)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .seriesCompletingOrBooster,
+			ageInDays: 2,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: .fake(validUntil: Date(timeIntervalSinceNow: -100)),
@@ -1125,7 +1141,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testDCCWalletInfoUpdate_ConfigurationDidChange() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .seriesCompletingOrBooster, ageInDays: 2)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .seriesCompletingOrBooster,
+			ageInDays: 2,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: .fake(validUntil: Date(timeIntervalSinceNow: 100)),
@@ -1397,7 +1417,11 @@ class HealthCertificateServiceTests: CWATestCase {
 			validUntil: Date(timeIntervalSinceNow: 100)
 		)
 		
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 180)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .incomplete,
+			ageInDays: 180,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: dccWalletInfo
@@ -1456,7 +1480,11 @@ class HealthCertificateServiceTests: CWATestCase {
 			validUntil: Date(timeIntervalSinceNow: 100)
 		)
 		
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 180)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .incomplete,
+			ageInDays: 180,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		let healthCertifiedPerson = HealthCertifiedPerson(
 			healthCertificates: [healthCertificate],
 			dccWalletInfo: nil,
@@ -1670,7 +1698,11 @@ class HealthCertificateServiceTests: CWATestCase {
 	}
 	
 	func testNoDuplicateCertificateReissuanceNotificationTriggeredFromDCCWalletInfo() throws {
-		let healthCertificate: HealthCertificate = try vaccinationCertificate(type: .incomplete, ageInDays: 180)
+		let healthCertificate: HealthCertificate = try vaccinationCertificate(
+			type: .incomplete,
+			ageInDays: 180,
+			cborWebTokenHeader: .fake(expirationTime: .distantFuture)
+		)
 		
 		let dccWalletInfo: DCCWalletInfo = .fake(
 			validUntil: Date(timeIntervalSinceNow: 100),


### PR DESCRIPTION
## Description
Now updating the wallet info immediately on every validity state change, not just to/from `revoked`.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13133
