### PR TITLE
Fix/14123: Pandemic Radar Tile: Info Button Accessibility Identifier

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeLinkCardView/HomeLinkCardView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeLinkCardView/HomeLinkCardView.swift
@@ -13,7 +13,6 @@ class HomeLinkCardView: UIView {
 		super.awakeFromNib()
 		
 		setupLayout()
-		setupAccessibility()
 	}
 	
 	override var accessibilityElements: [Any]? {
@@ -21,29 +20,23 @@ class HomeLinkCardView: UIView {
 			var accessibilityElements = [Any?]()
 			
 			if viewModel?.title != nil {
-				titleLabel.accessibilityTraits = .header
 				accessibilityElements.append(titleLabel)
 			}
 			
 			if viewModel?.subtitle != nil {
-				titleLabel.accessibilityTraits = .staticText
 				accessibilityElements.append(subtitleLabel)
 			}
 			
-			infoButton.accessibilityTraits = .button
 			accessibilityElements.append(infoButton)
 			
 			if viewModel?.description != nil {
-				descriptionLabel.accessibilityTraits = .staticText
 				accessibilityElements.append(descriptionLabel)
 			}
 			
 			if viewModel?.buttonTitle != nil {
-				button.accessibilityTraits = .button
 				accessibilityElements.append(button)
 			}
 			
-			deleteButton.accessibilityTraits = .button
 			accessibilityElements.append(deleteButton)
 			
 			return accessibilityElements as [Any]
@@ -99,6 +92,8 @@ class HomeLinkCardView: UIView {
 		self.onInfoButtonTap = onInfoButtonTap
 		self.onDeleteButtonTap = onDeleteButtonTap
 		self.onButtonTap = onButtonTap
+		
+		setupAccessibility()
 	}
 	
 	func set(editMode enabled: Bool, animated: Bool) {


### PR DESCRIPTION
## Description
Fix a tiny bug for the accessibility identifiers setup, regarding Info-Button:

**ID**
`AppStrings.LinkCard.PandemicRadar.infoButton`

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14123

## Screenshots

<img width="695" alt="Screen Shot 2022-10-12 at 11 31 58" src="https://user-images.githubusercontent.com/22373291/195306723-484cbdef-18c8-4ea3-bd5b-902ba13cbcd2.png">
