### PR TITLE
Fix: DMDatePickerTableViewCell trailing space for UIDatePicker.

### DIFF
--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/ConfigureAbleCells/CellsAndViewModels/DatePicker/DMDatePickerTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/ConfigureAbleCells/CellsAndViewModels/DatePicker/DMDatePickerTableViewCell.swift
@@ -79,7 +79,7 @@ class DMDatePickerTableViewCell: UITableViewCell, ConfigureableCell {
 
 		NSLayoutConstraint.activate([
 			stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-			stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 16),
+			stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
 			stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
 			stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
 		])


### PR DESCRIPTION
## Description
Change `.trailing` space constant to fix a layout issue with `UIDatePicker` in `DMDatePickerTableViewCell.`

## Screenshots
<img width="66%" alt="Screenshot 2023-03-01 at 12 07 37" src="https://user-images.githubusercontent.com/22373291/222122630-fd3e0542-a9c7-4c7b-a47d-c6f9b21f9faa.png">
