### PR TITLE
Fix/14451: Self-test - Share Check-Ins - wrong popup when cancellation

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -883,7 +883,10 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 						}
 					})
 				} else {
-					self?.showTestResultAvailableCloseAlert()
+					switch isSRSFlow {
+					case true: self?.showSRSFlowAlert(for: .consent(.cancelWarnOthers(on: checkinsVC)), isLoading: { _ in })
+					case false: self?.showTestResultAvailableCloseAlert()
+					}
 				}
 			}
 		)


### PR DESCRIPTION
## Description
SRS: Self-test / Share Check-Ins shows now the correct alert, when tap Close-Icon.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14451

## Screenshots
<img width="66%" alt="Screenshot 2022-12-16 at 14 56 12" src="https://user-images.githubusercontent.com/22373291/208114535-d086cfd1-cfde-43f0-8697-3eefe60a970c.png">

