### PR TITLE
Fix/13781: Infinite zoom out when previewing certificates using "Export all certificates"

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/PdfGeneration/HealthCertificatePDFVersionViewController.swift
@@ -31,14 +31,8 @@ class HealthCertificatePDFVersionViewController: DynamicTableViewController, UIA
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
-		// Avoid assertion when init with non-zero scale.
-		let pdfView = PDFView(frame: .init(x: 0, y: 0, width: 1, height: 1))
 
 		pdfView.document = viewModel.pdfDocument
-		pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
-		pdfView.autoScales = true
-
 		view = pdfView
 		view.backgroundColor = .enaColor(for: .background)
 		
@@ -60,6 +54,9 @@ class HealthCertificatePDFVersionViewController: DynamicTableViewController, UIA
 		if let dismissHandlingNC = navigationController as? DismissHandlingNavigationController {
 			dismissHandlingNC.restoreOriginalNavigationBar()
 		}
+		
+		pdfView.minScaleFactor = pdfView.scaleFactorForSizeToFit
+		pdfView.scaleFactor = pdfView.scaleFactorForSizeToFit
 	}
 	
 	override func viewWillDisappear(_ animated: Bool) {
@@ -97,6 +94,12 @@ class HealthCertificatePDFVersionViewController: DynamicTableViewController, UIA
 
 	// MARK: - Private
 
+	private let pdfView: PDFView = {
+		let pdfView = PDFView()
+		pdfView.autoScales = true
+		pdfView.maxScaleFactor = 3.0
+		return pdfView
+	}()
 	private let viewModel: HealthCertificatePDFVersionViewModel
 	private let onTapPrintPdf: (Data) -> Void
 	private let onTapExportPdf: (PDFExportItem) -> Void


### PR DESCRIPTION
## Description
Prevent the user to infinite zoom out PDF pages (Export all certificates)

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13781

## Screenshots
<img width="66%" alt="Screen Shot 2022-09-27 at 17 24 46" src="https://user-images.githubusercontent.com/22373291/192568357-d262b7fa-7257-43f4-bb6c-a84fca9dc250.png">

