### PR TITLE
Don't fail risk caculation on failed trace warning download.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Risk/Provider/RiskProvider.swift
@@ -182,21 +182,15 @@ final class RiskProvider: RiskProviding {
 					switch result {
 					case .success:
 						// If key download succeeds, continue with the download of the trace warning packages
-						self.downloadTraceWarningPackages(with: appConfiguration, completion: { result in
-							switch result {
-							case .success:
-								// And only if both downloads succeeds, we can determine a risk.
-								self.determineRisk(userInitiated: userInitiated, appConfiguration: appConfiguration) { result in
-									switch result {
-									case .success(let risk):
-										self.successOnTargetQueue(risk: risk)
-									case .failure(let error):
-										self.failOnTargetQueue(error: error)
-									}
-									group.leave()
+						self.downloadTraceWarningPackages(with: appConfiguration, completion: { _ in
+							// The download of TraceWarningPackages may not interrupt or prevent the download of Diagnosis Keys. It may also not interrupt or prevent Exposure Detection from running.
+							self.determineRisk(userInitiated: userInitiated, appConfiguration: appConfiguration) { result in
+								switch result {
+								case .success(let risk):
+									self.successOnTargetQueue(risk: risk)
+								case .failure(let error):
+									self.failOnTargetQueue(error: error)
 								}
-							case .failure(let error):
-								self.failOnTargetQueue(error: error)
 								group.leave()
 							}
 						})


### PR DESCRIPTION
## Description
Regarding to the tech spec, the risk caclulation should not fail because of a failed trace warning download.
"The download of TraceWarningPackages may not interrupt or prevent the download of Diagnosis Keys. It may also not interrupt or prevent Exposure Detection from running."

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8483
