### PR TITLE
Improve Whats New Text

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1721,7 +1721,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "NewVersionFeature_223_reissue_certificates_title" = "Erneuerung von Zertifikaten";
 
-"NewVersionFeature_223_reissue_certificates_description" = "Die Gültigkeit von Ihrem aktuell genutzten Zertifikat ist technisch auf 365 Tage begrenzt. Falls Ihr aktuell genutztes Zertifikat abläuft bietet die App Ihnen eine Erneuerung an. Die Erneuerung kann 28 Tage vor Ablauf der Gültigkeit und bis zu 90 Tage nach Ablauf der Gültigkeit vorgenommen werden. Falls Ihnen keine Erneuerung angeboten wird dann muss das Zertifikat nicht verlängert werden und keine weiteren Schritten Ihrerseits werden benötigt.";
+"NewVersionFeature_223_reissue_certificates_description" = "Die Gültigkeit von Ihrem aktuell genutzten Zertifikat ist technisch auf 365 Tage begrenzt. Falls Ihr aktuell genutztes Zertifikat abläuft, bietet die App Ihnen eine Erneuerung an. Die Erneuerung kann 28 Tage vor Ablauf der Gültigkeit und bis zu 90 Tage nach Ablauf der Gültigkeit vorgenommen werden. Falls Ihnen keine Erneuerung angeboten wird, muss das Zertifikat nicht verlängert werden und keine weiteren Schritte Ihrerseits werden benötigt.";
 
 /* Delta Onboarding */
 "DeltaOnboarding_AccessibilityImageLabel" = "Länderübergreifende Risiko-Ermittlung";


### PR DESCRIPTION
Improve grammar of the german whats new text no translation needed

_Die Gültigkeit von Ihrem aktuell genutzten Zertifikat ist technisch auf 365 Tage begrenzt. Falls Ihr aktuell genutztes Zertifikat abläuft, bietet die App Ihnen eine Erneuerung an. Die Erneuerung kann 28 Tage vor Ablauf der Gültigkeit und bis zu 90 Tage nach Ablauf der Gültigkeit vorgenommen werden. Falls Ihnen keine Erneuerung angeboten wird, muss das Zertifikat nicht verlängert werden und keine weiteren Schritte Ihrerseits werden benötigt._