### PR TITLE
Fix/14647: SRS-Warning: Running and completed checkins.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinator.swift
@@ -1010,8 +1010,8 @@ class ExposureSubmissionCoordinator: NSObject, RequiresAppDependencies {
 	private func showSRSFlowSymptomsOrCheckinsScreen() {
 		let checkins = model.eventProvider.checkinsPublisher.value
 		
-		// No checkins, or checkins without checkout (running)
-		if checkins.isEmpty || checkins.contains(where: { $0.checkinCompleted == false }) {
+		// No checkins, or all checkins are still running (not completed)
+		if checkins.isEmpty || checkins.allSatisfy({ $0.checkinCompleted == false }) {
 			showSymptomsScreen()
 		} else {
 			showCheckinsScreen(isSRSFlow: true)


### PR DESCRIPTION
## Description
Fix a SRS problem, if there are finished AND running events, the "Check-ins teilen?" appears with the finished events.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14647

## Screenshots
https://user-images.githubusercontent.com/22373291/217272924-c6b9fe33-04cb-42cf-8cd1-9e7ff62ae521.mov


