### PR TITLE
Fix/13799 contact diary location duration screenobject id issue for test automation

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -72,6 +72,11 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		notesTextField.text = cellModel.circumstances
 
 		accessibilityTraits = cellModel.accessibilityTraits
+
+		accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.cellView,
+			cellModel.accessibilityIdentifierIndex
+		)
 	}
 
 	// MARK: - Private

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -146,6 +146,19 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
 		return stackView
 	}()
+	
+	private lazy var visitDurationPickerWrapper: UIView = {
+		let view = UIView()
+		view.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(visitDurationPicker)
+		view.topAnchor.constraint(equalTo: visitDurationPicker.topAnchor).isActive = true
+		view.rightAnchor.constraint(equalTo: visitDurationPicker.rightAnchor).isActive = true
+		view.bottomAnchor.constraint(equalTo: visitDurationPicker.bottomAnchor).isActive = true
+		view.leftAnchor.constraint(equalTo: visitDurationPicker.leftAnchor).isActive = true
+		view.isAccessibilityElement = true // Check wether needed in Appium, or if accessibility identifier alone is fine
+		view.accessibilityIdentifier = AccessibilityIdentifiers.ContactDiaryInformation.Day.visitDurationPickerWrapper
+		return view
+	}()
 
 	private lazy var visitDurationPicker: UIDatePicker = {
 		let durationPicker = UIDatePicker()
@@ -171,18 +184,24 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
 		return durationPicker
 	}()
+	
+	private let durationLabel: ENALabel = {
+		let label = ENALabel()
+		label.style = .body
+		label.text = AppStrings.ContactDiary.Day.Visit.duration
+		label.accessibilityTraits = .staticText
+		label.isAccessibilityElement = true
+		label.accessibilityIdentifier = AccessibilityIdentifiers.ContactDiaryInformation.Day.durationLabel
+		return label
+	}()
 
 	private lazy var visitDurationStackView: UIStackView = {
 		let stackView = UIStackView()
 		stackView.axis = .horizontal
 		stackView.spacing = 8
 
-		let label = ENALabel()
-		label.style = .body
-		label.text = AppStrings.ContactDiary.Day.Visit.duration
-
-		stackView.addArrangedSubview(label)
-		stackView.addArrangedSubview(visitDurationPicker)
+		stackView.addArrangedSubview(durationLabel)
+		stackView.addArrangedSubview(visitDurationPickerWrapper)
 
 		return stackView
 	}()

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -156,8 +156,8 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		let label = ENALabel()
 		label.style = .body
 		label.text = AppStrings.ContactDiary.Day.Visit.duration
-		label.accessibilityTraits = .staticText
 		label.isAccessibilityElement = true
+		label.accessibilityTraits = .staticText
 		label.accessibilityIdentifier = AccessibilityIdentifiers.ContactDiaryInformation.Day.durationLabel
 		return label
 	}()

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -81,7 +81,6 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		accessibilityElements = [
 			headerStackView as Any,
 			durationLabel,
-//			visitDurationPickerWrapper, // Check wether accessibility identifier is still visible in appium ...
 			visitDurationPicker,
 			notesTextField,
 			notesInfoButton
@@ -155,19 +154,6 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
 		return stackView
 	}()
-	
-	private lazy var visitDurationPickerWrapper: UIView = {
-		let view = UIView()
-		view.translatesAutoresizingMaskIntoConstraints = false
-		view.addSubview(visitDurationPicker)
-		view.topAnchor.constraint(equalTo: visitDurationPicker.topAnchor).isActive = true
-		view.rightAnchor.constraint(equalTo: visitDurationPicker.rightAnchor).isActive = true
-		view.bottomAnchor.constraint(equalTo: visitDurationPicker.bottomAnchor).isActive = true
-		view.leftAnchor.constraint(equalTo: visitDurationPicker.leftAnchor).isActive = true
-		view.isAccessibilityElement = true // Check wether needed in Appium, or if accessibility identifier alone is fine
-		view.accessibilityIdentifier = AccessibilityIdentifiers.ContactDiaryInformation.Day.visitDurationPickerWrapper
-		return view
-	}()
 
 	private lazy var visitDurationPicker: UIDatePicker = {
 		let durationPicker = UIDatePicker()
@@ -210,7 +196,7 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		stackView.spacing = 8
 
 		stackView.addArrangedSubview(durationLabel)
-		stackView.addArrangedSubview(visitDurationPickerWrapper)
+		stackView.addArrangedSubview(visitDurationPicker)
 
 		return stackView
 	}()

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -223,13 +223,25 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		)
 		
 		// Give specific order
-		accessibilityElements = [
-			headerStackView as Any,
-			durationLabel,
-			visitDurationPicker,
-			notesTextField,
-			notesInfoButton
-		]
+		switch cellModel.entryType {
+		case .contactPerson:
+			accessibilityElements = [
+				headerStackView as Any,
+				durationSegmentedControl,
+				maskSituationSegmentedControl,
+				settingSegmentedControl,
+				notesTextField,
+				notesInfoButton
+			]
+		case .location:
+			accessibilityElements = [
+				headerStackView as Any,
+				durationLabel,
+				visitDurationPicker,
+				notesTextField,
+				notesInfoButton
+			]
+		}
 	}
 
 	private func updateContactPersonEncounter() {

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -42,24 +42,9 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		self.onInfoButtonTap = onInfoButtonTap
 
 		checkboxImageView.image = cellModel.image
-		checkboxImageView.accessibilityIdentifier = String(
-			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.checkboxImageView,
-			cellModel.accessibilityIdentifierIndex
-		)
 		
 		label.text = cellModel.text
 		label.font = cellModel.font
-		label.accessibilityIdentifier = String(
-			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.label,
-			cellModel.accessibilityIdentifierIndex
-		)
-		
-		headerStackView.accessibilityLabel = cellModel.text
-		headerStackView.accessibilityTraits = cellModel.parametersHidden ? [.button] : [.button, .selected]
-		headerStackView.accessibilityIdentifier = String(
-			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.headerStackView,
-			cellModel.accessibilityIdentifierIndex
-		)
 
 		setUpParameterViews()
 
@@ -71,20 +56,7 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 		visitDurationPicker.date = Date.dateWithMinutes(cellModel.locationVisitDuration) ?? Date()
 		notesTextField.text = cellModel.circumstances
 
-		accessibilityTraits = cellModel.accessibilityTraits
-
-		accessibilityIdentifier = String(
-			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.cellView,
-			cellModel.accessibilityIdentifierIndex
-		)
-		
-		accessibilityElements = [
-			headerStackView as Any,
-			durationLabel,
-			visitDurationPicker,
-			notesTextField,
-			notesInfoButton
-		]
+		setupAccessibility(cellModel)
 	}
 
 	// MARK: - Private
