### PR TITLE
Fix/14707 App crashes after change date

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -104,12 +104,10 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			.store(in: &subscriptions)
 		
 		viewModel.cclService.shouldShowNoticeTile
+			.receive(on: DispatchQueue.OCombine(.main))
 			.sink { [weak self] shouldShowNoticeTile in
 				self?.viewModel.shouldShowAppClosureNotice = shouldShowNoticeTile
-				
-				DispatchQueue.main.async { [weak self] in
-					self?.tableView.reloadSections([HomeTableViewModel.Section.appClosureNotice.rawValue], with: .none)
-				}
+				self?.tableView.reloadSections([HomeTableViewModel.Section.appClosureNotice.rawValue], with: .none)
 			}
 			.store(in: &subscriptions)
 	}


### PR DESCRIPTION
## Description
Solves a problem with the EOL-Notice-Tile, that the app will be crashed on `Home`, when you have a time travel on `iOS` `Date and Time `Settings.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14707

## Screenshots
https://user-images.githubusercontent.com/22373291/217812568-53ac46d5-07a4-416a-8655-0cb264eb95f2.mov



