### PR TITLE
Fix double whitespace in string 

### DIFF
--- a/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/src/xcode/ENA.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -83,6 +83,15 @@
         }
       },
       {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb.git",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
+        }
+      },
+      {
         "package": "jsonfunctions",
         "repositoryURL": "https://github.com/corona-warn-app/json-functions-swift",
         "state": {
@@ -128,6 +137,15 @@
         }
       },
       {
+        "package": "OpenCombine",
+        "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
+        "state": {
+          "branch": null,
+          "revision": "28993ae57de5a4ea7e164787636cafad442d568c",
+          "version": "0.12.0"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
@@ -155,6 +173,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
         "package": "SwiftJWT",
         "repositoryURL": "https://github.com/corona-warn-app/Swift-JWT.git",
         "state": {
@@ -173,6 +200,15 @@
         }
       },
       {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
+          "version": "1.20.3"
+        }
+      },
+      {
         "package": "SwiftCBOR",
         "repositoryURL": "https://github.com/unrelentingtech/SwiftCBOR",
         "state": {
@@ -188,6 +224,15 @@
           "branch": null,
           "revision": "b3dcd7dbd0d488e1a7077cb33b00f2083e382f07",
           "version": "5.0.1"
+        }
+      },
+      {
+        "package": "ZIPFoundation",
+        "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
+        "state": {
+          "branch": null,
+          "revision": "43ec568034b3731101dbf7670765d671c30f54f3",
+          "version": "0.9.16"
         }
       }
     ]

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -162,7 +162,7 @@
 
 "SRS_Consent_Legal_Text_1" = "Die App teilt Ihr positives Testergebnis, um andere Nutzer der Corona-Warn-App zu warnen, denen Sie begegnet sind oder die zeitgleich am selben Event oder Ort wie Sie eingecheckt waren.";
 
-"SRS_Consent_Legal_Text_2" = "Bevor das Testergebnis geteilt werden kann, wird die Echtheit Ihrer App einmalig geprüft. Dazu wird durch Ihr Smartphone eine eindeutige Kennung erzeugt und an Apple  in die USA oder andere Drittländer übermittelt, damit Apple die Echtheit Ihrer App gegenüber dem RKI bestätigen kann. Die Kennung enthält Informationen über die Version Ihres Smartphones und der App. Apple kann damit möglicherweise auf Ihre Identität schließen und nachvollziehen, dass die Echtheitsprüfung Ihres Smartphones stattgefunden hat. Weitere Angaben aus der App erhält Apple hierbei nicht.";
+"SRS_Consent_Legal_Text_2" = "Bevor das Testergebnis geteilt werden kann, wird die Echtheit Ihrer App einmalig geprüft. Dazu wird durch Ihr Smartphone eine eindeutige Kennung erzeugt und an Apple in die USA oder andere Drittländer übermittelt, damit Apple die Echtheit Ihrer App gegenüber dem RKI bestätigen kann. Die Kennung enthält Informationen über die Version Ihres Smartphones und der App. Apple kann damit möglicherweise auf Ihre Identität schließen und nachvollziehen, dass die Echtheitsprüfung Ihres Smartphones stattgefunden hat. Weitere Angaben aus der App erhält Apple hierbei nicht.";
 
 "SRS_Consent_Legal_Text_2_prefix" = "Bevor das Testergebnis geteilt werden kann, wird die ";
 


### PR DESCRIPTION
## Description
This PR removes an unnecessary whitespace in the "SRS_Consent_Legal_Text_2" string.

## Link to Jira
n/a

## Screenshots
This is a minimal change, no big visible impact. If you still want screenshots, let me know, I'll provide them. 
