### PR TITLE
Task/14823 adapt changes to error logging

### DIFF
--- a/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
+++ b/src/xcode/ENA/ENA.xcodeproj/project.pbxproj
@@ -1762,9 +1762,9 @@
 		DC7003092858A83800B164AC /* ErrorLogSubmissionProvidingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7003082858A83800B164AC /* ErrorLogSubmissionProvidingMock.swift */; };
 		DC8795AC2923ED8D00F478D5 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8795AB2923ED8D00F478D5 /* UIViewController+Helpers.swift */; };
 		DC8BC2BF2953266B003C8CB1 /* InternetConnectivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8BC2BE2953266B003C8CB1 /* InternetConnectivityMonitor.swift */; };
+		DC9390A2299F931A00C2F8F4 /* CWAHibernationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9390A1299F931A00C2F8F4 /* CWAHibernationProviderTests.swift */; };
 		DC9390A5299FAB6A00C2F8F4 /* DMHibernationOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9390A4299FAB6A00C2F8F4 /* DMHibernationOptionsViewController.swift */; };
 		DC9390A7299FAB9B00C2F8F4 /* DMHibernationOptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9390A6299FAB9B00C2F8F4 /* DMHibernationOptionsViewModel.swift */; };
-		DC9390A2299F931A00C2F8F4 /* CWAHibernationProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9390A1299F931A00C2F8F4 /* CWAHibernationProviderTests.swift */; };
 		DC9390A9299FC0F300C2F8F4 /* CWAHibernationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9390A8299FC0F300C2F8F4 /* CWAHibernationProvider.swift */; };
 		DC95881428BCF9FE00F4D03E /* MaskStateTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC95881328BCF9FE00F4D03E /* MaskStateTableViewCell.swift */; };
 		DC95881628BE3D5500F4D03E /* MaskStateCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC95881528BE3D5500F4D03E /* MaskStateCellModel.swift */; };
@@ -1772,6 +1772,7 @@
 		DC9AB2392908174000A2F9D1 /* String+Attributed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9AB2382908174000A2F9D1 /* String+Attributed.swift */; };
 		DCB2897D2948CB51000A3841 /* PPACServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB2897C2948CB51000A3841 /* PPACServiceMock.swift */; };
 		DCB78C47294B2FBC00EAE2AB /* MockRiskProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD2D09F25A86C2A006E4220 /* MockRiskProvider.swift */; };
+		DCBA940329AE21D100905B50 /* MockCWAHibernationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBA940229AE21D100905B50 /* MockCWAHibernationProvider.swift */; };
 		DCD345B8291BF7B700E95A2D /* UIView+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD345B7291BF7B700E95A2D /* UIView+Utils.swift */; };
 		DCDE5FD8292A9DE800F3E733 /* SRSErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDE5FD7292A9DE800F3E733 /* SRSErrorAlert.swift */; };
 		DCDE5FDA292CFABC00F3E733 /* SRSPreconditionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDE5FD9292CFABC00F3E733 /* SRSPreconditionError.swift */; };
@@ -3668,15 +3669,16 @@
 		DC7003082858A83800B164AC /* ErrorLogSubmissionProvidingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorLogSubmissionProvidingMock.swift; sourceTree = "<group>"; };
 		DC8795AB2923ED8D00F478D5 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		DC8BC2BE2953266B003C8CB1 /* InternetConnectivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetConnectivityMonitor.swift; sourceTree = "<group>"; };
+		DC9390A1299F931A00C2F8F4 /* CWAHibernationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CWAHibernationProviderTests.swift; sourceTree = "<group>"; };
 		DC9390A4299FAB6A00C2F8F4 /* DMHibernationOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMHibernationOptionsViewController.swift; sourceTree = "<group>"; };
 		DC9390A6299FAB9B00C2F8F4 /* DMHibernationOptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMHibernationOptionsViewModel.swift; sourceTree = "<group>"; };
-		DC9390A1299F931A00C2F8F4 /* CWAHibernationProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CWAHibernationProviderTests.swift; sourceTree = "<group>"; };
 		DC9390A8299FC0F300C2F8F4 /* CWAHibernationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CWAHibernationProvider.swift; sourceTree = "<group>"; };
 		DC95881328BCF9FE00F4D03E /* MaskStateTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskStateTableViewCell.swift; sourceTree = "<group>"; };
 		DC95881528BE3D5500F4D03E /* MaskStateCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskStateCellModel.swift; sourceTree = "<group>"; };
 		DC95881728BE5E2800F4D03E /* MaskStateCellModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskStateCellModelTests.swift; sourceTree = "<group>"; };
 		DC9AB2382908174000A2F9D1 /* String+Attributed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Attributed.swift"; sourceTree = "<group>"; };
 		DCB2897C2948CB51000A3841 /* PPACServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPACServiceMock.swift; sourceTree = "<group>"; };
+		DCBA940229AE21D100905B50 /* MockCWAHibernationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCWAHibernationProvider.swift; sourceTree = "<group>"; };
 		DCD345B7291BF7B700E95A2D /* UIView+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Utils.swift"; sourceTree = "<group>"; };
 		DCDE5FD7292A9DE800F3E733 /* SRSErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSErrorAlert.swift; sourceTree = "<group>"; };
 		DCDE5FD9292CFABC00F3E733 /* SRSPreconditionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRSPreconditionError.swift; sourceTree = "<group>"; };
@@ -5650,6 +5652,7 @@
 				BA7F15A02629D3F200CA4783 /* RouteTests.swift */,
 				502AB79826E64E5B00536DD2 /* NotificationManagerTests.swift */,
 				DC9390A1299F931A00C2F8F4 /* CWAHibernationProviderTests.swift */,
