### PR TITLE
Fix/14547: [Screenshots] Warn without TAN

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -1690,6 +1690,7 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 					)
 				}
 			)
+			confirmAction.accessibilityIdentifier = AccessibilityIdentifiers.SRSConfirmWarnOthersAlert.actionConfirm
 			alert.addAction(confirmAction)
 			
 			alert.addAction(UIAlertAction(

--- a/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AccessibilityIdentifiers.swift
@@ -369,6 +369,10 @@ enum AccessibilityIdentifiers {
 	enum SRSDataProcessingDetailInfo {
 		static let content = "AppStrings.SRSConsentScreen.dataProcessingDetailInfo"
 	}
+	
+	enum SRSConfirmWarnOthersAlert {
+		static let actionConfirm = "AppStrings.SRSConfirmWarnOthersAlert.actionConfirm"
+	}
 
 	enum ExposureSubmissionQRInfo {
 		static let headerSection1 = "AppStrings.ExposureSubmissionQRInfo.headerSection1"

--- a/src/xcode/ENA/ENAUITests/ExposureSubmission/ENAUITests_04a_ExposureSubmission.swift
+++ b/src/xcode/ENA/ENAUITests/ExposureSubmission/ENAUITests_04a_ExposureSubmission.swift
@@ -865,7 +865,7 @@ class ENAUITests_04a_ExposureSubmission: CWATestCase {
 
 		// Confirm Warn Others
 		snapshot("submissionflow_srs_screenshot_consent_warnothers")
-		app.alerts.firstMatch.buttons.element(boundBy: 0).waitAndTap()
+		app.alerts.firstMatch.buttons[AccessibilityIdentifiers.SRSConfirmWarnOthersAlert.actionConfirm].waitAndTap()
 		
 		// Thank You Screen
 		snapshot("submissionflow_srs_screenshot_success_thankyou", timeWaitingForIdle: .medium)


### PR DESCRIPTION
## Description
Solve a screenshot issue for `UI Tests`, the the order of the Consent Alert `"Confirm Warn Others"` from the SRS flow was different in languages. So in `EN,` the order was inverted against to all other languages.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14547

## Screenshots
<img width="66%" alt="Screenshot 2023-01-13 at 13 14 23" src="https://user-images.githubusercontent.com/22373291/212318035-bd213df1-0e72-4a8a-85d8-c8a9fe0a6751.png">

