### PR TITLE
Fix/14566 SRS Warn others offline - error message unclear

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -1739,6 +1739,7 @@
 		DC3B278F28F5936700A55769 /* NSAttributedString+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3B278E28F5936700A55769 /* NSAttributedString+Image.swift */; };
 		DC4618C429155B2F0035CAA7 /* SRSTestTypeSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4618C329155B2F0035CAA7 /* SRSTestTypeSelectionViewController.swift */; };
 		DC4618C629155E560035CAA7 /* SRSTestTypeSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4618C529155E560035CAA7 /* SRSTestTypeSelectionViewModel.swift */; };
+		DC535C872982A98A00A8BC7D /* SRSErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC535C862982A98A00A8BC7D /* SRSErrorTests.swift */; };
 		DC5469AF2934F2E40027B3B3 /* SRSErrorAlertProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5469AE2934F2E40027B3B3 /* SRSErrorAlertProviding.swift */; };
 		DC5469B12934F2FA0027B3B3 /* ErrorCodeProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5469B02934F2FA0027B3B3 /* ErrorCodeProviding.swift */; };
 		DC7002D9284F6B7900B164AC /* HealthCertificateExportCertificatesInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7002D8284F6B7900B164AC /* HealthCertificateExportCertificatesInfoViewModel.swift */; };
@@ -3630,6 +3631,7 @@
 		DC3B278E28F5936700A55769 /* NSAttributedString+Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Image.swift"; sourceTree = "<group>"; };
 		DC4618C329155B2F0035CAA7 /* SRSTestTypeSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSTestTypeSelectionViewController.swift; sourceTree = "<group>"; };
 		DC4618C529155E560035CAA7 /* SRSTestTypeSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSTestTypeSelectionViewModel.swift; sourceTree = "<group>"; };
+		DC535C862982A98A00A8BC7D /* SRSErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSErrorTests.swift; sourceTree = "<group>"; };
 		DC5469AE2934F2E40027B3B3 /* SRSErrorAlertProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSErrorAlertProviding.swift; sourceTree = "<group>"; };
 		DC5469B02934F2FA0027B3B3 /* ErrorCodeProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeProviding.swift; sourceTree = "<group>"; };
 		DC7002D8284F6B7900B164AC /* HealthCertificateExportCertificatesInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCertificateExportCertificatesInfoViewModel.swift; sourceTree = "<group>"; };
@@ -3971,6 +3973,7 @@
 				0123D5972501383100A91838 /* ExposureSubmissionErrorTests.swift */,
 				CDF27BD2246ADBA70044D32B /* ExposureSubmissionServiceTests.swift */,
 				DC11397F2944AB30008B7E7E /* SRSPreconditionErrorTests.swift */,
+				DC535C862982A98A00A8BC7D /* SRSErrorTests.swift */,
 			);
 			path = __tests__;
 			sourceTree = "<group>";
@@ -12560,6 +12563,7 @@
 				508266DA278DA60000091991 /* Archive+CBOR.swift in Sources */,
 				50C51CB625CDEA4300D4C33A /* HTTPClient+SubmitAnalyticsDataTests.swift in Sources */,
 				0127B09E272855D6008E30AF /* CoronaTestRestorationHandlerTests.swift in Sources */,
