### PR TITLE
Fix/14577 first srs submission leads to api token already issued

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMSRSPrechecks/DMSRSOptionsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMSRSPrechecks/DMSRSOptionsViewModel.swift
@@ -82,6 +82,16 @@ final class DMSRSOptionsViewModel {
 					self.refreshTableView([TableViewSections.srsStateValues.rawValue])
 				}
 			)
+		case .restApiTokenPPAC:
+			return DMButtonCellViewModel(
+				text: "Reset API Token",
+				textColor: .white,
+				backgroundColor: .enaColor(for: .buttonDestructive),
+				action: { [store] in
+					store.apiTokenPPAC = nil
+					self.refreshTableView([TableViewSections.srsStateValues.rawValue])
+				}
+			)
 		}
 	}
 

--- a/src/xcode/ENA/ENA/Source/Developer Menu/DMSRSPrechecks/DMSRSOptionsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/DMSRSPrechecks/DMSRSOptionsViewModel.swift
@@ -116,7 +116,12 @@ final class DMSRSOptionsViewModel {
 	
 	private func apiTokenStaticText() -> String {
 	   """
+	   DEPRICATED API Token EDUS
+	   \(store.ppacApiTokenEdus?.token ?? "No Existing EDUS API Token in the store")
 	   
+	   DEPRICATED API Token ELS
+	   \(store.ppacApiTokenEls?.token ?? "No Existing ELS API Token in the store")
+
 	   PPAC API Token
 	   \(store.apiTokenPPAC?.token ?? "No API Token generated yet")
 	   
@@ -151,6 +156,7 @@ extension DMSRSOptionsViewModel {
 		case apiToken
 		case resetMostRecentKeySubmission
 		case resetSRSStateValues
+		case restApiTokenPPAC
 		
 		var sectionTitle: String {
 			switch self {
@@ -164,6 +170,8 @@ extension DMSRSOptionsViewModel {
 				return "Most Recent Key Submission"
 			case .resetSRSStateValues:
 				return "All SRS State Values"
+			case .restApiTokenPPAC:
+				return "Rest API Token"
 			}
 		}
 	}

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
@@ -165,6 +165,8 @@ class PPACService: PrivacyPreservingAccessControl {
 			store.apiTokenPPAC = newToken
 			return newToken
 		}
+		Log.info("fetched existing valid API token: \(private: storedToken)", log: .ppac)
+		
 		return storedToken
 	}
 
@@ -174,7 +176,7 @@ class PPACService: PrivacyPreservingAccessControl {
 		let utcDate = Date()
 		let token = TimestampedToken(token: uuid, timestamp: utcDate)
 
-		Log.info("Generated new API token", log: .ppac)
+		Log.info("Generated new API token: \(private: token)", log: .ppac)
 		return token
 	}
 }

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -90,6 +90,10 @@ final class MockTestStore: Store, PPAnalyticsData {
 	var previousPpacApiTokenSrs: TimestampedToken?
 	var otpTokenSrs: OTPToken?
     var otpSrsAuthorizationDate: Date?
+	/// DEPRECATED, Only used for dev menu testing for API tokens
+	var ppacApiTokenEdus: TimestampedToken?
+	/// DEPRECATED, Only used for dev menu testing for API tokens
+	var ppacApiTokenEls: TimestampedToken?
 
 	// MARK: - PrivacyPreservingProviding
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -537,6 +537,14 @@ extension SecureStore: PrivacyPreservingProviding {
 		get { kvStore["previousAPITokenPPAC"] as TimestampedToken? }
 		set { kvStore["previousAPITokenPPAC"] = newValue }
 	}
+	
+	// FOR reading legacy values for DEVMENU ONLY!, dont save any new code to these 2 variables!
+	var ppacApiTokenEdus: TimestampedToken? {
+		kvStore["ppacApiToken"] as TimestampedToken?
+	}
+	var ppacApiTokenEls: TimestampedToken? {
+		kvStore["ppacApiTokenEls"] as TimestampedToken?
+	}
 }
 
 extension SecureStore: ErrorLogProviding {

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -521,12 +521,18 @@ extension SecureStore: PrivacyPreservingProviding {
 		get { kvStore["otpAuthorizationDate"] as Date? }
 		set { kvStore["otpAuthorizationDate"] = newValue }
 	}
-
 	var apiTokenPPAC: TimestampedToken? {
-		get { kvStore["apiTokenPPAC"] as TimestampedToken? }
+		get {
+			// "apiTokenPPAC" is the unified api token used in 3.0 or later versions
+			if let existingApiTokenPPAC = kvStore["apiTokenPPAC"] as TimestampedToken? {
+				return existingApiTokenPPAC
+			} else {
+				// we check for the legacy api tokens: "ppacApiToken" for EDUS and "ppacApiTokenEls" for ELS
+				return kvStore["ppacApiToken"] as TimestampedToken? ?? kvStore["ppacApiTokenEls"] as TimestampedToken?
+			}
+		}
 		set { kvStore["apiTokenPPAC"] = newValue }
 	}
-	
 	var previousAPITokenPPAC: TimestampedToken? {
 		get { kvStore["previousAPITokenPPAC"] as TimestampedToken? }
 		set { kvStore["previousAPITokenPPAC"] = newValue }

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -150,6 +150,10 @@ protocol PrivacyPreservingProviding: AnyObject {
 	var apiTokenPPAC: TimestampedToken? { get set }
 	/// Previous PPAC API token
 	var previousAPITokenPPAC: TimestampedToken? { get set }
+	/// DEPRECATED, Only used for dev menu testing for API tokens
+	var ppacApiTokenEdus: TimestampedToken? { get }
+	/// DEPRECATED, Only used for dev menu testing for API tokens
+	var ppacApiTokenEls: TimestampedToken? { get }
 }
 
 protocol ErrorLogProviding: AnyObject {


### PR DESCRIPTION
## Description

- merging the 3 api tokens we had previously "EDUS, ELS and SRS" into one created this bug, the fix was a migration logic to check the store for the old values
- add dev menu feature to see all stored api tokens
- add dev menu feature to delete the new api token from the store

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14577

## Screenshots
![Simulator Screen Shot - iPhone 8 - 2023-01-17 at 11 41 48](https://user-images.githubusercontent.com/15270737/212882344-449530f4-8e25-450b-92df-3ba36fc106ff.png)

