### PR TITLE
App incorrectly links red tile (increased risk) to free test

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 
 "ExposureDetection_Guide_Vaccination_HighRisk" = "Sollten Sie bisher nicht geimpft sein, besprechen Sie nach der Testung die Impfung mit Ihrer Hausarztpraxis.";
 
-"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, auch wenn Sie keine Symptome haben. Bei einer Warnung über ein erhöhtes Risiko (\"Rote Kachel\") haben Sie Anspruch auf einen kostenlosen Test. Dies muss nicht notwendigerweise ein PCR-Test sein.";
+"ExposureDetection_Guide_Title" = "Lassen Sie sich testen, z.B. mit einem Antigen-Schnelltest, oder testen Sie sich selbst, am besten mehrfach im Abstand von zwei Tagen. Sollte ein Test positiv ausfallen, lassen Sie diesen durch einen PCR-Test absichern.";
 
 "ExposureDetection_Guide_Point1" = "Testmöglichkeiten finden Sie hier. Sie können sich auch an Ihre Hausarztpraxis oder Apotheke wenden.";
 


### PR DESCRIPTION
## Description
The app states "Please get tested, even if you don’t have any symptoms. If you get a warning of increased risk (“red tile”), you are entitled to a test free of charge. It does not necessarily have to be a PCR test."

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13479
