### PR TITLE
Fix/13907: Mask Badge in Person Overview should be aligned with Toggle

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/PreferredPerson/PreferredPersonTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertifiedPerson/Cells/PreferredPerson/PreferredPersonTableViewCell.swift
@@ -108,6 +108,7 @@ class PreferredPersonTableViewCell: UITableViewCell, ReuseIdentifierProviding {
 		preferredPersonSwitch.setContentHuggingPriority(.required, for: .horizontal)
 		preferredPersonSwitch.addTarget(self, action: #selector(didTogglePreferredPersonSwitch(sender:)), for: .valueChanged)
 		topContentStackView.addArrangedSubview(preferredPersonSwitch)
+		preferredPersonSwitch.transform = CGAffineTransform(translationX: -2, y: 0)
 
 		descriptionLabel.numberOfLines = 0
 		contentStackView.addArrangedSubview(descriptionLabel)


### PR DESCRIPTION
## Description
Show mask status badge, admission status badge and preferred person switch toggle right aligned equally.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13907

## Screenshots
<img width="722" alt="13907" src="https://user-images.githubusercontent.com/22373291/192547130-b3519323-567d-4761-8597-2afaece62170.png">

