### PR TITLE
fix/6441 disabled button when edit & delete the event cell

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Cells/EventTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Cells/EventTableViewCell.swift
@@ -44,6 +44,17 @@ class EventTableViewCell: UITableViewCell, ReuseIdentifierProviding {
 			containerView.backgroundColor = cellBackgroundColor
 		}
 	}
+	
+	override func setEditing(_ editing: Bool, animated: Bool) {
+		super.setEditing(editing, animated: animated)
+		if editing {
+			button.isEnabled = false
+			button.setTitleColor(.enaColor(for: .textPrimary2), for: .disabled)
+			button.layer.borderColor = .enaColor(for: .textPrimary2)
+		} else {
+			button.isEnabled = true
+		}
+	}
 
 	// MARK: - Internal
 


### PR DESCRIPTION
## Description
"Meine QR-Codes" screen: when you want to delete the QR Code, a Check In was possible and the button was not disabled.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6441

## Screens
<img width="603" alt="Event" src="https://user-images.githubusercontent.com/72390277/203377450-4560ee19-9278-47da-aa2d-eeded1e60c05.png">