### PR TITLE
Fix/14148: Event Check-in - default duration 00:00 when event has same start date and end date

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
@@ -50,7 +50,7 @@ struct TraceLocation: Equatable {
 				to: endDate
 			).minute
 
-			duration = eventDuration ?? fallback
+			duration = eventDuration.map { $0 == 0 ? fallback : $0 } ?? fallback
 		} else {
 			duration = fallback
 		}


### PR DESCRIPTION
## Description
Event Check-In: the default duration is 15 minutes, when event has same start date and end date

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14148

## Screenshots
<img width="66%" alt="Screenshot 2022-12-19 at 20 02 50" src="https://user-images.githubusercontent.com/22373291/208501311-fbdf7d90-ac99-4ac6-9d23-4a0da62fe068.png">

