### PR TITLE
Fix/13772: Data Privacy and Terms Screen: Bottom text is cut off

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/style.css
+++ b/src/xcode/ENA/ENA/Resources/Localization/style.css
@@ -10,6 +10,10 @@ html, body, table {
 	"Roboto", "Oxygen", "Ubuntu", "Helvetica Neue", Arial, sans-serif;
 }
 
+body {
+	padding-bottom: 32px;
+}
+
 @supports (font: -apple-system-body) {
 	html, body, table {
 		font: -apple-system-body !important;


### PR DESCRIPTION
## Description
Fix bottom layout issue to avoid cut off last texts in data privacy and terms of use screens.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13772

## Screenshots
<img width="66%" alt="13772-data-privacy" src="https://user-images.githubusercontent.com/22373291/184326479-bef4f430-941b-4051-831f-e66ed7318063.png">

<img width="66%" alt="13772-terms" src="https://user-images.githubusercontent.com/22373291/184326487-7510e91c-9a49-4bbb-b4b2-0f85a0b6cf1f.png">
