### PR TITLE
Fix/14902 EOL - App crash if you tap the pic of the "Vielen Dank" area

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -285,7 +285,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 			onTestRegistrationCellTap()
 		case .traceLocations:
 			onTraceLocationsCellTap()
-		case .statistics, .moreInfo:
+		case .statistics, .moreInfo, .endOfLifeThankYou:
 			break
 		default:
 			fatalError("Invalid section")


### PR DESCRIPTION
## Description
Do nothing in `HomeTableViewController` when the user taps on `EndOfLifeThankYouCell` to prevent an app crash.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14902
