### PR TITLE
Fix/14128 Added local statistic does not focus to the added tile on iOS 12.5

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
@@ -40,8 +40,12 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 			let firstStatisticsCard = stackView.arrangedSubviews[safe: 1],
 			let secondStatisticsCard = stackView.arrangedSubviews[safe: 2] {
 			DispatchQueue.main.async { [weak self] in
+				var animated = false
+				if #available(iOS 13.0, *) {
+					animated = true
+				}
 				let shouldScrollToLocalStatistics = HomeStatisticsTableViewCell.editingStatistics || cellModel.hasNewRegion
-				self?.scrollView.scrollRectToVisible(shouldScrollToLocalStatistics ? secondStatisticsCard.frame : firstStatisticsCard.frame, animated: self?.wasAlreadyShown ?? false)
+				self?.scrollView.scrollRectToVisible(shouldScrollToLocalStatistics ? secondStatisticsCard.frame : firstStatisticsCard.frame, animated: animated)
 				self?.wasAlreadyShown = true
 			}
 		}


### PR DESCRIPTION
## Description
the animation is very laggy on iOS 12.5 since we are executing multiple codes async, as agreed with the testers we will disable the animation for iOS 12.5, there will be a 0.5 sec lag for the screen to show the tile but it looks a bit better

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14128

## Screenshots
https://user-images.githubusercontent.com/15270737/196721275-178f76c4-d920-4a32-9401-9db1b60dbb63.MP4


