### PR TITLE
Fix/13990 QR Codes processed without opening QR Code Scanner

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/QRScanner/QRScannerViewController.swift
@@ -83,7 +83,7 @@ class QRScannerViewController: UIViewController {
 	}
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		viewModel?.activateScanning()
+		activateScanning()
 	}
 
 	override func viewWillDisappear(_ animated: Bool) {
@@ -95,7 +95,14 @@ class QRScannerViewController: UIViewController {
 	// MARK: - Internal
 
 	func activateScanning() {
-		viewModel?.activateScanning()
+		// This extra check of the visible view controller is for Testing purposes only
+		if let viewControllers = navigationController?.viewControllers {
+			for viewController in viewControllers {
+				if viewController.isKind(of: HomeTableViewController.self) {
+					viewModel?.activateScanning()
+				}
+			}
+		}
 	}
 
 	func deactivateScanning() {
@@ -303,12 +310,18 @@ class QRScannerViewController: UIViewController {
 			previewLayer = AVCaptureVideoPreviewLayer()
 			return
 		}
-		viewModel?.startCaptureSession()
-		
-		previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
-		previewLayer.frame = view.layer.bounds
-		previewLayer.videoGravity = .resizeAspectFill
-		view.layer.insertSublayer(previewLayer, at: 0)
+		// This extra check of the visible view controller is for Testing purposes only
+		if let viewControllers = navigationController?.viewControllers {
+			for viewController in viewControllers {
+				if viewController.isKind(of: HomeTableViewController.self) {
+					viewModel?.startCaptureSession()
+					previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+					previewLayer.frame = view.layer.bounds
+					previewLayer.videoGravity = .resizeAspectFill
+					view.layer.insertSublayer(previewLayer, at: 0)
+				}
+			}
+		}
 	}
 
 	private func updatePreviewMask() {


### PR DESCRIPTION
## Description
During the test automation on the MDC we experienced a issue which cannot happen on real devices. But blocks the test automation

In the test automation we simulate qr code scans by uploading a qr-code image as camera image. This change of the camera image triggers the qr code processing of the CWA iOS App. This means in every screen on the app it can happens that the app tries to process qr-codes in the background.

This leads to multiple issue during testing because already scanned qr-code are scanned again or invalid qr code error during the image upload because the app tries to recognized a partial upload as qr-code

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13990