+				DC535C872982A98A00A8BC7D /* SRSErrorTests.swift in Sources */,
 				ABA146CE27E380650096A44E /* Migration2To3Tests.swift in Sources */,
 				3421AFD828104A7D0059802B /* AddAntigenTestProfileCellModelTests.swift in Sources */,
 				BA89F94A27F24C3200132C59 /* FamilyMemberPCRTest+Mock.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSErrorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSErrorTests.swift
@@ -1,0 +1,194 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import XCTest
+@testable import ENA
+
+final class SRSErrorTests: XCTestCase {
+	
+	override func setUp() async throws {
+		InternetConnectivityMonitor.shared.isDeviceOnlineMock = true
+	}
+	
+	override func tearDown() async throws {
+		InternetConnectivityMonitor.shared.isDeviceOnlineMock = false
+	}
+	
+	func testDescription_ppacError() throws {
+		// GIVEN
+		let sut: SRSError = .ppacError(.submissionTooEarly)
+		
+		// THEN
+		XCTAssertEqual(sut.description, PPACError.submissionTooEarly.description)
+	}
+
+    func testDescription_otpError() throws {
+		// GIVEN
+		let sut: SRSError = .otpError(.apiTokenExpired)
+		
+		// THEN
+		XCTAssertEqual(sut.description, OTPError.apiTokenExpired.description)
+    }
+	
+	func testDescription_srsOTPClientError() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTPClientError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_CLIENT_ERROR")
+	}
+
+	func testDescription_srsOTPNetworkError() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTPNetworkError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_NO_NETWORK")
+	}
+
+	func testDescription_srsOTPServerError() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTPServerError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_SERVER_ERROR")
+	}
+
+	func testDescription_srsOTP400() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTP400
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_400")
+	}
+
+	func testDescription_srsOTP401() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTP401
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_401")
+	}
+
+	func testDescription_srsOTP403() throws {
+		// GIVEN
+		let sut: SRSError = .srsOTP403
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_403")
+	}
+
+	func testDescription_srsSUBClientError() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUBClientError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_CLIENT_ERROR")
+	}
+
+	func testDescription_srsSUBNoNetwork() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUBNoNetwork
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_NO_NETWORK")
+	}
+
+	func testDescription_srsSUBServerError() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUBServerError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_SERVER_ERROR")
+	}
+
+	func testDescription_srsSUB400() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUB400
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_400")
+	}
+
+	func testDescription_srsSUB403() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUB403
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_403")
+	}
+	
+	func testDescription_srsSUB429() throws {
+		// GIVEN
+		let sut: SRSError = .srsSUB429
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_SUB_429")
+	}
+	
+	func testDescription_isDeviceOnline_false_NO_NETWORK() throws {
+		// GIVEN
+		InternetConnectivityMonitor.shared.isDeviceOnlineMock = false
+		let sut: SRSError = .srsOTPClientError
+		
+		// THEN
+		XCTAssertEqual(sut.description, "SRS_OTP_NO_NETWORK")
+	}
+	
+	func testSRSErrorAlert_ppacError() throws {
+		// GIVEN
+		let sut: SRSError = .ppacError(.submissionTooEarly)
+		
+		// THEN
+		XCTAssertEqual(sut.srsErrorAlert, PPACError.submissionTooEarly.srsErrorAlert)
+	}
+	
+	func testSRSErrorAlert_otpError() throws {
+		// GIVEN
+		let sut: SRSError = .otpError(.apiTokenExpired)
+		
+		// THEN
+		XCTAssertEqual(sut.srsErrorAlert, OTPError.apiTokenExpired.srsErrorAlert)
+	}
+	
+	func testSRSErrorAlert_multiple_callHotline() throws {
+		// THEN
+		[
+			SRSError.srsOTPClientError,
+			.srsOTP400,
+			.srsOTP401,
+			.srsOTP403,
+			.srsSUBClientError,
+			.srsSUB400,
+			.srsSUB403
+		]
+		.forEach { sut in XCTAssertEqual(sut.srsErrorAlert, .callHotline) }
+	}
+	
+	func testSRSErrorAlert_multiple_noNetwork() throws {
+		// THEN
+		[
+			SRSError.srsOTPNetworkError,
+			.srsSUBNoNetwork
+		].forEach { sut in XCTAssertEqual(sut.srsErrorAlert, .noNetwork) }
+	}
+	
+	func testSRSErrorAlert_multiple_tryAgainLater() throws {
+		// THEN
+		[
+			SRSError.srsOTPServerError,
+			.srsSUBServerError,
+			.srsSUB429
+		].forEach { sut in XCTAssertEqual(sut.srsErrorAlert, .tryAgainLater) }
+	}
+	
+	func testSRSErrorAlert_isDeviceOnline_false_noNetwork() throws {
+		// GIVEN
+		InternetConnectivityMonitor.shared.isDeviceOnlineMock = false
+		let sut: SRSError = .srsOTP400
+		
+		// THEN
+		XCTAssertEqual(sut.srsErrorAlert, .noNetwork)
+	}
+}

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSError.swift
@@ -23,6 +23,10 @@ enum SRSError: Error, Equatable {
 
 extension SRSError: ErrorCodeProviding {
 	var description: String {
+		guard InternetConnectivityMonitor.shared.isDeviceOnline else {
+			return "SRS_OTP_NO_NETWORK"
+		}
+		
 		switch self {
 		case .ppacError(let ppacError):
 			return ppacError.description
@@ -58,6 +62,10 @@ extension SRSError: ErrorCodeProviding {
 
 extension SRSError: SRSErrorAlertProviding {
 	var srsErrorAlert: SRSErrorAlert? {
+		guard InternetConnectivityMonitor.shared.isDeviceOnline else {
+			return .noNetwork
+		}
+		
 		switch self {
 		case .ppacError(let ppacError):
 			return ppacError.srsErrorAlert


### PR DESCRIPTION
## Description
Show `.noNetwork` `SRSErrorAlert`, independent from `SRSError` when the device is offline.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14566

## Screenshots
<img width="66%" alt="14566" src="https://user-images.githubusercontent.com/22373291/214842259-835017de-e574-4b9c-a60c-6d2346577890.png">
