### PR TITLE
Fix/10926: Data privacy & Terms screen - issue with format of some links

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/style.css
+++ b/src/xcode/ENA/ENA/Resources/Localization/style.css
@@ -67,6 +67,12 @@ a:link, a:visited {
 	color: #007fad;
 }
 
+/* Any element that directly contains an <a> element */
+*:has(> a) {
+	/* Avoid broken layouts due long URL text flowing outside a container. */
+	overflow-wrap: break-word;
+}
+
 p, ul {
 	font-size: 1.0em;
 	font-weight: normal;
@@ -89,6 +95,6 @@ li {
 	margin: 1em 2em;
 }
 
-p, ul{
+p, ul {
 	margin-bottom: 1em;
 }


### PR DESCRIPTION
## Description
Fix URL text flow outside of an container.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10926

## Screenshots
<img width="66%" alt="10926-data-privacy" src="https://user-images.githubusercontent.com/22373291/184320690-8eec2de1-cdc5-40df-a57b-2da35ce7e056.png">

<img width="66%" alt="10926-terms" src="https://user-images.githubusercontent.com/22373291/184324294-08c09fa2-4eb3-4d4d-aa88-2dfaf42e84a0.png">

