### PR TITLE
fix/13920 false screen color when checking mask rules for recovery certificate

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -214,6 +214,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		Analytics.triggerAnalyticsSubmission()
 		appUpdateChecker.checkAppVersionDialog(for: window?.rootViewController)
 		healthCertificateService.updateValidityStatesAndNotifications(completion: { })
+		healthCertificateService.updateDCCWalletInfosIfNeeded()
 	}
 	
 	func applicationWillTerminate(_ application: UIApplication) {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -296,9 +296,19 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 	}
 	
 	var needsDCCWalletInfoUpdate: Bool {
-		let now = Date()
+		guard let dccWalletInfo else {
+			return true
+		}
 
-		return dccWalletInfo == nil || mostRecentWalletInfoUpdateFailed || (dccWalletInfo?.validUntil ?? now) < now
+		guard !mostRecentWalletInfoUpdateFailed else {
+			return true
+		}
+
+		guard let validUntil = dccWalletInfo.validUntil else {
+			return true // Should never happen
+		}
+
+		return validUntil < Date()
 	}
 	
 	func healthCertificate(for reference: DCCCertificateReference) -> HealthCertificate? {


### PR DESCRIPTION
## Description
Update DCCWalletInfo, when validIUntil date is prior than current device date.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13920

