### PR TITLE
Fix/13749 Add missing accessibility identifier issues for test automation

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewViewController.swift
@@ -267,6 +267,8 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 	private func didTapMoreButton() {
 		let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+		// Info Action
+
 		let infoAction = UIAlertAction(
 			title: AppStrings.TraceLocations.Overview.ActionSheet.infoTitle,
 			style: .default,
@@ -274,8 +276,12 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 				self?.onInfoButtonTap()
 			}
 		)
+		infoAction.isAccessibilityElement = true
+		infoAction.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Overview.MenuActionSheet.infoAction
 		actionSheet.addAction(infoAction)
 
+		// Edit Action
+	
 		let editAction = UIAlertAction(
 			title: AppStrings.TraceLocations.Overview.ActionSheet.editTitle,
 			style: .default,
@@ -285,8 +291,12 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 			}
 		)
 		editAction.isEnabled = !viewModel.isEmpty
+		editAction.isAccessibilityElement = true
+		editAction.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Overview.MenuActionSheet.editAction
 		actionSheet.addAction(editAction)
 
+		// On Behalf Checkin Action
+		
 		let onBehalfCheckinSubmissionAction = UIAlertAction(
 			title: AppStrings.TraceLocations.Overview.ActionSheet.onBehalfCheckinSubmissionTitle,
 			style: .default,
@@ -294,8 +304,12 @@ class TraceLocationsOverviewViewController: UITableViewController, FooterViewHan
 				self?.onOnBehalfCheckinSubmissionTap()
 			}
 		)
+		onBehalfCheckinSubmissionAction.isAccessibilityElement = true
+		onBehalfCheckinSubmissionAction.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Overview.MenuActionSheet.onBehalfCheckinSubmissionAction
 		actionSheet.addAction(onBehalfCheckinSubmissionAction)
 
+		// Cancel
+		
 		let cancelAction = UIAlertAction(title: AppStrings.Common.alertActionCancel, style: .cancel)
 		actionSheet.addAction(cancelAction)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -24,6 +24,7 @@ struct HealthCertificateQRCodeCellViewModel {
 			showRealQRCodeIfValidityStateBlocked: mode == .details,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: accessibilityText,
+			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: healthCertificate.uniqueCertificateIdentifier),
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Cells/HealthCertificateQRCodeCellViewModel.swift
@@ -24,7 +24,9 @@ struct HealthCertificateQRCodeCellViewModel {
 			showRealQRCodeIfValidityStateBlocked: mode == .details,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: accessibilityText,
-			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: healthCertificate.uniqueCertificateIdentifier),
+			qrCodeAccessibilityIdentifier: AccessibilityIdentifiers.HealthCertificate.qrCodeView(
+				of: healthCertificate.uniqueCertificateIdentifier
+			),
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -30,7 +30,7 @@ class HealthCertifiedPersonCellModel {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: [.image, .button],
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
-			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: initialCertificate.uniqueCertificateIdentifier),
+			qrCodeAccessibilityIdentifier: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: initialCertificate.uniqueCertificateIdentifier),
 			covPassCheckInfoPosition: .bottom,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -94,7 +94,7 @@ class HealthCertifiedPersonCellModel {
 			shouldBlockCertificateCode: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
-			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: decodingFailedHealthCertificate.base45),
+			qrCodeAccessibilityIdentifier: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: decodingFailedHealthCertificate.base45),
 			covPassCheckInfoPosition: .bottom,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/Cells/HealthCertifiedPerson/HealthCertifiedPersonCellModel.swift
@@ -30,6 +30,7 @@ class HealthCertifiedPersonCellModel {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: [.image, .button],
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
+			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: initialCertificate.uniqueCertificateIdentifier),
 			covPassCheckInfoPosition: .bottom,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)
