### PR TITLE
Fix/13970: Certificates - mask symbol when you choose "Berlin" or "Keine Auswahl"

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/MaskState/MaskStateCellModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/MaskState/MaskStateCellModel.swift
@@ -27,11 +27,15 @@ class MaskStateCellModel {
 	}
 	
 	var badgeImage: UIImage? {
-		switch healthCertifiedPerson.dccWalletInfo?.maskState?.identifier {
+		guard let maskStateIdentifier = healthCertifiedPerson.dccWalletInfo?.maskState?.identifier else { return nil }
+		
+		switch maskStateIdentifier {
 		case .maskRequired:
 			return UIImage(named: "Badge_mask")
-		default:
+		case .maskOptional:
 			return UIImage(named: "Badge_nomask")
+		case .other:
+			return nil
 		}
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/MaskStateCellModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/__tests__/MaskStateCellModelTests.swift
@@ -105,5 +105,47 @@ class MaskStateCellModelTests: XCTestCase {
 	
 		XCTAssertEqual(badgeImageExpected, badgeImageToTest)
 	}
+	
+	func testMaskStateFromWalletInfo_Other() throws {
+		
+		// GIVEN
+		
+		let healthCertifiedPerson = HealthCertifiedPerson(healthCertificates: [])
+		
+		let titleMock = "Maskenpflicht"
+		let subtitleMock = "keine Auswahl"
+		let longTextMock = "Ohne Auswahl eines Bundeslandes kann Ihnen nicht angezeigt werden, ob Sie von einer bundeslandspezifischen Maskenpflicht ausgenommen sind."
+		let faqAnchorMock = "maskstate"
+		
+		healthCertifiedPerson.dccWalletInfo = .fake(
+			maskState: .fake(
+				visible: true,
+				badgeText: .fake(string: "Ein-Badge-Text"),
+				titleText: .fake(string: titleMock),
+				subtitleText: .fake(string: subtitleMock),
+				longText: .fake(string: longTextMock),
+				faqAnchor: faqAnchorMock,
+				identifier: .other
+			)
+		)
+		
+		let fakeCCLService = FakeCCLService()
+		
+		// WHEN
+		
+		let sut = MaskStateCellModel(
+			healthCertifiedPerson: healthCertifiedPerson,
+			cclService: fakeCCLService
+		)
+		
+		// THEN
+		
+		XCTAssertEqual(sut.title, titleMock)
+		XCTAssertEqual(sut.subtitle, subtitleMock)
+		XCTAssertEqual(sut.description, longTextMock)
+		XCTAssertEqual(sut.faqLink?.string, AppStrings.HealthCertificate.Person.faqMaskState)
+		
+		XCTAssertNil(sut.badgeImage)
+	}
 
 }


### PR DESCRIPTION
## Description
Certificate Detail: show no badge icon, when mask status identifier is `other`.

## Link to Jira
[<!-- Please add the link to the related Jira issue -->](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13970)

## Screenshots
<img width="66%" alt="Screen Shot 2022-09-21 at 16 42 41" src="https://user-images.githubusercontent.com/22373291/191535471-1669e357-4ee2-4778-b54f-7208d277dee2.png">

