### PR TITLE
Fix double whitespace

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.legal.strings
@@ -162,7 +162,7 @@
 
 "SRS_Consent_Legal_Text_1" = "Die App teilt Ihr positives Testergebnis, um andere Nutzer der Corona-Warn-App zu warnen, denen Sie begegnet sind oder die zeitgleich am selben Event oder Ort wie Sie eingecheckt waren.";
 
-"SRS_Consent_Legal_Text_2" = "Bevor das Testergebnis geteilt werden kann, wird die Echtheit Ihrer App einmalig geprüft. Dazu wird durch Ihr Smartphone eine eindeutige Kennung erzeugt und an Apple  in die USA oder andere Drittländer übermittelt, damit Apple die Echtheit Ihrer App gegenüber dem RKI bestätigen kann. Die Kennung enthält Informationen über die Version Ihres Smartphones und der App. Apple kann damit möglicherweise auf Ihre Identität schließen und nachvollziehen, dass die Echtheitsprüfung Ihres Smartphones stattgefunden hat. Weitere Angaben aus der App erhält Apple hierbei nicht.";
+"SRS_Consent_Legal_Text_2" = "Bevor das Testergebnis geteilt werden kann, wird die Echtheit Ihrer App einmalig geprüft. Dazu wird durch Ihr Smartphone eine eindeutige Kennung erzeugt und an Apple in die USA oder andere Drittländer übermittelt, damit Apple die Echtheit Ihrer App gegenüber dem RKI bestätigen kann. Die Kennung enthält Informationen über die Version Ihres Smartphones und der App. Apple kann damit möglicherweise auf Ihre Identität schließen und nachvollziehen, dass die Echtheitsprüfung Ihres Smartphones stattgefunden hat. Weitere Angaben aus der App erhält Apple hierbei nicht.";
 
 "SRS_Consent_Legal_Text_2_prefix" = "Bevor das Testergebnis geteilt werden kann, wird die ";
 


### PR DESCRIPTION
## Description
This PR removes an unnecessary whitespace in the "SRS_Consent_Legal_Text_2" string.

## Link to Jira
n/a

## Screenshots
This is a minimal change, no big visible impact. If you still want screenshots, let me know, I'll provide them. 