### PR TITLE
Fix/14412 Contact Diary Warn others entry UI issue

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/Cells/DiaryOverviewDayTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ContactDiary/Overview/Cells/DiaryOverviewDayTableViewCell.swift
@@ -255,7 +255,7 @@ class DiaryOverviewDayTableViewCell: UITableViewCell {
 				horizontalStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
 				horizontalStackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16.0),
 				horizontalStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-				horizontalStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+				horizontalStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -12.0)
 			]
 		)
 		


### PR DESCRIPTION
## Description
Warn others UI was overlapping in contact diary after adding the Person and Place encounters.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14412

## Screenshots
<img width="761" alt="Screenshot 2023-01-16 at 13 44 32" src="https://user-images.githubusercontent.com/72390277/212681778-c5cf75dd-7a4e-4687-ae07-f07459e3d931.png">
