### PR TITLE
Fix/9746 missing swipe down on trace locations infoViewController

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Info/TraceLocationsInfoViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Info/TraceLocationsInfoViewController.swift
@@ -34,9 +34,6 @@ class TraceLocationsInfoViewController: DynamicTableViewController, FooterViewHa
 				self?.onDismiss(false)
 			})
 		}
-		if #available(iOS 13.0, *) {
-			parent?.isModalInPresentation = true
-		}
 		navigationItem.title = AppStrings.TraceLocations.Information.title
 		navigationController?.navigationBar.prefersLargeTitles = true
 	}


### PR DESCRIPTION
## Description
When create the event and open the information view then user can't dismiss the view on swipe down.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9746

## Screenshots
https://user-images.githubusercontent.com/72390277/193810740-8f90a21a-c47a-4e53-8545-71559ec7507b.MP4
