### PR TITLE
COMMUNITY: 13529: Add missing text reg. check-in based risk calculation (Alignment to Android)

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -272,7 +272,7 @@
 "ExposureDetection_ActiveTracingSection_Subtitle" = "Dieser Zeitraum wird berücksichtigt.";
 
 /* There are two paragraphs in this section. The first one just contains text… */
-"ExposureDetection_ActiveTracingSection_Text_Paragraph0" = "Die Berechnung des Infektionsrisikos kann nur für die Zeiträume erfolgen, an denen die Risiko-Ermittlung aktiv war. Die Risiko-Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird der Zeitraum der letzten %u Tage betrachtet.";
+"ExposureDetection_ActiveTracingSection_Text_Paragraph0" = "Die Berechnung des Infektionsrisikos kann nur für die Zeiträume erfolgen, an denen die Risiko-Ermittlung aktiv war. Die Risiko-Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird der Zeitraum der letzten %u Tage betrachtet. Bei der Risikoermittlung werden außerdem Ihre Check-Ins berücksichtigt. Sie werden gewarnt, wenn Sie sich zur selben Zeit oder bis 30 Minuten nach der positiv getesteten Person im selben Raum aufgehalten haben.";
 
 "ExposureDetection_ActiveTracingSection_Text_Paragraph1b" = "Wenn die Risiko-Ermittlung zu Zeiten, in denen Sie andere Personen getroffen haben, aktiv war, kann die Berechnung des Infektionsrisikos für diesen Zeitraum erfolgen.";
 


### PR DESCRIPTION
## Description
This PR adds missing text reg. the check-in based risk calculation. This text already exits under Android ([Link](https://github.com/corona-warn-app/cwa-app-android/blob/82acaf03775bebf24e18d6adac3ad4a43d0914d1/Corona-Warn-App/src/main/res/values-de/strings.xml#L205)), so it does not need additional approval from RKI to be implemented.
For the translation, please use the same strings as under Android. 

## Link to Jira
- GitHub Issue: https://github.com/corona-warn-app/cwa-documentation/issues/725
	- JIRA: [EXPOSUREAPP-13529](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13529)

## Screenshots

| Light Mode | Dark Mode |
|---|---|
| ![Light Mode](https://user-images.githubusercontent.com/67682506/177784950-393fb0e4-247f-40d3-b116-e809dc90368b.png) | ![Dark Mode](https://user-images.githubusercontent.com/67682506/177784965-994077f5-cd5a-4070-b37c-d98186b83622.png) |

