### PR TITLE
Fix/14020 Add accessibility id for Checkin Texts Labels

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/DynamicTableViewCell.swift
@@ -170,7 +170,9 @@ extension DynamicCell {
 		selectionStyle: UITableViewCell.SelectionStyle = .none,
 		action: DynamicAction = .none,
 		configure: CellConfigurator? = nil,
-		alignment: UIStackView.Alignment = .center
+		alignment: UIStackView.Alignment = .center,
+		imageAccessibilityIdentifier: String? = nil,
+		textAccessibilityIdentifier: String? = nil
 	) -> Self {
 		.identifier(
 			CellReuseIdentifier.icon,
@@ -188,7 +190,9 @@ extension DynamicCell {
 					style: style,
 					iconWidth: iconWidth,
 					selectionStyle: selectionStyle,
-					alignment: alignment
+					alignment: alignment,
+					imageAccessibilityIdentifier: imageAccessibilityIdentifier,
+					textAccessibilityIdentifier: textAccessibilityIdentifier
 				)
 				configure?(viewController, cell, indexPath)
 			}

--- a/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewIconCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/DynamicTableViewController/Views/DynamicTableViewIconCell.swift
@@ -70,7 +70,9 @@ class DynamicTableViewIconCell: UITableViewCell {
 		style: ENAFont,
 		iconWidth: CGFloat,
 		selectionStyle: UITableViewCell.SelectionStyle,
-		alignment: UIStackView.Alignment
+		alignment: UIStackView.Alignment,
+		imageAccessibilityIdentifier: String? = nil,
+		textAccessibilityIdentifier: String? = nil
 	) {
 		stackView.alignment = alignment
 
@@ -101,6 +103,11 @@ class DynamicTableViewIconCell: UITableViewCell {
 		}
 		
 		self.selectionStyle = selectionStyle
+		
+		configureAccessibility(
+			imageAccessibilityIdentifier: imageAccessibilityIdentifier,
+			textAccessibilityIdentifier: textAccessibilityIdentifier
+		)
 	}
 
 	// MARK: - Private
@@ -110,4 +117,19 @@ class DynamicTableViewIconCell: UITableViewCell {
 	private var iconImageView = UIImageView()
 	private var contentTextLabel = ENALabel()
 
+	private func configureAccessibility(
+		imageAccessibilityIdentifier: String? = nil,
+		textAccessibilityIdentifier: String? = nil
+	) {
+		iconImageView.accessibilityTraits = .image
+		iconImageView.accessibilityIdentifier = imageAccessibilityIdentifier
+
+		contentTextLabel.accessibilityTraits = .staticText
+		contentTextLabel.accessibilityIdentifier = textAccessibilityIdentifier
+		
+		accessibilityElements = [
+			iconImageView,
+			contentTextLabel
+		]
+	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Cells/EventTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Cells/EventTableViewCell.swift
@@ -103,12 +103,14 @@ class EventTableViewCell: UITableViewCell, ReuseIdentifierProviding {
 
 		titleLabel.text = cellModel.title
 		titleLabel.accessibilityLabel = cellModel.titleAccessibilityLabelPublisher.value
+		titleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Overview.eventTableViewCellTitleLabel
 		cellModel.titleAccessibilityLabelPublisher
 			.receive(on: DispatchQueue.main.ocombine)
 			.assign(to: \.accessibilityLabel, on: titleLabel)
 			.store(in: &subscriptions)
 		
 		addressLabel.text = cellModel.address
+		addressLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Overview.eventTableViewCellAddressLabel
 
 		button.setTitle(cellModel.buttonTitle, for: .normal)
 		button.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.eventTableViewCellButton

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Configuration/TraceLocationConfigurationViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Configuration/TraceLocationConfigurationViewController.swift
@@ -37,6 +37,7 @@ class TraceLocationConfigurationViewController: UIViewController, FooterViewHand
 		setUpLayout()
 		setUpGestureRecognizers()
 		setUpBindings()
+		setupAccessibility()
 
 		temporaryDefaultLengthPicker.countDownDuration = TimeInterval(minutes: viewModel.defaultCheckInLengthInMinutes) ?? viewModel.defaultTemporaryCheckInLengthTimeInterval
 		permanentDefaultLengthPicker.countDownDuration = TimeInterval(minutes: viewModel.defaultCheckInLengthInMinutes) ?? viewModel.defaultPermanentCheckInLengthTimeInterval
@@ -46,23 +47,17 @@ class TraceLocationConfigurationViewController: UIViewController, FooterViewHand
 		permanentSettingsContainerView.isHidden = viewModel.permanentSettingsContainerIsHidden
 
 		descriptionTextField.placeholder = AppStrings.TraceLocations.Configuration.descriptionPlaceholder
-		descriptionTextField.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.descriptionPlaceholder
 		descriptionTextField.autocapitalizationType = .sentences
 		addressTextField.placeholder = AppStrings.TraceLocations.Configuration.addressPlaceholder
-		addressTextField.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.addressPlaceholder
 		addressTextField.autocapitalizationType = .sentences
 
 		startDateTitleLabel.text = AppStrings.TraceLocations.Configuration.startDateTitle
 		endDateTitleLabel.text = AppStrings.TraceLocations.Configuration.endDateTitle
 
 		temporaryDefaultLengthTitleLabel.text = AppStrings.TraceLocations.Configuration.defaultCheckinLengthTitle
-		temporaryDefaultLengthTitleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.temporaryDefaultLengthTitleLabel
 		temporaryDefaultLengthFootnoteLabel.text = AppStrings.TraceLocations.Configuration.defaultCheckinLengthFootnote
-		temporaryDefaultLengthFootnoteLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.temporaryDefaultLengthFootnoteLabel
 		permanentDefaultLengthTitleLabel.text = AppStrings.TraceLocations.Configuration.defaultCheckinLengthTitle
-		permanentDefaultLengthTitleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.permanentDefaultLengthTitleLabel
 		permanentDefaultLengthFootnoteLabel.text = AppStrings.TraceLocations.Configuration.defaultCheckinLengthFootnote
-		permanentDefaultLengthFootnoteLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.permanentDefaultLengthFootnoteLabel
 
 	}
 
@@ -385,6 +380,18 @@ class TraceLocationConfigurationViewController: UIViewController, FooterViewHand
 				self?.footerView?.setEnabled($0, button: .primary)
 			}
 			.store(in: &subscriptions)
+	}
+	
+	private func setupAccessibility() {
+		traceLocationTypeLabel.accessibilityTraits = .header
+		traceLocationTypeLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.traceLocationTypeLabel
+		descriptionTextField.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.descriptionPlaceholder
+		addressTextField.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.addressPlaceholder
+		temporaryDefaultLengthTitleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.temporaryDefaultLengthTitleLabel
+		temporaryDefaultLengthFootnoteLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.temporaryDefaultLengthFootnoteLabel
+		permanentDefaultLengthTitleLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.permanentDefaultLengthTitleLabel
+		permanentDefaultLengthValueLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.permanentDefaultLengthValueLabel
+		permanentDefaultLengthFootnoteLabel.accessibilityIdentifier = AccessibilityIdentifiers.TraceLocation.Configuration.permanentDefaultLengthFootnoteLabel
 	}
 
 	private func showError(_ error: Error) {

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Info/TraceLocationsInfoViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Info/TraceLocationsInfoViewModel.swift
@@ -47,7 +47,9 @@ struct TraceLocationsInfoViewModel {
 					.icon(
 						UIImage(imageLiteralResourceName: "Icons_CheckInRiskStatus"),
 						text: .string(AppStrings.TraceLocations.Information.itemCheckinRiskStatus),
-						alignment: .top
+						alignment: .top,
+						imageAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletIconCheckinRiskStatus,
+						textAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletTextCheckinRiskStatus
 					),
 					.space(
 						height: 15.0,
@@ -56,7 +58,9 @@ struct TraceLocationsInfoViewModel {
 					.icon(
 						UIImage(imageLiteralResourceName: "Icons_Checkin_QR"),
 						text: .string(AppStrings.TraceLocations.Information.itemCheckinTitle),
-						alignment: .top
+						alignment: .top,
+						imageAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletIconCheckinQR,
+						textAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletTextCheckinQR
 					),
 					.space(
 						height: 15.0,
@@ -65,7 +69,9 @@ struct TraceLocationsInfoViewModel {
 					.icon(
 						UIImage(imageLiteralResourceName: "Icons_Diary_Deleted_Automatically"),
 						text: .string(AppStrings.TraceLocations.Information.itemContactTitle),
-						alignment: .top
+						alignment: .top,
+						imageAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletIconDiaryDeletedAutomatically,
+						textAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletTextDiaryDeletedAutomatically
 					),
 					.space(
 						height: 15.0,
@@ -74,7 +80,9 @@ struct TraceLocationsInfoViewModel {
 					.icon(
 						UIImage(imageLiteralResourceName: "Icons_Group"),
 						text: .string(AppStrings.TraceLocations.Information.itemGroupTitle),
-						alignment: .top
+						alignment: .top,
+						imageAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletIconGroup,
+						textAccessibilityIdentifier: AccessibilityIdentifiers.TraceLocation.infoBulletTextGroup
 					),
 					.space(
 						height: 15.0,

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewEmptyStateViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/Overview/TraceLocationsOverviewEmptyStateViewModel.swift
@@ -12,6 +12,8 @@ struct TraceLocationsOverviewEmptyStateViewModel: EmptyStateViewModel {
 	let title = AppStrings.TraceLocations.Overview.emptyTitle
 	let description = AppStrings.TraceLocations.Overview.emptyDescription
 	let imageDescription = AppStrings.TraceLocations.Overview.emptyImageDescription
-	let imageAccessibilityIdentifier: String? = AccessibilityIdentifiers.TraceLocation.Overview.emptyState
+	let imageAccessibilityIdentifier: String? = AccessibilityIdentifiers.TraceLocation.Overview.emptyStateImage
+	let titleAccessibilityIdentifier: String? = AccessibilityIdentifiers.TraceLocation.Overview.emptyStateTitle
+	let descriptionAccessibilityIdentifier: String? = AccessibilityIdentifiers.TraceLocation.Overview.emptyStateDescription
 
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/Header/SelectTraceLocationTypeHeaderView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/Header/SelectTraceLocationTypeHeaderView.swift
@@ -20,8 +20,9 @@ class SelectTraceLocationTypeHeaderView: UITableViewHeaderFooterView, ReuseIdent
 
 	// MARK: - Internal
 
-	func configure(_ model: String) {
+	func configure(_ model: String, accessibilityIdentifier: String? = nil) {
 		titleLabel.text = model
+		setupAccessibility(accessibilityIdentifier: accessibilityIdentifier)
 	}
 
 	// MARK: - Private
@@ -35,7 +36,6 @@ class SelectTraceLocationTypeHeaderView: UITableViewHeaderFooterView, ReuseIdent
 		contentView.addSubview(titleLabel)
 		titleLabel.font = .enaFont(for: .footnote)
 		titleLabel.textColor = .enaColor(for: .textSemanticGray)
-		titleLabel.accessibilityTraits = .header
 
 		let separatorView = UIView()
 		separatorView.translatesAutoresizingMaskIntoConstraints = false
@@ -52,5 +52,10 @@ class SelectTraceLocationTypeHeaderView: UITableViewHeaderFooterView, ReuseIdent
 			separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
 			separatorView.heightAnchor.constraint(equalToConstant: 1.0)
 		])
+	}
+	
+	private func setupAccessibility(accessibilityIdentifier: String? = nil) {
+		titleLabel.accessibilityTraits = .header
+		titleLabel.accessibilityIdentifier = accessibilityIdentifier
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/TraceLocationTypeSelectionViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/TraceLocationTypeSelectionViewController.swift
@@ -55,7 +55,10 @@ class TraceLocationTypeSelectionViewController: UITableViewController {
 			Log.debug("Failed to dequeue SelectTraceLocationTypeHeaderView")
 			return nil
 		}
-		headerView.configure(viewModel.sectionTitle(for: section))
+		headerView.configure(
+			viewModel.sectionTitle(for: section),
+			accessibilityIdentifier: viewModel.sectionHeaderAccessibilityIdentifier(for: section)
+		)
 		return headerView
 	}
 

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/TraceLocationTypeSelectionViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/TraceLocations/TypeSelection/TraceLocationTypeSelectionViewModel.swift
@@ -47,6 +47,10 @@ struct TraceLocationTypeSelectionViewModel {
 	func sectionTitle(for index: Int) -> String {
 		TraceLocationSection.allCases[index].title
 	}
+	
+	func sectionHeaderAccessibilityIdentifier(for index: Int) -> String {
+		String(format: AccessibilityIdentifiers.TraceLocations.sectionHeader, TraceLocationSection.allCases[index].rawValue)
+	}
 
 	func cellViewModel(at indexPath: IndexPath) -> TraceLocationType {
 		guard let traceLocationSection = TraceLocationSection(rawValue: indexPath.section),

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -767,12 +767,21 @@ enum AccessibilityIdentifiers {
 		static let temporaryClubActivity = "AppStrings.TraceLocations.temporary.title.clubActivity"
 		static let temporaryPrivateEvent = "AppStrings.TraceLocations.temporary.title.privateEvent"
 		static let temporaryWorshipService = "AppStrings.TraceLocations.temporary.title.worshipService"
+		static let sectionHeader = "AppStrings.TraceLocations.sectionHeader-%d"
 	}
 	
 	enum TraceLocation {
 		static let imageDescription = "AppStrings.TraceLocations.imageDescription"
 		static let descriptionTitle = "AppStrings.TraceLocations.descriptionTitle"
 		static let descriptionSubHeadline = "AppStrings.TraceLocations.descriptionSubHeadline"
+		static let infoBulletIconCheckinRiskStatus = "AppStrings.TraceLocations.InfoBullet.Icon.itemCheckinRiskStatus"
+		static let infoBulletTextCheckinRiskStatus = "AppStrings.TraceLocations.InfoBullet.Text.itemCheckinRiskStatus"
+		static let infoBulletIconCheckinQR = "AppStrings.TraceLocations.InfoBullet.Icon.checkinQR"
+		static let infoBulletTextCheckinQR = "AppStrings.TraceLocations.InfoBullet.Text.checkinQR"
+		static let infoBulletIconDiaryDeletedAutomatically = "AppStrings.TraceLocations.InfoBullet.Icon.diaryDeletedAutomatically"
+		static let infoBulletTextDiaryDeletedAutomatically = "AppStrings.TraceLocations.InfoBullet.Text.diaryDeletedAutomatically"
+		static let infoBulletIconGroup = "AppStrings.TraceLocations.InfoBullet.Icon.Group"
+		static let infoBulletTextGroup = "AppStrings.TraceLocations.InfoBullet.Text.Group"
 		static let dataPrivacyTitle = "AppStrings.TraceLocations.dataPrivacyTitle"
 		static let acknowledgementTitle = "TraceLocation.acknowledgementTitle"
 		static let legal_1 = "AppStrings.TraceLocations.legalHeadline_1"
@@ -789,7 +798,11 @@ enum AccessibilityIdentifiers {
 			static let tableView = "TableView.TracelocationOverview"
 			static let menueButton = "AppStrings.TraceLocations.Overview.menueButton"
 			static let addButton = "AppStrings.TraceLocations.Overview.addButton"
-			static let emptyState = "AppStrings.TraceLocations.Overview.emptyState"
+			static let emptyStateImage = "AppStrings.TraceLocations.Overview.emptyStateImage"
+			static let emptyStateTitle = "AppStrings.TraceLocations.Overview.emptyStateTitle"
+			static let emptyStateDescription = "AppStrings.TraceLocations.Overview.emptyStateDescription"
+			static let eventTableViewCellTitleLabel = "AppStrings.TraceLocations.Overview.eventTableViewCell.titleLabel"
+			static let eventTableViewCellAddressLabel = "AppStrings.TraceLocations.Overview.eventTableViewCell.addressLabel"
 			
 			enum MenuActionSheet {
 				static let infoAction = "AppStrings.TraceLocations.Overview.MenuActionSheet.infoAction"
@@ -799,11 +812,13 @@ enum AccessibilityIdentifiers {
 		}
 		
 		enum Configuration {
+			static let traceLocationTypeLabel = "AppStrings.TraceLocations.Configuration.traceLocationTypeLabel"
 			static let descriptionPlaceholder = "AppStrings.TraceLocations.Configuration.descriptionPlaceholder"
 			static let addressPlaceholder = "AppStrings.TraceLocations.Configuration.addressPlaceholder"
 			static let temporaryDefaultLengthTitleLabel = "AppStrings.TraceLocations.Configuration.temporaryDefaultLengthTitleLabel"
 			static let temporaryDefaultLengthFootnoteLabel = "AppStrings.TraceLocations.Configuration.temporaryDefaultLengthFootnoteLabel"
 			static let permanentDefaultLengthTitleLabel = "AppStrings.TraceLocations.Configuration.permanentDefaultLengthTitleLabel"
+			static let permanentDefaultLengthValueLabel = "AppStrings.TraceLocations.Configuration.permanentDefaultLengthValueLabel"
 			static let permanentDefaultLengthFootnoteLabel = "AppStrings.TraceLocations.Configuration.permanentDefaultLengthFootnoteLabel"
 			static let eventTableViewCellButton = "AppStrings.TraceLocations.Configuration.eventTableViewCellButton"
 		}

--- a/src/xcode/ENA/ENA/Source/Views/AddButtonAsTableViewCell/AddButtonAsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Views/AddButtonAsTableViewCell/AddButtonAsTableViewCell.swift
@@ -39,8 +39,8 @@ class AddButtonAsTableViewCell: UITableViewCell, ReuseIdentifierProviding {
 
 	func configure(cellModel: AddButtonAsTableViewCelling) {
 		label.text = cellModel.text
-		label.accessibilityIdentifier = cellModel.accessibilityIdentifier
-		
+
+		containerView.accessibilityIdentifier = cellModel.accessibilityIdentifier
 		containerView.accessibilityLabel = cellModel.text
 		
 		cellModel.iconImagePublisher

--- a/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
+++ b/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateView.swift
@@ -64,6 +64,8 @@ class EmptyStateView: UIView {
 		titleLabel.adjustsFontSizeToFitWidth = true
 		titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 		titleLabel.text = viewModel.title
+		titleLabel.accessibilityTraits = .staticText
+		titleLabel.accessibilityIdentifier = viewModel.titleAccessibilityIdentifier
 		stackView.addArrangedSubview(titleLabel)
 
 		let descriptionLabel = ENALabel()
@@ -74,6 +76,8 @@ class EmptyStateView: UIView {
 		descriptionLabel.adjustsFontSizeToFitWidth = true
 		descriptionLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 		descriptionLabel.text = viewModel.description
+		descriptionLabel.accessibilityTraits = .staticText
+		descriptionLabel.accessibilityIdentifier = viewModel.descriptionAccessibilityIdentifier
 		stackView.addArrangedSubview(descriptionLabel)
 
 		// We take a number for that the image is not too big and not too small and fits for big and small devices for all five occurrences of the EmptyStateView

--- a/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Views/EmptyStateView/EmptyStateViewModel.swift
@@ -9,7 +9,14 @@ protocol EmptyStateViewModel {
 	var image: UIImage? { get }
 	var imageAccessibilityIdentifier: String? { get }
 	var title: String { get }
+	var titleAccessibilityIdentifier: String? { get }
 	var description: String { get }
+	var descriptionAccessibilityIdentifier: String? { get }
 	var imageDescription: String { get }
 
+}
+
+extension EmptyStateViewModel {
+	var titleAccessibilityIdentifier: String? { nil }
+	var descriptionAccessibilityIdentifier: String? { nil }
 }


### PR DESCRIPTION
## Description
Adds accessibility id for Checkin Texts Labels.

**TraceLocationsInfoViewController**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| keine, Navigation Title | QR-Code erstellen |
| `AppStrings.TraceLocations.imageDescription` | Bild: Eine Person zeigt auf ein Flipchart, zwei Personen sitzen daneben und schauen auf das Flipchart. |
| `AppStrings.TraceLocations.descriptionTitle` | Mehr Sicherheit für Sie und Ihre Gäste |
| `AppStrings.TraceLocations.descriptionSubHeadline` | Erstellen Sie einen QR-Code, den Ihre Gäste bei ihrer Ankunft scannen können. So können sie bei Bedarf andere Gäste warnen oder von ihnen gewarnt werden. |
| `AppStrings.TraceLocations.InfoBullet.Text.itemCheckinRiskStatus` | Jeder Check-in wird bei der Ermittlung des Risikostatus zusätzlich berücksichtigt. Wird eine eingecheckte Person später positiv getestet, können die Gäste gewarnt werden, wenn sie sich zur gleichen Zeit oder bis zu 30 Minuten nach der positiv getesteten Person im gleichen Raum aufgehalten haben. |
| `AppStrings.TraceLocations.InfoBullet.Text.checkinQR` | Stellen Sie den QR-Code Ihren Gästen entweder über Ihr Smartphone oder in ausgedruckter Form zur Verfügung. |
| `AppStrings.TraceLocations.InfoBullet.Text.diaryDeletedAutomatically` | Wenn Sie dauerhaft einen QR-Code verwenden, sollten Sie diesen einmal täglich außerhalb der Öffnungszeiten neu erstellen. | 
| `AppStrings.TraceLocations.InfoBullet.Text.Group` | Sie können Ihre Gäste in Vertretung für eine positiv getestete Person warnen, die am Event teilgenommen hat, aber nicht über die Corona-Warn-App eingecheckt war. |

**TraceLocationsOverviewViewController (Empty)**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| keine ID, Navigation Title | Meine QR-Codes |
| `AppStrings.TraceLocations.Overview.addButton` | QR-Code erstellen (Button) |
| `AppStrings.TraceLocations.Overview.emptyStateTitle` | Noch keine QR-Codes erstellt |
| `AppStrings.TraceLocations.Overview.emptyStateDescription` | Hier werden alle QR-Codes angezeigt, die Sie für einen Ort oder ein Event erstellt haben. Sie können die QR-Codes löschen, wenn diese nicht mehr verwendet werden sollen. |

**TraceLocationTypeSelectionViewController**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| keine ID, Navigation Title | QR-Code erstellen |
| `AppStrings.TraceLocations.sectionHeader-0` | ORT |
| `AppStrings.TraceLocations.permanent.title.retail` | Einzelhandel, Geschäft, Verkaufsraum |
| `AppStrings.TraceLocations.permanent.title.foodService` | Gastronomiebetrieb, Café, Kneipe, Restaurant, Hotel |
| `AppStrings.TraceLocations.permanent.title.craft` | Handwerksbetrieb, Friseur, Schreinerei |
| `AppStrings.TraceLocations.permanent.title.workplace` | Arbeitsstätte, Büro, Konferenzraum, Kantine |
| `AppStrings.TraceLocations.permanent.title.educationalInstitution` | Bildungsstätte, Klassenzimmer, Vorlesungssaal, Bibliothek |
| `AppStrings.TraceLocations.permanent.title.publicBuilding` | Öffentliches Gebäude, Bürgeramt, Museum |
| `AppStrings.TraceLocations.permanent.title.other` | Anderer Ort |
| `AppStrings.TraceLocations.sectionHeader-1` | EVENT |
| `AppStrings.TraceLocations.temporary.title.culturalEvent` | Kulturveranstaltung, Konzert, Kunstausstellung |
| `AppStrings.TraceLocations.temporary.title.clubActivity` | Vereinsaktivität, Sporttraining, Mitgliederversammlung |
| `AppStrings.TraceLocations.temporary.title.privateEvent` | Private Feier, Geburtstag, Familienfeier |
| `AppStrings.TraceLocations.temporary.title.worshipService` | Gottesdienst |
| `AppStrings.TraceLocations.temporary.title.other` | Anderes Event |

**TraceLocationConfigurationViewController**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| keine ID | QR-Code erstellen (Navigation Title) |
| `AppStrings.TraceLocations.Configuration.traceLocationTypeLabel` | Anderer Ort (Trace Location Type) |
| `AppStrings.TraceLocations.Configuration.permanentDefaultLengthValueLabel` | 02:00 Std. (Permanent Default Length Value Label) |
| `AppStrings.ExposureSubmission.primaryButton` | Speichern (Primary Button) |

**TraceLocationsOverviewViewController (With Location)**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| `AppStrings.TraceLocations.Overview.eventTableViewCell.titleLabel` | Haircutter (Event Title Label) |
| `AppStrings.TraceLocations.Overview.eventTableViewCell.addressLabel` | Berlin (Event Address Label) |
| `AppStrings.TraceLocations.Configuration.eventTableViewCellButton` | Selbst einchecken |

**TraceLocationDetailsViewController**

| **Accessibility Identifier** | **Text / Element / Label** |
|---|---|
| `General.primaryFooterButton` | Druckversion anzeigen |
| `General.secondaryFooterButton` | Als Vorlage verwenden |

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14020

## Screenshots
<img width="66%" alt="Screen Shot 2022-10-18 at 09 32 38" src="https://user-images.githubusercontent.com/22373291/196365681-06470513-5ad6-4625-9bf7-406885554caf.png">