@@ -224,7 +196,42 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 
 		parametersStackView.addArrangedSubview(notesStackView)
 	}
-	
+
+	private func setupAccessibility(_ cellModel: DiaryDayEntryCellModel) {
+		accessibilityTraits = cellModel.accessibilityTraits
+		
+		accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.cellView,
+			cellModel.accessibilityIdentifierIndex
+		)
+		
+		checkboxImageView.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.checkboxImageView,
+			cellModel.accessibilityIdentifierIndex
+		)
+
+		label.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.label,
+			cellModel.accessibilityIdentifierIndex
+		)
+		
+		headerStackView.accessibilityLabel = cellModel.text
+		headerStackView.accessibilityTraits = cellModel.parametersHidden ? [.button] : [.button, .selected]
+		headerStackView.accessibilityIdentifier = String(
+			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.headerStackView,
+			cellModel.accessibilityIdentifierIndex
+		)
+		
+		// Give specific order
+		accessibilityElements = [
+			headerStackView as Any,
+			durationLabel,
+			visitDurationPicker,
+			notesTextField,
+			notesInfoButton
+		]
+	}
+
 	private func updateContactPersonEncounter() {
 		let circumstances = notesTextField.text ?? ""
 		guard cellModel.circumstances != circumstances else {

--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Day/Cells/DiaryDayEntryTableViewCell.swift
@@ -77,6 +77,15 @@ class DiaryDayEntryTableViewCell: UITableViewCell, UITextFieldDelegate {
 			format: AccessibilityIdentifiers.ContactDiaryInformation.Day.cellView,
 			cellModel.accessibilityIdentifierIndex
 		)
+		
+		accessibilityElements = [
+			headerStackView as Any,
+			durationLabel,
+//			visitDurationPickerWrapper, // Check wether accessibility identifier is still visible in appium ...
+			visitDurationPicker,
+			notesTextField,
+			notesInfoButton
+		]
 	}
 
 	// MARK: - Private

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -159,7 +159,6 @@ enum AccessibilityIdentifiers {
 			static let maskSituationSegmentedControl = "AppStrings.ContactDiaryInformation.maskSituationSegmentedControl"
 			static let settingSegmentedControl = "AppStrings.ContactDiaryInformation.settingSegmentedControl"
 			static let durationLabel = "AppStrings.ContactDiaryInformation.durationLabel"
-			static let visitDurationPickerWrapper = "AppStrings.ContactDiaryInformation.visitDurationPickerWrapper"
 			static let notesTextField = "AppStrings.ContactDiaryInformation.notesTextField"
 			static let notesInfoButton = "AppStrings.ContactDiaryInformation.notesInfoButton"
 		}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -158,6 +158,8 @@ enum AccessibilityIdentifiers {
 			static let durationSegmentedContol = "AppStrings.ContactDiaryInformation.durationSegmentedContol"
 			static let maskSituationSegmentedControl = "AppStrings.ContactDiaryInformation.maskSituationSegmentedControl"
 			static let settingSegmentedControl = "AppStrings.ContactDiaryInformation.settingSegmentedControl"
+			static let durationLabel = "AppStrings.ContactDiaryInformation.durationLabel"
+			static let visitDurationPickerWrapper = "AppStrings.ContactDiaryInformation.visitDurationPickerWrapper"
 			static let notesTextField = "AppStrings.ContactDiaryInformation.notesTextField"
 			static let notesInfoButton = "AppStrings.ContactDiaryInformation.notesInfoButton"
 		}

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -151,6 +151,7 @@ enum AccessibilityIdentifiers {
 		static let legal_1 = "AppStrings.ContactDiaryInformation.legalHeadline_1"
 		
 		enum Day {
+			static let cellView = "AppStrings.ContactDiaryInformation.cellView-%d"
 			static let headerStackView = "AppStrings.ContactDiaryInformation.headerStackView-%d"
 			static let checkboxImageView = "AppStrings.ContactDiaryInformation.checkboxImageView-%d"
 			static let label = "AppStrings.ContactDiaryInformation.label-%d"


### PR DESCRIPTION
## Description
Adds some accessibility identifiers in `DiaryDayEntryTableViewCell`, and also set accessibility elements order, to grab duration picker view by Appium (UI automation tests).

- Cell
- Duration Label

```swift

// Cell, %d = cell index
"AppStrings.ContactDiaryInformation.cellView-%d"

// Duration Label
"AppStrings.ContactDiaryInformation.durationLabel" 
```

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13799

## Screenshots

https://user-images.githubusercontent.com/22373291/186148209-80040e84-2be0-4495-a6a6-5724217a96db.mov


