### PR TITLE
13630: Revert bouncing bug fix changes 

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ENSetting/ExposureNotificationSettingViewController.swift
@@ -43,6 +43,7 @@ final class ExposureNotificationSettingViewController: UITableViewController, Ac
 
 		tableView.sectionFooterHeight = 0.0
 		tableView.separatorStyle = .none
+		tableView.estimatedRowHeight = 1000 // this is need to prevent jumping of scroll position when tableview datasource is reloaded
 	}
 
 	override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Description
Revert the bug fix from PR https://github.com/corona-warn-app/cwa-app-ios/pull/4647.
On iPhone 5s with iOS 12.5 it leads to a problem, that the exposure-detection enable/disable Switch toggle cannot be tapped.

**That gives us the bouncing bug behavior back, but the possibility to switch the toggle on such old devices is more important regarding 2.25 release deadline.**

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13630

## Screenshots
https://user-images.githubusercontent.com/22373291/178966113-955a3c2b-117f-4df0-ae82-b247efdb47a8.MP4


