### PR TITLE
Adjust info screen for release 2.27

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -1701,11 +1701,17 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "DeltaOnboarding_NewVersionFeatures_Button_Continue" = "Weiter";
 
-"DeltaOnboarding_NewVersionFeatures_Description" = "Mit diesem Update beheben wir Fehler in der App. Es enthält keine neuen Funktionen.";
+"DeltaOnboarding_NewVersionFeatures_Description" = "Mit diesem Update stellen wir Ihnen neben Fehlerbehebungen auch neue und erweiterte Funktionen zur Verfügung.";
 
 /* New Version Features */
 
 "NewVersionFeatures_Info_about_abb_information" = "Änderungen zum Release finden Sie in den App-Informationen unter dem Menüpunkt „Neue Funktionen”.";
+
+/* Version 2.27 */
+
+ "NewVersionFeature_227_wear_mask_title" = "Anzeige der Maskenbefreiung";
+
+ "NewVersionFeature_227_wear_mask_description" = "Auf Ihrem digitalen COVID-Zertifikat wird angezeigt, ob Sie nach den aktuell gültigen Regeln von der Maskenpflicht befreit sind, oder eine Maske tragen müssen.";
 
 /* Delta Onboarding */
 "DeltaOnboarding_AccessibilityImageLabel" = "Länderübergreifende Risiko-Ermittlung";

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeatures.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeatures.swift
@@ -7,7 +7,7 @@ import UIKit
 // WARNING: Do not rename class name because it is used to identify already presented onboardings. But if you need to, rename it and override the id property of the DeltaOnboarding Protocol and assign the origin id (see DeltaOnboardingProtocols)
 class DeltaOnboardingNewVersionFeatures: DeltaOnboarding {
 
-	let version = "2.26"
+	let version = "2.27"
 	let store: Store
 
 	init(store: Store) {

--- a/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Onboarding/DeltaOnboarding/NewVersionFeatures/DeltaOnboardingNewVersionFeaturesViewModel.swift
@@ -13,7 +13,12 @@ struct DeltaOnboardingNewVersionFeaturesViewModel {
 		
 		// ADD NEW FEATURES HERE
 		
-		self.featureVersion = "2.26"
+		self.featureVersion = "2.27"
+		
+		self.newVersionFeatures.append(
+			// wear mask
+			NewVersionFeature(title: AppStrings.NewVersionFeatures.feature227WearMaskTitle, description: AppStrings.NewVersionFeatures.feature227WearMaskDescription)
+		)
 	}
 
 	// MARK: - Internal

--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -1182,6 +1182,10 @@ enum AppStrings {
 		static let buttonContinue = NSLocalizedString("DeltaOnboarding_NewVersionFeatures_Button_Continue", comment: "")
 		static let generalDescription = NSLocalizedString("DeltaOnboarding_NewVersionFeatures_Description", comment: "")
 		static let aboutAppInformation = NSLocalizedString("NewVersionFeatures_Info_about_abb_information", comment: "")
+		
+		/* Version 2.27 */
+		static let feature227WearMaskTitle = NSLocalizedString("NewVersionFeature_227_wear_mask_title", comment: "")
+		static let feature227WearMaskDescription = NSLocalizedString("NewVersionFeature_227_wear_mask_description", comment: "")
 	}
 
 	enum DeltaOnboarding {


### PR DESCRIPTION
## Description
Adjust info screen for release 2.27

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13806

## Screenshots
![Simulator Screen Shot - Clone 1 of iPhone 13 - 2022-08-31 at 15 11 51](https://user-images.githubusercontent.com/77438487/187686682-7a0e92bb-64ec-47c1-9614-036fbd4873a1.png)