+				DCBA940229AE21D100905B50 /* MockCWAHibernationProvider.swift */,
 			);
 			path = __tests__;
 			sourceTree = "<group>";
@@ -12663,6 +12666,7 @@
 				509B1E4426D62BB2007B97E0 /* HealthCertificatePDFGenerationInfoViewModelTests.swift in Sources */,
 				358D780C2632FA7C00070BED /* HTTPClient+SubmitErrorLogFileTests.swift in Sources */,
 				BA7D178E25D55EB1006B9EBF /* DefaultDataDonationViewModelTests.swift in Sources */,
+				DCBA940329AE21D100905B50 /* MockCWAHibernationProvider.swift in Sources */,
 				508266DA278DA60000091991 /* Archive+CBOR.swift in Sources */,
 				50C51CB625CDEA4300D4C33A /* HTTPClient+SubmitAnalyticsDataTests.swift in Sources */,
 				0127B09E272855D6008E30AF /* CoronaTestRestorationHandlerTests.swift in Sources */,

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -190,6 +190,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		NotificationCenter.default.addObserver(self, selector: #selector(isOnboardedDidChange(_:)), name: .isOnboardedDidChange, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(backgroundRefreshStatusDidChange), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: nil)
 		
+		if CWAHibernationProvider.shared.isHibernationState {
+			try? elsService.stopAndDeleteLog()
+		}
+		
 		guard #available(iOS 13.5, *) else {
 			// Background task registration on iOS 12.5 requires us to activate the ENManager (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8919)
 			if store.isOnboarded, exposureManager.exposureManagerState.status == .unknown {

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/MockCWAHibernationProvider.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/MockCWAHibernationProvider.swift
@@ -1,0 +1,28 @@
+//
+// 🦠 Corona-Warn-App
+//
+
+import Foundation
+@testable import ENA
+
+class MockCWAHibernationProvider: CWAHibernationProvider {
+	
+	// MARK: - Init
+	
+	init(testStore: MockTestStore = MockTestStore()) {
+		self.testStore = testStore
+		super.init(customStore: testStore)
+	}
+	
+	// MARK: - Overrides
+	
+	override var isHibernationState: Bool {
+		isHibernationStateToReturn
+	}
+	
+	// MARK: - Internal
+	
+	var isHibernationStateToReturn: Bool = false
+	
+	let testStore: MockTestStore
+}

--- a/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/ELSService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/ELSService.swift
@@ -69,6 +69,13 @@ final class ErrorLogSubmissionService: ErrorLogSubmissionProviding {
 	private(set) lazy var logFileSizePublisher: AnyPublisher<Int64, ELSError> = setupFileSizePublisher()
 	
 	func submit(completion: @escaping (Result<ELSSubmitReceiveModel, ELSError>) -> Void) {
+
+		// Hibernation
+		guard !CWAHibernationProvider.shared.isHibernationState else {
+			Log.info("In hibernation status it's not allowed to send error logs.", log: .els)
+			completion(.failure(.hibernation))
+			return
+		}
 		
 		// get log data from the 'all logs' file
 		guard

--- a/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/ELSService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/ELSService.swift
@@ -53,12 +53,14 @@ final class ErrorLogSubmissionService: ErrorLogSubmissionProviding {
 		restServicerProvider: RestServiceProviding,
 		store: ErrorLogProviding,
 		ppacService: PrivacyPreservingAccessControl,
-		otpService: OTPServiceProviding
+		otpService: OTPServiceProviding,
+		cwaHibernationProvider: CWAHibernationProvider = CWAHibernationProvider.shared
 	) {
 		self.restServicerProvider = restServicerProvider
 		self.store = store
 		self.ppacService = ppacService
 		self.otpService = otpService
+		self.cwaHibernationProvider = cwaHibernationProvider
 	}
 	
 	// MARK: - Protocol ErrorLogSubmitting
@@ -71,7 +73,7 @@ final class ErrorLogSubmissionService: ErrorLogSubmissionProviding {
 	func submit(completion: @escaping (Result<ELSSubmitReceiveModel, ELSError>) -> Void) {
 
 		// Hibernation
-		guard !CWAHibernationProvider.shared.isHibernationState else {
+		guard !cwaHibernationProvider.isHibernationState else {
 			Log.info("In hibernation status it's not allowed to send error logs.", log: .els)
 			completion(.failure(.hibernation))
 			return
@@ -119,6 +121,7 @@ final class ErrorLogSubmissionService: ErrorLogSubmissionProviding {
 	private let store: ErrorLogProviding
 	private let ppacService: PrivacyPreservingAccessControl
 	private let otpService: OTPServiceProviding
+	private let cwaHibernationProvider: CWAHibernationProvider
 	
 	private lazy var fileLogger = FileLogger()
 	private lazy var fileManager = FileManager.default

--- a/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/Model/ELSError.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/Model/ELSError.swift
@@ -15,7 +15,7 @@ indirect enum ELSError: Error {
 	case emptyLogFile
 	case couldNotReadLogfile(_ message: String? = nil)
 	case restServiceError(ServiceError<ELSSubmitResource.CustomError>)
-
+	case hibernation
 }
 
 extension ELSError: Equatable {

--- a/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/__tests__/ELSServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/__tests__/ELSServiceTests.swift
@@ -168,9 +168,13 @@ class ELSServiceTests: CWATestCase {
 	}
 	
 	func testGIVEN_ELSService_WHEN_Hibernation_THEN_HibernationErrorIsReturned() throws {
+		// GIVEN
 		let elsService = createELSService(isHibernation: true)
 
+		// WHEN
 		elsService.submit { result in
+			
+			// THEN
 			switch result {
 			case .success:
 				XCTFail("Test should not succeed")

--- a/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/__tests__/ELSServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/ELS LoggingService/__tests__/ELSServiceTests.swift
@@ -167,6 +167,19 @@ class ELSServiceTests: CWATestCase {
 		}
 	}
 	
+	func testGIVEN_ELSService_WHEN_Hibernation_THEN_HibernationErrorIsReturned() throws {
+		let elsService = createELSService(isHibernation: true)
+
+		elsService.submit { result in
+			switch result {
+			case .success:
+				XCTFail("Test should not succeed")
+			case .failure(let error):
+				XCTAssertEqual(ELSError.hibernation, error)
+			}
+		}
+	}
+	
 	func testLogFetching() throws {
 		let elsService = createELSService()
 
@@ -186,7 +199,8 @@ class ELSServiceTests: CWATestCase {
 	private func createELSService(
 		store: Store & PPAnalyticsData = MockTestStore(),
 		restService: RestServiceProviding = RestServiceProviderStub(),
-		ppacSucceeds: Bool = true
+		ppacSucceeds: Bool = true,
+		isHibernation: Bool = false
 	) -> ErrorLogSubmissionService {
 
 		#if targetEnvironment(simulator)
@@ -216,11 +230,14 @@ class ELSServiceTests: CWATestCase {
 			ppacService: ppacService,
 			appConfiguration: CachedAppConfigurationMock()
 		)
+		let mockCWAHibernationProvider = MockCWAHibernationProvider()
+		mockCWAHibernationProvider.isHibernationStateToReturn = isHibernation
 		let elsService = ErrorLogSubmissionService(
 			restServicerProvider: restService,
 			store: store,
 			ppacService: ppacService,
-			otpService: otpService
+			otpService: otpService,
+			cwaHibernationProvider: mockCWAHibernationProvider
 		)
 		return elsService
 	}


### PR DESCRIPTION
## Description
Stop and delete error logs when app call `didFinishLaunchingWithOptions` and hibernation state is given. Prevent to submit error logs in `ELSService`.

**Hint**

The code change for `MockCWAHibernationProvider` is a cherry pick from https://github.com/corona-warn-app/cwa-app-ios/pull/5064. So the timestamps are the same and that's not redundant code.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14823