### PR TITLE
Fix/6210 wrong font on Check-In-Information Screen

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Info/CheckinsInfoScreenViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Checkin/Info/CheckinsInfoScreenViewModel.swift
@@ -71,7 +71,11 @@ struct CheckInsInfoScreenViewModel {
 						bulletPointCellWithBoldText(text: AppStrings.Checkins.Information.legalText02),
 						bulletPointCellWithBoldText(text: AppStrings.Checkins.Information.legalText03)
 						],
-					subheadline2: NSAttributedString(string: AppStrings.Checkins.Information.legalSubHeadline02),
+					subheadline2: NSAttributedString(
+						string: AppStrings.Checkins.Information.legalSubHeadline02,
+						attributes: [
+							.font: UIFont.preferredFont(forTextStyle: .body)
+					]),
 					accessibilityIdentifier: AccessibilityIdentifiers.Checkin.Information.acknowledgementTitle,
 					configure: { _, cell, _ in
 						cell.backgroundColor = .enaColor(for: .background)


### PR DESCRIPTION
## Description
Check-in-Information: Wrong font of the last text section in "Ihr Einverständnis"

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6210

## Screenshots
<img width="626" alt="Screenshot 2022-10-26 at 17 05 12" src="https://user-images.githubusercontent.com/72390277/198063774-480f7be3-ff1b-4ad5-a026-c476076f95d1.png">
