### PR TITLE
13467: Change `validityStateIsConsideredNewsworthy`

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -306,9 +306,9 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 
 	var validityStateIsConsideredNewsworthy: Bool {
 		switch validityState {
-		case .valid, .expiringSoon:
+		case .valid:
 			return false
-		case .invalid, .blocked, .revoked, .expired:
+		case .invalid, .blocked, .revoked, .expired, .expiringSoon:
 			return true
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -306,9 +306,9 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 
 	var validityStateIsConsideredNewsworthy: Bool {
 		switch validityState {
-		case .valid, .expiringSoon, .expired:
+		case .valid, .expiringSoon:
 			return false
-		case .invalid, .blocked, .revoked:
+		case .invalid, .blocked, .revoked, .expired:
 			return true
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateRequestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateRequestServiceTests.swift
@@ -101,7 +101,7 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 				}
 			}
 		
-		let expectedCounts = [0, 1, 0]
+		let expectedCounts = [0, 1]
 		let countExpectation = expectation(description: "Count updated")
 		countExpectation.expectedFulfillmentCount = expectedCounts.count
 		var receivedCounts = [Int]()
@@ -125,8 +125,8 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 		// Wait for certificate registration to succeed
 		wait(for: [completionExpectation], timeout: .medium)
 		
-		healthCertificateService.healthCertifiedPersons.first?.healthCertificates.first?.isValidityStateNew = false
-		healthCertificateService.healthCertifiedPersons.first?.healthCertificates.first?.isNew = false
+		healthCertificateService.healthCertifiedPersons.first?.healthCertificates.first?.isValidityStateNew = true
+		healthCertificateService.healthCertifiedPersons.first?.healthCertificates.first?.isNew = true
 		
 		waitForExpectations(timeout: .medium)
 		
@@ -222,7 +222,7 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 		)
 
 		let personsExpectation = expectation(description: "Persons not empty")
-		personsExpectation.expectedFulfillmentCount = 3
+		personsExpectation.expectedFulfillmentCount = 4
 		let personsSubscription = healthCertificateService.$healthCertifiedPersons
 			.sink {
 				if !$0.isEmpty {
@@ -339,7 +339,7 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 		)
 
 		let personsExpectation = expectation(description: "Persons not empty")
-		personsExpectation.expectedFulfillmentCount = 3
+		personsExpectation.expectedFulfillmentCount = 4
 		let personsSubscription = healthCertificateService.$healthCertifiedPersons
 			.sink {
 				if !$0.isEmpty {
@@ -458,7 +458,7 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 		)
 
 		let personsExpectation = expectation(description: "Persons not empty")
-		personsExpectation.expectedFulfillmentCount = 3
+		personsExpectation.expectedFulfillmentCount = 4
 		let personsSubscription = healthCertificateService.$healthCertifiedPersons
 			.sink {
 				if !$0.isEmpty {
@@ -642,7 +642,7 @@ class HealthCertificateRequestServiceTests: CWATestCase {
 		)
 
 		let personsExpectation = expectation(description: "Persons not empty")
-		personsExpectation.expectedFulfillmentCount = 3
+		personsExpectation.expectedFulfillmentCount = 4
 		let personsSubscription = healthCertificateService.$healthCertifiedPersons
 			.sink {
 				if !$0.isEmpty {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/__tests__/HealthCertificateServiceTests.swift
@@ -27,7 +27,7 @@ class HealthCertificateServiceTests: CWATestCase {
 		
 		let healthCertifiedPersonsExpectation = expectation(description: "healthCertifiedPersons publisher updated")
 		// One for registration, one for the validity state update, and one for the wallet info update
-		healthCertifiedPersonsExpectation.expectedFulfillmentCount = 3
+		healthCertifiedPersonsExpectation.expectedFulfillmentCount = 4
 		
 		let subscription = service.$healthCertifiedPersons
 			.dropFirst()
@@ -348,7 +348,7 @@ class HealthCertificateServiceTests: CWATestCase {
 		let firstRecoveryCertificate = try HealthCertificate(base45: firstRecoveryCertificateBase45, validityState: .expired, isValidityStateNew: false)
 		
 		let personsExpectation = expectation(description: "healthCertifiedPersons publisher triggered")
-		personsExpectation.expectedFulfillmentCount = 4
+		personsExpectation.expectedFulfillmentCount = 5
 		
 		let personsSubscription = service.$healthCertifiedPersons
 			.sink { _ in
@@ -356,7 +356,7 @@ class HealthCertificateServiceTests: CWATestCase {
 			}
 		
 		let newsExpectation = expectation(description: "unseenNewsCount publisher triggered")
-		newsExpectation.expectedFulfillmentCount = 1
+		newsExpectation.expectedFulfillmentCount = 2
 		
 		let newsSubscription = service.unseenNewsCount
 			.sink { _ in
@@ -383,11 +383,11 @@ class HealthCertificateServiceTests: CWATestCase {
 		
 		XCTAssertEqual(store.healthCertifiedPersons[safe: 1]?.healthCertificates.map { $0.base45 }, [firstRecoveryCertificate.base45])
 		XCTAssertEqual(service.healthCertifiedPersons[safe: 1]?.gradientType, .solidGrey)
-		XCTAssertEqual(try XCTUnwrap(store.healthCertifiedPersons[safe: 1]).unseenNewsCount, 0)
+		XCTAssertEqual(try XCTUnwrap(store.healthCertifiedPersons[safe: 1]).unseenNewsCount, 1)
 		
 		// Expired state does not increase unseen news count
-		XCTAssertEqual(service.unseenNewsCount.value, 2)
-		XCTAssertFalse(try XCTUnwrap(store.healthCertifiedPersons[safe: 1]?.healthCertificates[safe: 0]).isValidityStateNew)
+		XCTAssertEqual(service.unseenNewsCount.value, 3)
+		XCTAssertTrue(try XCTUnwrap(store.healthCertifiedPersons[safe: 1]?.healthCertificates[safe: 0]).isValidityStateNew)
 		
 		XCTAssertEqual(store.healthCertifiedPersons[safe: 2]?.healthCertificates.map { $0.base45 }, [firstVaccinationCertificate, firstTestCertificate, secondTestCertificate].map { $0.base45 })
 		XCTAssertEqual(service.healthCertifiedPersons[safe: 2]?.gradientType, .darkBlue)


### PR DESCRIPTION
## Description
Change `validityStateIsConsideredNewsworthy` of a `HealthCertificate` object for `expired` or `expiredSoon` certificates to `true`.
Now you get a red notification badge as expected.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13467

## Screenshots
### Expired
https://user-images.githubusercontent.com/22373291/180423982-92c3f9c5-d343-4921-8028-fb55d1d18d06.mov

### ExpiredSoon
https://user-images.githubusercontent.com/22373291/180456846-32ba105b-f0c2-497f-a210-742e7e299cac.mov



