### PR TITLE
13750: Certificate for PCR Test older than 72 Hours is exported

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -278,14 +278,6 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 	var expirationDate: Date {
 		return cborWebTokenHeader.expirationTime
 	}
-	
-	var ageInMinutes: Int? {
-		guard let sortDate = sortDate else {
-			return nil
-		}
-
-		return Calendar.current.dateComponents([.minute], from: sortDate, to: Date()).minute
-	}
 
 	var ageInHours: Int? {
 		guard let sortDate = sortDate else {
@@ -335,11 +327,10 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		case .vaccination, .recovery:
 			return true
 		case .test:
-			guard let ageInMinutes = ageInMinutes else {
+			guard let ageInHours = ageInHours else {
 				return false
 			}
-			// Not older that 3 days (72h), based on minutes
-			return ageInMinutes <= 72 * 60
+			return ageInHours < 72
 		}
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertificate.swift
@@ -278,6 +278,14 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 	var expirationDate: Date {
 		return cborWebTokenHeader.expirationTime
 	}
+	
+	var ageInMinutes: Int? {
+		guard let sortDate = sortDate else {
+			return nil
+		}
+
+		return Calendar.current.dateComponents([.minute], from: sortDate, to: Date()).minute
+	}
 
 	var ageInHours: Int? {
 		guard let sortDate = sortDate else {
@@ -327,10 +335,11 @@ final class HealthCertificate: Codable, Equatable, Comparable, RecycleBinIdentif
 		case .vaccination, .recovery:
 			return true
 		case .test:
-			guard let ageInHours = ageInHours else {
+			guard let ageInMinutes = ageInMinutes else {
 				return false
 			}
-			return ageInHours <= 72
+			// Not older that 3 days (72h), based on minutes
+			return ageInMinutes <= 72 * 60
 		}
 	}
 	


### PR DESCRIPTION
## Description
Give `HealthCertificate` the `ageInHours` less than `72` hours, to avoid rounding issues for exporting.

Background:

```swift
// Bug Ticket Values

var fromDateComponents = DateComponents()
fromDateComponents.year = 2022
fromDateComponents.month = 8
fromDateComponents.day = 7
fromDateComponents.timeZone = .current
fromDateComponents.hour = 7
fromDateComponents.minute = 30

var toDateComponents = DateComponents()
toDateComponents.year = 2022
toDateComponents.month = 8
toDateComponents.day = 10
toDateComponents.timeZone = .current
toDateComponents.hour = 8
toDateComponents.minute = 06

let fromDate = Calendar.current.date(from: fromDateComponents)
let toDate = Calendar.current.date(from: toDateComponents)

var ageInHours: Int? {
    guard let fromDate = fromDate, let toDate = toDate else { return nil }
    return Calendar.current.dateComponents([.hour], from: fromDate, to: toDate).hour
}

var ageInMinutes: Int? {
    guard let fromDate = fromDate, let toDate = toDate else { return nil }
    return Calendar.current.dateComponents([.minute], from: fromDate, to: toDate).minute
}

// Tests

ageInHours! <= 72 // true (CORRECT BUT NOT THE BEHAVIOUR WE WANT, BUG)

ageInHours! < 72 // false (CORRECT, FIX)
ageInMinutes! < 72 * 60 // false (CORRECT, FIX)

```

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13751
