### PR TITLE
Fix/13205 check reissuance identifier

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -180,9 +180,14 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 				isNewBoosterRule = dccWalletInfo?.boosterNotification.identifier != nil
 			}
 
-			if dccWalletInfo?.certificateReissuance != oldValue?.certificateReissuance {
+			var oldReissuanceIdentifier = oldValue?.certificateReissuance?.reissuanceDivision.identifier
+			if let oldCertificateReissuance = oldValue?.certificateReissuance, oldCertificateReissuance.reissuanceDivision.identifier == nil {
+				oldReissuanceIdentifier = "renew"
+			}
+			if dccWalletInfo?.certificateReissuance?.reissuanceDivision.identifier != oldReissuanceIdentifier {
 				isNewCertificateReissuance = dccWalletInfo?.certificateReissuance?.reissuanceDivision.visible == true
 			}
+
 			if oldValue?.admissionState.identifier != nil && dccWalletInfo?.admissionState.identifier != oldValue?.admissionState.identifier {
 				isAdmissionStateChanged = dccWalletInfo?.admissionState.identifier != nil
 			}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/__tests__/HealthCertifiedPersonTests.swift
@@ -134,4 +134,169 @@ class HealthCertifiedPersonTests: CWATestCase {
 		XCTAssertEqual(decodedHealthCertifiedPerson.healthCertificates.map { $0.didShowRevokedNotification }, [firstHealthCertificate, secondHealthCertificate].map { $0.didShowRevokedNotification })
 	}
 
+	// MARK: - isNewCertificateReissuance
+
+	func testIsNewCertificateReissuanceIsTrueIfWalletInfoWasNil() throws {
+		let person = HealthCertifiedPerson(healthCertificates: [], dccWalletInfo: nil)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: true,
+					identifier: "identifier"
+				)
+			)
+		)
+
+		XCTAssertTrue(person.isNewCertificateReissuance)
+	}
+
+	func testIsNewCertificateReissuanceIsFalseIfReissuanceDivisionBecomesInvisible() throws {
+		let person = HealthCertifiedPerson(
+			healthCertificates: [],
+			dccWalletInfo: .fake(
+				certificateReissuance: .fake(
+					reissuanceDivision: .fake(
+						visible: true,
+						identifier: "identifier"
+					)
+				)
+			),
+			isNewCertificateReissuance: false
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: false,
+					identifier: "identifier"
+				)
+			)
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+	}
+
+	func testIsNewCertificateReissuanceIsFalseIfReissuanceDivisionIdentifierIsUnchanged() throws {
+		let person = HealthCertifiedPerson(
+			healthCertificates: [],
+			dccWalletInfo: .fake(
+				certificateReissuance: .fake(
+					reissuanceDivision: .fake(
+						visible: true,
+						identifier: "identifier",
+						titleText: .fake(string: "oldTitleText")
+					)
+				)
+			),
+			isNewCertificateReissuance: false
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: true,
+					identifier: "identifier",
+					titleText: .fake(string: "newTitleText")
+				)
+			)
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+	}
+
+	func testIsNewCertificateReissuanceIsTrueIfReissuanceDivisionIdentifierIsChanged() throws {
+		let person = HealthCertifiedPerson(
+			healthCertificates: [],
+			dccWalletInfo: .fake(
+				certificateReissuance: .fake(
+					reissuanceDivision: .fake(
+						visible: true,
+						identifier: "oldIdentifier"
+					)
+				)
+			),
+			isNewCertificateReissuance: false
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: true,
+					identifier: "newIdentifier"
+				)
+			)
+		)
+
+		XCTAssertTrue(person.isNewCertificateReissuance)
+	}
+
+	func testIsNewCertificateReissuanceIsFalseIfReissuanceDivisionIdentifierWasNilAndIsRenew() throws {
+		let person = HealthCertifiedPerson(
+			healthCertificates: [],
+			dccWalletInfo: .fake(
+				certificateReissuance: .fake(
+					reissuanceDivision: .fake(
+						visible: true,
+						identifier: nil,
+						titleText: .fake(string: "oldTitleText")
+					)
+				)
+			),
+			isNewCertificateReissuance: false
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: true,
+					identifier: "renew",
+					titleText: .fake(string: "newTitleText")
+				)
+			)
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+	}
+
+	func testIsNewCertificateReissuanceIsFalseIfReissuanceDivisionIdentifierWasNilAndIsNotRenew() throws {
+		let person = HealthCertifiedPerson(
+			healthCertificates: [],
+			dccWalletInfo: .fake(
+				certificateReissuance: .fake(
+					reissuanceDivision: .fake(
+						visible: true,
+						identifier: nil,
+						titleText: .fake(string: "oldTitleText")
+					)
+				)
+			),
+			isNewCertificateReissuance: false
+		)
+
+		XCTAssertFalse(person.isNewCertificateReissuance)
+
+		person.dccWalletInfo = .fake(
+			certificateReissuance: .fake(
+				reissuanceDivision: .fake(
+					visible: true,
+					identifier: "notrenew",
+					titleText: .fake(string: "newTitleText")
+				)
+			)
+		)
+
+		XCTAssertTrue(person.isNewCertificateReissuance)
+	}
+
 }

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
@@ -1809,12 +1809,12 @@ class HealthCertificateServiceTests: CWATestCase {
 		XCTAssertTrue(try XCTUnwrap(store.healthCertifiedPersons.first?.healthCertificates.first).isNew)
 		
 		// Setting certificate reissuance increases unseen news count
-		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true)))
+		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true, identifier: "identifier")))
 		XCTAssertEqual(store.healthCertifiedPersons.first?.unseenNewsCount, 2)
 		XCTAssertEqual(service.unseenNewsCount.value, 2)
 		
 		// Setting to same certificate reissuance leaves unseen news count unchanged
-		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true)))
+		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true, identifier: "identifier")))
 		XCTAssertEqual(store.healthCertifiedPersons.first?.unseenNewsCount, 2)
 		XCTAssertEqual(service.unseenNewsCount.value, 2)
 		
@@ -1824,12 +1824,12 @@ class HealthCertificateServiceTests: CWATestCase {
 		XCTAssertEqual(service.unseenNewsCount.value, 1)
 		
 		// Setting invisible certificate reissuance does not increase unseen news count
-		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: false)))
+		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: false, identifier: "identifier")))
 		XCTAssertEqual(store.healthCertifiedPersons.first?.unseenNewsCount, 1)
 		XCTAssertEqual(service.unseenNewsCount.value, 1)
 		
 		// Setting certificate reissuance increases unseen news count
-		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true)))
+		store.healthCertifiedPersons.first?.dccWalletInfo = .fake(certificateReissuance: .fake(reissuanceDivision: .fake(visible: true, identifier: "newidentifier")))
 		XCTAssertEqual(store.healthCertifiedPersons.first?.unseenNewsCount, 2)
 		XCTAssertEqual(service.unseenNewsCount.value, 2)
 		


### PR DESCRIPTION
## Description
Compares the identifier of the certificate reissuance division instead of the whole certificate reissuance to set `isNewCertificateReissuance`. That way it is aligned with the notification scheduling and the tech spec.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13205
