### PR TITLE
Fix/14149 app crash scanning redeemed code

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
@@ -216,7 +216,7 @@ class HomeTableViewModel {
 			riskAndTestResultsRows.append(.risk)
 		}
 
-		if let pcrTest = coronaTestService.pcrTest.value {
+		if let pcrTest = coronaTestService.pcrTest.value, pcrTest.finalTestResultReceivedDate != nil {
 			let testResultState: TestResultState
 			if pcrTest.testResult == .positive && pcrTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown
@@ -226,7 +226,7 @@ class HomeTableViewModel {
 			riskAndTestResultsRows.append(.pcrTestResult(testResultState))
 		}
 
-		if let antigenTest = coronaTestService.antigenTest.value {
+		if let antigenTest = coronaTestService.antigenTest.value, antigenTest.finalTestResultReceivedDate != nil {
 			let testResultState: TestResultState
 			if antigenTest.testResult == .positive && antigenTest.positiveTestResultWasShown {
 				testResultState = .positiveResultWasShown

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -976,6 +976,12 @@ class CoronaTestService: CoronaTestServiceProviding {
 				case .pending:
 					completion(.success(testResult))
 				case .expired:
+					switch coronaTestType {
+					case .pcr:
+						self.pcrTest.value = nil
+					case .antigen:
+						self.antigenTest.value = nil
+					}
 					if duringRegistration {
 						// The .expired status is only known after the test has been registered on the server
 						// so we generate an error here, even if the server returned the http result 201

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2557,7 +2557,7 @@ class CoronaTestServiceTests: CWATestCase {
 			recycleBin: .fake(),
 			badgeWrapper: .fake()
 		)
-		service.pcrTest.value = .mock(registrationToken: nil)
+		service.pcrTest.value = .mock(registrationToken: nil, finalTestResultReceivedDate: nil)
 
 		let expectation = self.expectation(description: "Expect to receive a result.")
 
@@ -2611,7 +2611,7 @@ class CoronaTestServiceTests: CWATestCase {
 			recycleBin: .fake(),
 			badgeWrapper: .fake()
 		)
-		service.antigenTest.value = .mock(registrationToken: nil)
+		service.antigenTest.value = .mock(registrationToken: nil, finalTestResultReceivedDate: nil)
 
 		let expectation = self.expectation(description: "Expect to receive a result.")
 
@@ -2962,8 +2962,8 @@ class CoronaTestServiceTests: CWATestCase {
 		waitForExpectations(timeout: .short)
 
 		XCTAssertEqual(diaryStore.coronaTests.count, 0)
-		XCTAssertFalse(try XCTUnwrap(testService.antigenTest.value?.journalEntryCreated))
-		XCTAssertFalse(try XCTUnwrap(testService.pcrTest.value?.journalEntryCreated))
+		XCTAssertNil(testService.antigenTest.value?.journalEntryCreated)
+		XCTAssertNil(testService.pcrTest.value?.journalEntryCreated)
 	}
 
 	func test_When_UpdateTestResultSuccessWithInvalid_Then_ContactJournalHasNoEntry() throws {


### PR DESCRIPTION
## Description
Fixing the crash when scanning a redeemed code, we shouldn't save the expired tests on the app even temporarily this causes a confusion in the number of rows, because there should be one cell for the risk state "in case of the redeemed test" but the app thinks there should be 2 "risk cell and test result cell", the introduced solution will prevent the app from adding this extra cell to the view model and hence prevent the crash

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14149
