### PR TITLE
Update the white risk card check to exclude bluetooth state

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/ExposureManager.swift
@@ -64,7 +64,7 @@ struct ExposureManagerState: Equatable {
 	private(set) var authorized: Bool
 	private(set) var enabled: Bool
 	private(set) var status: ENStatus
-	var isGood: Bool { authorized && enabled && status == .active }
+	var isGood: Bool { authorized && enabled && (status == .active || status == .bluetoothOff) }
 }
 
 @objc protocol Manager: NSObjectProtocol {


### PR DESCRIPTION
## Description
when bluetooth is turned off we show the white risk card which is not the expected behavior

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8322

## Screenshots
https://user-images.githubusercontent.com/15270737/193299240-f0cd7c7e-e1e8-49d3-aa08-b068f11daffe.MP4


