### PR TITLE
fix/9906 settings notifications screen wording wrong when notifications are turned off

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -351,7 +351,7 @@ Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird d
 
 "NotificationSettings_BulletHeadlineOn" = "Mitteilungen verwalten";
 
-"NotificationSettings_BulletHeadlineOff" = "Mitteilungen aktivieren";
+"NotificationSettings_BulletHeadlineOff" = "Mitteilungen verwalten";
 
 "NotificationSettings_BulletDescOn" = "Sie können hier festlegen, ob:";
 


### PR DESCRIPTION
## Description
The settings notifications screen wording wrong when notifications are turned off when the phone language was in German.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9906

## Screenshots
![Mitteilungen An](https://user-images.githubusercontent.com/72390277/181311992-1cc6d10a-6ed2-4f20-8723-88c074cf15ba.PNG)
![Mitteilungen Aus](https://user-images.githubusercontent.com/72390277/181312006-302e00f7-1c4c-4dc9-ad99-c9d3f5f990dc.PNG)

