### PR TITLE
13617: Add accessibility identifier to the specific view element.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryCellModel.swift
@@ -11,11 +11,13 @@ struct DiaryDayEntryCellModel {
 	init(
 		entry: DiaryEntry,
 		dateString: String,
-		store: DiaryStoringProviding
+		store: DiaryStoringProviding,
+		accessibilityIdentifierIndex: Int = 0
 	) {
 		self.entry = entry
 		self.dateString = dateString
 		self.store = store
+		self.accessibilityIdentifierIndex = accessibilityIdentifierIndex
 
 		image = entry.isSelected ? UIImage(named: "Diary_Checkmark_Selected") : UIImage(named: "Diary_Checkmark_Unselected")
 		text = entry.name
@@ -46,6 +48,7 @@ struct DiaryDayEntryCellModel {
 	let parametersHidden: Bool
 
 	let accessibilityTraits: UIAccessibilityTraits
+	let accessibilityIdentifierIndex: Int
 
 	let durationValues: [SegmentedControlValue<ContactPersonEncounter.Duration>] = [
 		SegmentedControlValue(title: AppStrings.ContactDiary.Day.Encounter.lessThan10Minutes, value: .lessThan10Minutes),

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -47,6 +47,10 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		
 		headerStackView.accessibilityLabel = cellModel.text
 		headerStackView.accessibilityTraits = cellModel.parametersHidden ? [.button] : [.button, .selected]
+		headerStackView.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.headerStackView,
+			cellModel.accessibilityIdentifierIndex
+		)
 
 		setUpParameterViews()
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -42,8 +42,17 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		self.onInfoButtonTap = onInfoButtonTap
 
 		checkboxImageView.image = cellModel.image
+		checkboxImageView.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.checkboxImageView,
+			cellModel.accessibilityIdentifierIndex
+		)
+		
 		label.text = cellModel.text
 		label.font = cellModel.font
+		label.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.label,
+			cellModel.accessibilityIdentifierIndex
+		)
 		
 		headerStackView.accessibilityLabel = cellModel.text
 		headerStackView.accessibilityTraits = cellModel.parametersHidden ? [.button] : [.button, .selected]

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/DiaryDayViewModel.swift
@@ -65,7 +65,8 @@ class DiaryDayViewModel {
 		return DiaryDayEntryCellModel(
 			entry: entriesOfSelectedType[indexPath.row],
 			dateString: day.dateString,
-			store: store
+			store: store,
+			accessibilityIdentifierIndex: indexPath.row
 		)
 	}
 

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -119,6 +119,7 @@ enum AccessibilityIdentifiers {
 		static let legal_1 = "AppStrings.ContactDiaryInformation.legalHeadline_1"
 		
 		enum Day {
+			static let headerStackView = "AppStrings.ContactDiaryInformation.headerStackView-%d"
 			static let durationSegmentedContol = "AppStrings.ContactDiaryInformation.durationSegmentedContol"
 			static let maskSituationSegmentedControl = "AppStrings.ContactDiaryInformation.maskSituationSegmentedControl"
 			static let settingSegmentedControl = "AppStrings.ContactDiaryInformation.settingSegmentedControl"

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -120,6 +120,8 @@ enum AccessibilityIdentifiers {
 		
 		enum Day {
 			static let headerStackView = "AppStrings.ContactDiaryInformation.headerStackView-%d"
+			static let checkboxImageView = "AppStrings.ContactDiaryInformation.checkboxImageView-%d"
+			static let label = "AppStrings.ContactDiaryInformation.label-%d"
 			static let durationSegmentedContol = "AppStrings.ContactDiaryInformation.durationSegmentedContol"
 			static let maskSituationSegmentedControl = "AppStrings.ContactDiaryInformation.maskSituationSegmentedControl"
 			static let settingSegmentedControl = "AppStrings.ContactDiaryInformation.settingSegmentedControl"


### PR DESCRIPTION
## Description
Adds an _iteratable_ **accessibility identifier** to the person accessibility `.button` trait. (`headerSteackView`).

### Supplement
Accessibility identifiers added to checkbox image view and the name label as well, see regarding comment in the bug ticket.

```swift
"AppStrings.ContactDiaryInformation.headerStackView-0" // (Alice)
"AppStrings.ContactDiaryInformation.headerStackView-1" // (Bob)
...

"AppStrings.ContactDiaryInformation.checkboxImageView-0" // (Alice)
"AppStrings.ContactDiaryInformation.checkboxImageView-1" // (Bob)
...

"AppStrings.ContactDiaryInformation.label-0" // (Alice)
"AppStrings.ContactDiaryInformation.label-1" // (Bob)
...
```

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13617

## Screenshots
<img width="480" alt="Screen Shot 2022-07-15 at 14 43 57" src="https://user-images.githubusercontent.com/22373291/179225776-2dfccc34-e7e4-42c2-b415-fe6655088594.png">

