### PR TITLE
Fix/13928  Wrong Button text if Background App Refresh is off

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -81,7 +81,7 @@
 
 "ExposureDetection_RefreshingIn" = "Aktualisierung in %02d:%02d\U00A0Minuten";
 
-"ExposureDetection_RefreshIn" = "Aktualisierung in %@";
+"ExposureDetection_RefreshIn" = "Aktualisierung alle 4 Std. im WLAN";
 
 "ExposureDetection_LastRiskLevel" = "Letzte Risiko-Überprüfung: %@";
 


### PR DESCRIPTION
## Description
Wrong Button text if Background App Refresh is off & the device is connected via a cellular connection

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13928

## Screenshots
![IMG_0137](https://user-images.githubusercontent.com/72390277/210555348-70f65ea6-27bb-4c21-a770-b26e98d9f117.PNG)