### PR TITLE
Fix/6511 Nothing happens when you check-in at an event

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
@@ -47,11 +47,10 @@ struct TraceLocation: Equatable {
 			let eventDuration = Calendar.current.dateComponents(
 				[.minute],
 				from: startDate,
-				// The event duration should be atleast 15 minutes
-				to: endDate.addingTimeInterval(15 * 60)
+				to: endDate
 			).minute
 
-			duration = eventDuration ?? fallback
+			duration = eventDuration.map { $0 == 0 ? fallback : $0 } ?? fallback
 		} else {
 			duration = fallback
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Events/Store/Model/TraceLocation.swift
@@ -47,7 +47,8 @@ struct TraceLocation: Equatable {
 			let eventDuration = Calendar.current.dateComponents(
 				[.minute],
 				from: startDate,
-				to: endDate
+				// The event duration should be atleast 15 minutes
+				to: endDate.addingTimeInterval(15 * 60)
 			).minute
 
 			duration = eventDuration ?? fallback


### PR DESCRIPTION
## Description
Nothing happens when you check-in at an event which has the same start and end time. Now, the default event duration is at-least for 15 minutes.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6511

## Screenshots
https://user-images.githubusercontent.com/72390277/211600085-fc0fdb77-c795-4168-884f-1fcd137c6945.MP4