### PR TITLE
Fix/14904 EOL - "Mehr" area has unnecessary line / space in the end

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/HomeMoreInfoTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/HomeMoreInfoTableViewCell.swift
@@ -36,7 +36,7 @@ class HomeMoreInfoTableViewCell: UITableViewCell {
 			if let actionItemView = nib.instantiate(withOwner: self, options: nil).first as? MoreActionItemView {
 				actionItemView.configure(
 					actionItem: item,
-					hideSeparatorView: item == items.last // index == items.count - 1
+					hideSeparatorView: item == items.last
 				) { selectedItem in
 					onItemTap(selectedItem)
 				}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/HomeMoreInfoTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/HomeMoreInfoTableViewCell.swift
@@ -34,7 +34,10 @@ class HomeMoreInfoTableViewCell: UITableViewCell {
 			let nib = UINib(nibName: nibName, bundle: .main)
 
 			if let actionItemView = nib.instantiate(withOwner: self, options: nil).first as? MoreActionItemView {
-				actionItemView.configure(actionItem: item) { selectedItem in
+				actionItemView.configure(
+					actionItem: item,
+					hideSeparatorView: item == items.last // index == items.count - 1
+				) { selectedItem in
 					onItemTap(selectedItem)
 				}
 				stackView.addArrangedSubview(actionItemView)

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/MoreActionItem/MoreActionItemView.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/More/MoreActionItem/MoreActionItemView.swift
@@ -23,6 +23,7 @@ class MoreActionItemView: UIView {
 	
 	func configure(
 		actionItem: MoreInfoItem,
+		hideSeparatorView: Bool = false,
 		completion: @escaping ((MoreInfoItem) -> Void)
 	) {
 		imageView.image = actionItem.image
@@ -31,7 +32,7 @@ class MoreActionItemView: UIView {
 		accessibilityIdentifier = actionItem.accessibilityIdentifier
 		accessibilityLabel = actionItem.title
 
-		separatorView.isHidden = actionItem == .share
+		separatorView.isHidden = hideSeparatorView
 
 		self.actionItem = actionItem
 		self.completion = completion


### PR DESCRIPTION
## Description
`MoreActionItemView` is now configurable to hide separator view. 
Hide separator view for the last item of the **Home/Mehr** card.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14904

## Screenshots
<img width="66%" alt="Screenshot 2023-03-10 at 09 11 14" src="https://user-images.githubusercontent.com/22373291/224259828-e463c076-f39b-4c7b-9663-3ee00ca6a794.png">

