### PR TITLE
Fix/14480: Wrong text in SRS dialog "Andere warnen nicht möglich" for error MIN_TIME_SINCE_ONBOARDING

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -587,7 +587,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_title" = "Andere warnen nicht möglich";
 
-"ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_insufficientAppUsageTime_message" = "Leider können Sie momentan andere noch nicht warnen, da Sie die App noch nicht lange genug installiert haben. Dies dient der Vermeidung von Missbrauch.\nEinen offiziellen Test können Sie jederzeit registrieren und andere damit warnen. (Fehlercode %@)";
+"ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_insufficientAppUsageTime_message" = "Aus Sicherheitsgründen können Sie erst %@ Stunden, nachdem Sie die App installiert oder aktualisiert haben, diese Art von Warnung senden. Bitte versuchen Sie es in %@ Stunden erneut. (Fehlercode %@)";
 
 "ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_positiveTestResultWasAlreadySubmittedWithinThresholdDays_message" = "Sie können momentan andere nicht warnen, da Sie innerhalb der vergangenen %@ Tage bereits ein positives Testergebnis gemeldet haben. Dies dient der Vermeidung von Missbrauch.\nEinen offiziellen Test können Sie jederzeit registrieren und andere damit warnen. (Fehlercode %@)";
 

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSPreconditionErrorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSPreconditionErrorTests.swift
@@ -23,13 +23,20 @@ final class SRSPreconditionErrorTests: CWATestCase {
 
 	func testInsufficientAppUsageTime_Message() {
 		// GIVEN
-		let sut = SRSPreconditionError.insufficientAppUsageTime
+		let timeSinceOnboardingInHours = 42
+		let timeStillToWaitInHours = 23
+		let sut = SRSPreconditionError.insufficientAppUsageTime(
+			timeSinceOnboardingInHours: timeSinceOnboardingInHours,
+			timeStillToWaitInHours: timeStillToWaitInHours
+		)
 		
 		// THEN
 		XCTAssertEqual(
 			sut.message,
 			String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
+				String(timeSinceOnboardingInHours),
+				String(timeStillToWaitInHours),
 				sut.errorCode
 			)
 		)
@@ -55,7 +62,7 @@ final class SRSPreconditionErrorTests: CWATestCase {
 	
 	func testErrorCode_EqualTo_ErrorDescription() {
 		// GIVEN
-		let sut = SRSPreconditionError.insufficientAppUsageTime
+		let sut = SRSPreconditionError.insufficientAppUsageTime(timeSinceOnboardingInHours: 42, timeStillToWaitInHours: 42)
 		
 		// THEN
 		XCTAssertEqual(sut.errorCode, sut.description)
@@ -75,7 +82,7 @@ final class SRSPreconditionErrorTests: CWATestCase {
 		XCTAssertEqual(sut.description, "DEVICE_TIME_UNVERIFIED")
 		
 		// WHEN
-		sut = .insufficientAppUsageTime
+		sut = SRSPreconditionError.insufficientAppUsageTime(timeSinceOnboardingInHours: 42, timeStillToWaitInHours: 42)
 		
 		// THEN
 		XCTAssertEqual(sut.description, "MIN_TIME_SINCE_ONBOARDING")

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
@@ -8,7 +8,7 @@ enum SRSPreconditionError: Error {
 	case deviceTimeError(PPACError)
 
 	/// Precondition: the app was installed less than 48h
-	case insufficientAppUsageTime
+	case insufficientAppUsageTime(timeSinceOnboardingInHours: Int, timeStillToWaitInHours: Int)
 	
 	/// Precondition: there was already a key submission without a registered test, depending from configuration (for e.g. in the last 3 months)
 	case positiveTestResultWasAlreadySubmittedWithinThreshold(timeBetweenSubmissionsInDays: Int)
@@ -22,9 +22,11 @@ enum SRSPreconditionError: Error {
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.deviceCheckError,
 				errorCode
 			)
-		case .insufficientAppUsageTime:
+		case .insufficientAppUsageTime(let timeSinceOnboardingInHours, let timeStillToWaitInHours):
 			return String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
+				String(timeSinceOnboardingInHours),
+				String(timeStillToWaitInHours),
 				errorCode
 			)
 		case  .positiveTestResultWasAlreadySubmittedWithinThreshold(let timeBetweenSubmissionsInDays):

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
@@ -22,14 +22,14 @@ enum SRSPreconditionError: Error {
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.deviceCheckError,
 				errorCode
 			)
-		case .insufficientAppUsageTime(let timeSinceOnboardingInHours, let timeStillToWaitInHours):
+		case let .insufficientAppUsageTime(timeSinceOnboardingInHours, timeStillToWaitInHours):
 			return String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
 				String(timeSinceOnboardingInHours),
 				String(timeStillToWaitInHours),
 				errorCode
 			)
-		case  .positiveTestResultWasAlreadySubmittedWithinThreshold(let timeBetweenSubmissionsInDays):
+		case let .positiveTestResultWasAlreadySubmittedWithinThreshold(timeBetweenSubmissionsInDays):
 			return String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.positiveTestResultWasAlreadySubmittedWithinThresholdDaysMessage,
 				String(timeBetweenSubmissionsInDays),

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
@@ -74,7 +74,18 @@ class PPACService: PrivacyPreservingAccessControl {
 			
 			if difference < minTimeSinceOnboarding {
 				Log.error("SRSError: too short time since onboarding", log: .ppac)
-				completion(.failure(.insufficientAppUsageTime))
+				
+				// Default is 1 to avoid texts like "wait for 0 hours" ...
+				let timeStillToWaitInHours = difference == 0 ? 1 : difference
+
+				completion(
+					.failure(
+						.insufficientAppUsageTime(
+							timeSinceOnboardingInHours: minTimeSinceOnboarding,
+							timeStillToWaitInHours: timeStillToWaitInHours
+						)
+					)
+				)
 				return
 			}
 		}


### PR DESCRIPTION
## Description
Show new warn alert text for SRS precondition error `MIN_TIME_SINCE_ONBOARDING.`

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14480

## Screenshots
<img width="66%" alt="Screenshot 2023-01-03 at 12 53 33" src="https://user-images.githubusercontent.com/22373291/210352594-1f6376e2-750f-43d6-81d3-bd56c172b14b.png">