@@ -93,6 +94,7 @@ class HealthCertifiedPersonCellModel {
 			shouldBlockCertificateCode: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: AppStrings.HealthCertificate.Overview.covidDescription,
+			qrCodeAccessibilityID: AccessibilityIdentifiers.HealthCertificate.qrCodeView(of: decodingFailedHealthCertificate.base45),
 			covPassCheckInfoPosition: .bottom,
 			onCovPassCheckInfoButtonTap: onCovPassCheckInfoButtonTap
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeView.swift
@@ -44,7 +44,7 @@ class HealthCertificateQRCodeView: UIView {
 
 		qrCodeImageView.accessibilityTraits = viewModel.imageAccessibilityTraits
 		qrCodeImageView.accessibilityLabel = viewModel.accessibilityLabel
-		qrCodeImageView.accessibilityIdentifier = viewModel.qrCodeAccessibilityID
+		qrCodeImageView.accessibilityIdentifier = viewModel.qrCodeAccessibilityIdentifier
 		blockingView.isHidden = !viewModel.shouldBlockCertificateCode
 		covPassCheckInfoStackView.isHidden = viewModel.shouldBlockCertificateCode
 		onCovPassCheckInfoButtonTap = viewModel.onCovPassCheckInfoButtonTap

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeView.swift
@@ -44,6 +44,7 @@ class HealthCertificateQRCodeView: UIView {
 
 		qrCodeImageView.accessibilityTraits = viewModel.imageAccessibilityTraits
 		qrCodeImageView.accessibilityLabel = viewModel.accessibilityLabel
+		qrCodeImageView.accessibilityIdentifier = viewModel.qrCodeAccessibilityID
 		blockingView.isHidden = !viewModel.shouldBlockCertificateCode
 		covPassCheckInfoStackView.isHidden = viewModel.shouldBlockCertificateCode
 		onCovPassCheckInfoButtonTap = viewModel.onCovPassCheckInfoButtonTap

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
@@ -14,14 +14,14 @@ struct HealthCertificateQRCodeViewModel {
 		showRealQRCodeIfValidityStateBlocked: Bool,
 		imageAccessibilityTraits: UIAccessibilityTraits,
 		accessibilityLabel: String,
-		qrCodeAccessibilityID: String,
+		qrCodeAccessibilityIdentifier: String,
 		covPassCheckInfoPosition: CovPassCheckInfoPosition,
 		onCovPassCheckInfoButtonTap: @escaping () -> Void
 	) {
 		self.shouldBlockCertificateCode = !healthCertificate.isUsable && !(showRealQRCodeIfValidityStateBlocked && healthCertificate.validityState == .blocked)
 		self.imageAccessibilityTraits = imageAccessibilityTraits
 		self.accessibilityLabel = accessibilityLabel
-		self.qrCodeAccessibilityID = qrCodeAccessibilityID
+		self.qrCodeAccessibilityID = qrCodeAccessibilityIdentifier
 		self.covPassCheckInfoPosition = covPassCheckInfoPosition
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
@@ -21,7 +21,7 @@ struct HealthCertificateQRCodeViewModel {
 		self.shouldBlockCertificateCode = !healthCertificate.isUsable && !(showRealQRCodeIfValidityStateBlocked && healthCertificate.validityState == .blocked)
 		self.imageAccessibilityTraits = imageAccessibilityTraits
 		self.accessibilityLabel = accessibilityLabel
-		self.qrCodeAccessibilityID = qrCodeAccessibilityIdentifier
+		self.qrCodeAccessibilityIdentifier = qrCodeAccessibilityIdentifier
 		self.covPassCheckInfoPosition = covPassCheckInfoPosition
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
 
@@ -33,14 +33,14 @@ struct HealthCertificateQRCodeViewModel {
 		shouldBlockCertificateCode: Bool,
 		imageAccessibilityTraits: UIAccessibilityTraits,
 		accessibilityLabel: String,
-		qrCodeAccessibilityID: String,
+		qrCodeAccessibilityIdentifier: String,
 		covPassCheckInfoPosition: CovPassCheckInfoPosition,
 		onCovPassCheckInfoButtonTap: @escaping () -> Void
 	) {
 		self.shouldBlockCertificateCode = shouldBlockCertificateCode
 		self.imageAccessibilityTraits = imageAccessibilityTraits
 		self.accessibilityLabel = accessibilityLabel
-		self.qrCodeAccessibilityID = qrCodeAccessibilityID
+		self.qrCodeAccessibilityIdentifier = qrCodeAccessibilityIdentifier
 		self.covPassCheckInfoPosition = covPassCheckInfoPosition
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
 
@@ -57,7 +57,7 @@ struct HealthCertificateQRCodeViewModel {
 	let shouldBlockCertificateCode: Bool
 	let imageAccessibilityTraits: UIAccessibilityTraits
 	let accessibilityLabel: String
-	let qrCodeAccessibilityID: String
+	let qrCodeAccessibilityIdentifier: String
 	let covPassCheckInfoPosition: CovPassCheckInfoPosition
 	let onCovPassCheckInfoButtonTap: () -> Void
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/HealthCertificateQRCodeViewModel.swift
@@ -14,12 +14,14 @@ struct HealthCertificateQRCodeViewModel {
 		showRealQRCodeIfValidityStateBlocked: Bool,
 		imageAccessibilityTraits: UIAccessibilityTraits,
 		accessibilityLabel: String,
+		qrCodeAccessibilityID: String,
 		covPassCheckInfoPosition: CovPassCheckInfoPosition,
 		onCovPassCheckInfoButtonTap: @escaping () -> Void
 	) {
 		self.shouldBlockCertificateCode = !healthCertificate.isUsable && !(showRealQRCodeIfValidityStateBlocked && healthCertificate.validityState == .blocked)
 		self.imageAccessibilityTraits = imageAccessibilityTraits
 		self.accessibilityLabel = accessibilityLabel
+		self.qrCodeAccessibilityID = qrCodeAccessibilityID
 		self.covPassCheckInfoPosition = covPassCheckInfoPosition
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
 
@@ -31,12 +33,14 @@ struct HealthCertificateQRCodeViewModel {
 		shouldBlockCertificateCode: Bool,
 		imageAccessibilityTraits: UIAccessibilityTraits,
 		accessibilityLabel: String,
+		qrCodeAccessibilityID: String,
 		covPassCheckInfoPosition: CovPassCheckInfoPosition,
 		onCovPassCheckInfoButtonTap: @escaping () -> Void
 	) {
 		self.shouldBlockCertificateCode = shouldBlockCertificateCode
 		self.imageAccessibilityTraits = imageAccessibilityTraits
 		self.accessibilityLabel = accessibilityLabel
+		self.qrCodeAccessibilityID = qrCodeAccessibilityID
 		self.covPassCheckInfoPosition = covPassCheckInfoPosition
 		self.onCovPassCheckInfoButtonTap = onCovPassCheckInfoButtonTap
 
@@ -53,6 +57,7 @@ struct HealthCertificateQRCodeViewModel {
 	let shouldBlockCertificateCode: Bool
 	let imageAccessibilityTraits: UIAccessibilityTraits
 	let accessibilityLabel: String
+	let qrCodeAccessibilityID: String
 	let covPassCheckInfoPosition: CovPassCheckInfoPosition
 	let onCovPassCheckInfoButtonTap: () -> Void
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -59,13 +59,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: [.image, .button],
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "accessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, [.image, .button])
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -90,13 +91,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -27,7 +27,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -59,7 +59,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: [.image, .button],
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "accessibilityID",
+			qrCodeAccessibilityIdentifier: "accessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -90,7 +90,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "",
+			qrCodeAccessibilityIdentifier: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -121,7 +121,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -153,7 +153,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -185,7 +185,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -219,7 +219,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -251,7 +251,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -283,7 +283,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -315,7 +315,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -347,7 +347,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -379,7 +379,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -413,7 +413,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -445,7 +445,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -477,7 +477,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -509,7 +509,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -541,7 +541,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -573,7 +573,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -600,7 +600,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityID: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -27,14 +27,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -121,14 +121,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -153,14 +153,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -185,14 +185,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -219,14 +219,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -251,14 +251,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -283,14 +283,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -315,14 +315,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -347,14 +347,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -379,14 +379,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -413,14 +413,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -445,14 +445,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -477,14 +477,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -509,14 +509,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -541,14 +541,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -573,14 +573,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityIdentifier")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -600,7 +600,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
-			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityID",
+			qrCodeAccessibilityIdentifier: "qrCodeAccessibilityIdentifier",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -34,7 +34,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -128,7 +128,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -160,7 +160,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -192,7 +192,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -226,7 +226,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -258,7 +258,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -290,7 +290,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -322,7 +322,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -354,7 +354,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -386,7 +386,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -420,7 +420,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -452,7 +452,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -484,7 +484,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -516,7 +516,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -548,7 +548,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -580,7 +580,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
-		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityIdentifier, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewModelTests.swift
@@ -27,12 +27,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -57,6 +59,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: [.image, .button],
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "accessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -87,6 +90,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
@@ -117,12 +121,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -147,12 +153,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -177,12 +185,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -209,12 +219,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -239,12 +251,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -269,12 +283,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -299,12 +315,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -329,12 +347,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -359,12 +379,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -391,12 +413,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -421,12 +445,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -451,12 +477,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -481,12 +509,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -511,12 +541,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -541,12 +573,14 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: true,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)
 
 		XCTAssertEqual(viewModel.imageAccessibilityTraits, .image)
 		XCTAssertEqual(viewModel.accessibilityLabel, "accessibilityLabel")
+		XCTAssertEqual(viewModel.qrCodeAccessibilityID, "qrCodeAccessibilityID")
 
 		XCTAssertEqual(
 			viewModel.qrCodeImage?.parsedQRCodeStrings.first,
@@ -566,6 +600,7 @@ class HealthCertificateQRCodeViewModelTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "accessibilityLabel",
+			qrCodeAccessibilityID: "qrCodeAccessibilityID",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: { }
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
@@ -26,6 +26,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "",
+			qrCodeAccessibilityID: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: {}
 		)
@@ -55,6 +56,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "",
+			qrCodeAccessibilityID: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: {}
 		)

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Views/__tests__/HealthCertificateQRCodeViewTests.swift
@@ -26,7 +26,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "",
-			qrCodeAccessibilityID: "",
+			qrCodeAccessibilityIdentifier: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: {}
 		)
@@ -56,7 +56,7 @@ class HealthCertificateQRCodeViewTests: XCTestCase {
 			showRealQRCodeIfValidityStateBlocked: false,
 			imageAccessibilityTraits: .image,
 			accessibilityLabel: "",
-			qrCodeAccessibilityID: "",
+			qrCodeAccessibilityIdentifier: "",
 			covPassCheckInfoPosition: .top,
 			onCovPassCheckInfoButtonTap: {}
 		)

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -899,6 +899,7 @@ enum AccessibilityIdentifiers {
 
 		static let header = "HealthCertificate.header"
 		static let qrCodeCell = "HealthCertificate.qrCodeCell"
+		static func qrCodeView(of identifier: String) -> String { "HealthCertificate.QRCode.\(identifier)" }
 		
 		enum Reissuance {
 			static let cell = "AppStrings.HealthCertificate.Reissuance.cell"

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -739,6 +739,12 @@ enum AccessibilityIdentifiers {
 			static let menueButton = "AppStrings.TraceLocations.Overview.menueButton"
 			static let addButton = "AppStrings.TraceLocations.Overview.addButton"
 			static let emptyState = "AppStrings.TraceLocations.Overview.emptyState"
+			
+			enum MenuActionSheet {
+				static let infoAction = "AppStrings.TraceLocations.Overview.MenuActionSheet.infoAction"
+				static let editAction = "AppStrings.TraceLocations.Overview.MenuActionSheet.editAction"
+				static let onBehalfCheckinSubmissionAction = "AppStrings.TraceLocations.Overview.MenuActionSheet.onBehalfCheckinSubmissionAction"
+			}
 		}
 		
 		enum Configuration {

--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATextField.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATextField.swift
@@ -104,7 +104,6 @@ class ENATextField: UITextField {
 		if let clearButton = value(forKey: "clearButton") as? UIButton {
 			clearButton.isAccessibilityElement = true
 			clearButton.accessibilityIdentifier = "\(identifier).ClearButton"
-			print("clearButton.accessibilityIdentifier: ", clearButton.accessibilityIdentifier)
 		}
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATextField.swift
+++ b/src/xcode/ENA/ENA/Source/Views/BaseElements/ENATextField.swift
@@ -18,16 +18,23 @@ class ENATextField: UITextField {
 
 		super.init(frame: frame)
 
-		setup()
+		setupLayout()
 	}
 
 	required init?(coder: NSCoder) {
 		super.init(coder: coder)
 
-		setup()
+		setupLayout()
 	}
 
 	// MARK: - Overrides
+	
+	override var accessibilityIdentifier: String? {
+		didSet {
+			guard let identifier = accessibilityIdentifier else { return }
+			setupClearButtonAccessibility(for: identifier)
+		}
+	}
 
 	override func textRect(forBounds bounds: CGRect) -> CGRect {
 		return super.textRect(forBounds: bounds)
@@ -71,7 +78,7 @@ class ENATextField: UITextField {
 
 	// MARK: - Private
 
-	private func setup() {
+	private func setupLayout() {
 		borderStyle = .none
 		backgroundColor = .enaColor(for: .textField)
 
@@ -93,4 +100,11 @@ class ENATextField: UITextField {
 		self.text = String(text.prefix(maxLength))
 	}
 
+	private func setupClearButtonAccessibility(for identifier: String) {
+		if let clearButton = value(forKey: "clearButton") as? UIButton {
+			clearButton.isAccessibilityElement = true
+			clearButton.accessibilityIdentifier = "\(identifier).ClearButton"
+			print("clearButton.accessibilityIdentifier: ", clearButton.accessibilityIdentifier)
+		}
+	}
 }


### PR DESCRIPTION
## Description
Adds a set of accessibilityIdentifiers to view elements, that should become better testable.

### Certificates

#### QR Code (1.)
`HealthCertificate.QRCode.<certificate-identifier>`

_Example:_
_HealthCertificate.QRCode.URN:UVCI:01DE/IZ14452A/JP15ZN6BPD7U7AB3TNTWO6611#D_

### Contact Diary Edit Location

#### Delete Button (2.)

That seems to not possible, because this specific deletion button we use is a native view element from iOS. There is no access to that element at the moment. I submitted a question about this topic to Stackoverflow: https://stackoverflow.com/questions/73391056/how-to-give-an-accessibilityid-to-uitableviewcelleditcontrol-of-uitableviewcell

#### Beschreibung Clear Button (3.)
`AppStrings.ContactDiary.EditEntries.nameTextField.ClearButton`

#### Telefon Clear Button (3.)
`AppStrings.ContactDiary.EditEntries.phoneNumberTextField.ClearButton`

#### E-Mail Clear Button (3.)
`AppStrings.ContactDiary.EditEntries.eMailTextField.ClearButton`

### Contact Diary Edit Person

#### Delete Button (4.)

That seems to not possible, because this specific deletion button we use is a native view element from iOS. There is no access to that element at the moment. I submitted a question about this topic to Stackoverflow: https://stackoverflow.com/questions/73391056/how-to-give-an-accessibilityid-to-uitableviewcelleditcontrol-of-uitableviewcell

#### Beschreibung Clear Button (5.)
`AppStrings.ContactDiary.EditEntries.nameTextField.ClearButton`

#### Telefon Clear Button (5.)
`AppStrings.ContactDiary.EditEntries.phoneNumberTextField.ClearButton`

#### E-Mail Clear Button (5.)
`AppStrings.ContactDiary.EditEntries.eMailTextField.ClearButton`

### Checkin Creation

#### Informationen Action (6.)
`AppStrings.TraceLocations.Overview.MenuActionSheet.infoAction`

#### Bearbeiten Action (6.)
`AppStrings.TraceLocations.Overview.MenuActionSheet.editAction`

#### In Vertretung warnen Action (6.)
`AppStrings.TraceLocations.Overview.MenuActionSheet.onBehalfCheckinSubmissionAction`

### Contact Diary Set Duration for Person and Location (7.)

The date pickers should be outdated.
For Person/Location you see less/more than 10 minutes picker.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13749

## Screenshots
<img width="1105" alt="Screen Shot 2022-08-17 at 16 10 01" src="https://user-images.githubusercontent.com/22373291/185385663-efd2a376-f98b-40c3-9da7-89a249047407.png">
<img width="1108" alt="Screen Shot 2022-08-17 at 16 14 08" src="https://user-images.githubusercontent.com/22373291/185385668-7308b3af-bce5-4b9f-87d1-1bd9f55bc6db.png">
<img width="623" alt="Screen Shot 2022-08-18 at 12 55 34" src="https://user-images.githubusercontent.com/22373291/185385671-390b7ee4-7777-493b-a6de-b239bee1c507.png">
<img width="660" alt="Screen Shot 2022-08-18 at 12 55 52" src="https://user-images.githubusercontent.com/22373291/185385676-b6db37f8-be57-4329-abc6-17eddfc71a3b.png">
<img width="662" alt="Screen Shot 2022-08-18 at 12 56 14" src="https://user-images.githubusercontent.com/22373291/185385679-f52e5ffa-bf08-4754-a34a-b02f1ca391c9.png">
<img width="1135" alt="Screen Shot 2022-08-18 at 13 20 17" src="https://user-images.githubusercontent.com/22373291/185385680-eb06549a-a527-4c27-b555-afe273d2ebaf.png">
