### PR TITLE
Fix/9906 settings notifications screen graphic glitch

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/NotificationSettingsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/NotificationSettingsViewModel.swift
@@ -151,7 +151,6 @@ class NotificationSettingsViewModel {
 				.section(
 					background: .greyBoxed,
 					cells: [
-						.space(height: 5),
 						.icon(
 							UIImage(imageLiteralResourceName: "Icons_iOS_Mitteilungen"),
 							imageAlignment: .right,

--- a/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/__tests__/NotificationSettingsViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Settings/NotificationSettings/__tests__/NotificationSettingsViewModelTests.swift
@@ -46,7 +46,7 @@ class NotificationSettingsViewModelTests: CWATestCase {
 		XCTAssertEqual(numberOfSections, 3)
 		XCTAssertEqual(numberOfRowsInSection0, 1)
 		XCTAssertEqual(numberOfRowsInSection1, 2)
-		XCTAssertEqual(numberOfRowsInSection2, 5)
+		XCTAssertEqual(numberOfRowsInSection2, 4)
 	}
 	
 }


### PR DESCRIPTION
## Description
The ticket was reopened to fix the graphic issue. When the notification was on then view height was overlapping. Please see the comment into the ticket for more details of the issue.
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9906

## Screenshots
![IMG_637F87BD4B28-1](https://user-images.githubusercontent.com/72390277/189110593-d650f23e-c227-41ea-ad2a-894736b9c5ca.jpeg)
