### PR TITLE
Fix/14576 Wrong error text for min time since onboarding

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/Localizable.strings
@@ -587,7 +587,7 @@ Bei ausgeschalteter Hintergrundaktualisierung müssen Sie die App täglich aufru
 
 "ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_title" = "Andere warnen nicht möglich";
 
-"ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_insufficientAppUsageTime_message" = "Leider können Sie momentan andere noch nicht warnen, da Sie die App noch nicht lange genug installiert haben. Dies dient der Vermeidung von Missbrauch.\nEinen offiziellen Test können Sie jederzeit registrieren und andere damit warnen. (%@)";
+"ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_insufficientAppUsageTime_message" = "Aus Sicherheitsgründen können Sie erst %@ Stunden, nachdem Sie die App installiert oder aktualisiert haben, diese Art von Warnung senden. Bitte versuchen Sie es in %@ Stunden erneut. (%@)";
 
 "ExposureSubmissionDispatch_SRSWarnOthersPreconditionError_positiveTestResultWasAlreadySubmittedWithinThresholdDays_message" = "Sie können momentan andere nicht warnen, da Sie innerhalb der vergangenen %@ Tage bereits ein positives Testergebnis gemeldet haben. Dies dient der Vermeidung von Missbrauch.\nEinen offiziellen Test können Sie jederzeit registrieren und andere damit warnen. (%@)";
 

--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/ExposureSubmissionCoordinatorModel.swift
@@ -471,11 +471,11 @@ class ExposureSubmissionCoordinatorModel {
 				)
 			} else if case .timeSinceOnboardingUnverified = srsErrorAlert {
 				let timeSinceOnboardingInHours = srsParametersCommon.timeSinceOnboardingInHours <= 0 ? 24 : srsParametersCommon.timeSinceOnboardingInHours
-								message = String(
+				message = String(
 					format: srsErrorAlert.message,
 					String(timeSinceOnboardingInHours),
 					String(timeSinceOnboardingInHours),
-					AppStrings.SRSErrorAlert.timeSinceOnboardingUnverified
+					error.description
 				)
 			} else {
 				message = String(format: srsErrorAlert.message, error.description)

--- a/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSPreconditionErrorTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/Exposure Submission/__tests__/SRSPreconditionErrorTests.swift
@@ -23,13 +23,20 @@ final class SRSPreconditionErrorTests: CWATestCase {
 
 	func testInsufficientAppUsageTime_Message() {
 		// GIVEN
-		let sut = SRSPreconditionError.insufficientAppUsageTime
+		let timeSinceOnboardingInHours = 42
+		let timeStillToWaitInHours = 23
+		let sut = SRSPreconditionError.insufficientAppUsageTime(
+			timeSinceOnboardingInHours: timeSinceOnboardingInHours,
+			timeStillToWaitInHours: timeStillToWaitInHours
+		)
 		
 		// THEN
 		XCTAssertEqual(
 			sut.message,
 			String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
+				String(timeSinceOnboardingInHours),
+				String(timeStillToWaitInHours),
 				sut.errorCode
 			)
 		)
@@ -55,7 +62,7 @@ final class SRSPreconditionErrorTests: CWATestCase {
 	
 	func testErrorCode_EqualTo_ErrorDescription() {
 		// GIVEN
-		let sut = SRSPreconditionError.insufficientAppUsageTime
+		let sut = SRSPreconditionError.insufficientAppUsageTime(timeSinceOnboardingInHours: 42, timeStillToWaitInHours: 42)
 		
 		// THEN
 		XCTAssertEqual(sut.errorCode, sut.description)
@@ -75,7 +82,7 @@ final class SRSPreconditionErrorTests: CWATestCase {
 		XCTAssertEqual(sut.description, "DEVICE_TIME_UNVERIFIED")
 		
 		// WHEN
-		sut = .insufficientAppUsageTime
+		sut = SRSPreconditionError.insufficientAppUsageTime(timeSinceOnboardingInHours: 42, timeStillToWaitInHours: 42)
 		
 		// THEN
 		XCTAssertEqual(sut.description, "MIN_TIME_SINCE_ONBOARDING")

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
@@ -8,7 +8,7 @@ enum SRSPreconditionError: Error {
 	case deviceTimeError(PPACError)
 
 	/// Precondition: the app was installed less than 48h
-	case insufficientAppUsageTime
+	case insufficientAppUsageTime(timeSinceOnboardingInHours: Int, timeStillToWaitInHours: Int)
 	
 	/// Precondition: there was already a key submission without a registered test, depending from configuration (for e.g. in the last 3 months)
 	case positiveTestResultWasAlreadySubmittedWithinThreshold(timeBetweenSubmissionsInDays: Int)
@@ -22,9 +22,11 @@ enum SRSPreconditionError: Error {
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.deviceCheckError,
 				errorCode
 			)
-		case .insufficientAppUsageTime:
+		case .insufficientAppUsageTime(let timeSinceOnboardingInHours, let timeStillToWaitInHours):
 			return String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
+				String(timeSinceOnboardingInHours),
+				String(timeStillToWaitInHours),
 				errorCode
 			)
 		case let .positiveTestResultWasAlreadySubmittedWithinThreshold(timeBetweenSubmissionsInDays):

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/Model/SRSPreconditionError.swift
@@ -22,7 +22,7 @@ enum SRSPreconditionError: Error {
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.deviceCheckError,
 				errorCode
 			)
-		case .insufficientAppUsageTime(let timeSinceOnboardingInHours, let timeStillToWaitInHours):
+		case let .insufficientAppUsageTime(timeSinceOnboardingInHours, timeStillToWaitInHours):
 			return String(
 				format: AppStrings.ExposureSubmissionDispatch.SRSWarnOthersPreconditionAlert.insufficientAppUsageTimeMessage,
 				String(timeSinceOnboardingInHours),

--- a/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/PPAccessControl/PPACService.swift
@@ -74,7 +74,18 @@ class PPACService: PrivacyPreservingAccessControl {
 			
 			if difference < minTimeSinceOnboarding {
 				Log.error("SRSError: too short time since onboarding", log: .ppac)
-				completion(.failure(.insufficientAppUsageTime))
+				
+				// Default is 1 to avoid texts like "wait for 0 hours" ...
+				let timeStillToWaitInHours = difference == 0 ? 1 : difference
+
+				completion(
+					.failure(
+						.insufficientAppUsageTime(
+							timeSinceOnboardingInHours: minTimeSinceOnboarding,
+							timeStillToWaitInHours: timeStillToWaitInHours
+						)
+					)
+				)
 				return
 			}
 		}


### PR DESCRIPTION
## Description
Fix a message problem with the `SRSPreconditionError` case `insufficientAppUsageTime`.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14576

## Screenshots
![Simulator Screen Recording - iPhone 14 Pro - 2023-02-10 at 14 03 44](https://user-images.githubusercontent.com/22373291/218099320-399385a9-c3e5-4475-a9f0-8f8cae7a95e4.gif)

