### PR TITLE
Fix/11123 TraceLocationCheckinViewController description hyphenation

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewController.swift
@@ -96,6 +96,11 @@ class TraceLocationCheckinViewController: UIViewController, DismissHandling {
 				self.checkOutView.accessibilityLabel = "\(AppStrings.Checkins.Details.automaticCheckout)\(self.viewModel.pickerButtonAccessibilityLabel)"
 			}
 			.store(in: &subscriptions)
+		
+		viewModel.$locationDescription
+			.receive(on: DispatchQueue.main.ocombine)
+			.assign(to: \.attributedText, on: descriptionLabel)
+			.store(in: &subscriptions)
 	}
 	
 	private func setupNavigationBar() {
@@ -172,7 +177,7 @@ class TraceLocationCheckinViewController: UIViewController, DismissHandling {
 		switchView.accessibilityLabel = "\(AppStrings.Checkins.Details.saveToDiary) \(AppStrings.Checkins.Details.saveSwitch) \(pickerSwitch.isOn ? AppStrings.Checkins.Details.saveSwitchOn : AppStrings.Checkins.Details.saveSwitchOff)"
 
 		activityLabel.text = viewModel.locationType
-		descriptionLabel.text = viewModel.locationDescription
+//		descriptionLabel.attributedText = viewModel.locationDescription
 		addressLabel.text = viewModel.locationAddress
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewController.swift
@@ -177,7 +177,6 @@ class TraceLocationCheckinViewController: UIViewController, DismissHandling {
 		switchView.accessibilityLabel = "\(AppStrings.Checkins.Details.saveToDiary) \(AppStrings.Checkins.Details.saveSwitch) \(pickerSwitch.isOn ? AppStrings.Checkins.Details.saveSwitchOn : AppStrings.Checkins.Details.saveSwitchOff)"
 
 		activityLabel.text = viewModel.locationType
-//		descriptionLabel.attributedText = viewModel.locationDescription
 		addressLabel.text = viewModel.locationAddress
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/TraceLocationCheckinViewModel.swift
@@ -23,10 +23,10 @@ final class TraceLocationCheckinViewModel {
 		#endif
 		self.locationType = traceLocation.type.title
 		self.locationAddress = traceLocation.address
-		self.locationDescription = traceLocation.description
 		self.shouldSaveToContactJournal = store.shouldAddCheckinToContactDiaryByDefault
 
 		self.duration = TimeInterval(traceLocation.suggestedCheckoutLengthInMinutes * 60)
+		setTraceLocation(description: traceLocation.description)
 	}
 	
 	// MARK: - Internal
@@ -38,7 +38,7 @@ final class TraceLocationCheckinViewModel {
 	}
 
 	let locationType: String
-	let locationDescription: String
+	@OpenCombine.Published var locationDescription: NSAttributedString?
 	let locationAddress: String
 
 	var shouldSaveToContactJournal: Bool
@@ -135,5 +135,19 @@ final class TraceLocationCheckinViewModel {
 		formatter.zeroFormattingBehavior = .pad
 		return formatter
 	}()
+	
+	private func setTraceLocation(description: String) {
+		let paragraphStyle = NSMutableParagraphStyle()
+		paragraphStyle.hyphenationFactor = 0.8
+
+		let attributedString = NSAttributedString(
+			string: description,
+			attributes: [
+				.paragraphStyle: paragraphStyle
+			]
+		)
+
+		locationDescription = attributedString
+	}
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/__tests__/TraceLocationCheckinViewModelTests.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/TraceLocationCheckin/__tests__/TraceLocationCheckinViewModelTests.swift
@@ -32,7 +32,7 @@ class TraceLocationCheckinViewModelTests: CWATestCase {
 		let sut = TraceLocationCheckinViewModel(traceLocation, eventStore: MockEventStore(), store: store)
 		
 		XCTAssertEqual(sut.locationType, TraceLocationType.locationTypePermanentFoodService.title)
-		XCTAssertEqual(sut.locationDescription, "Los Pollos Hermanos")
+		XCTAssertEqual(sut.locationDescription?.string, "Los Pollos Hermanos")
 		XCTAssertEqual(sut.locationAddress, "13 Main Street, Albuquerque")
 		// Duration should be rounded up to 30
 		XCTAssertEqual(sut.duration, 30 * 60)
@@ -66,7 +66,7 @@ class TraceLocationCheckinViewModelTests: CWATestCase {
 		let sut = TraceLocationCheckinViewModel(traceLocation, eventStore: MockEventStore(), store: store)
 		
 		XCTAssertEqual(sut.locationType, TraceLocationType.locationTypePermanentFoodService.title)
-		XCTAssertEqual(sut.locationDescription, "Los Pollos Hermanos")
+		XCTAssertEqual(sut.locationDescription?.string, "Los Pollos Hermanos")
 		XCTAssertEqual(sut.locationAddress, "13 Main Street, Albuquerque")
 		// max checkout Duration should be clipped to 23:45 to match the picker
 		XCTAssertEqual(sut.duration, ((23 * 60) + 45) * 60)


### PR DESCRIPTION
## Description
Improves a displaying issue with very large location description string in `TraceLocationCheckinViewController`.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11123

## Screenshots
<img width="33%" src="https://user-images.githubusercontent.com/22373291/196099464-d1cdc695-8899-461f-99c4-76e0d234e9af.png" /> 

<img width="33%" src="https://user-images.githubusercontent.com/22373291/196099473-14a1de7c-c9de-4aa1-829b-4ac6da1c339e.png" /> 


