### PR TITLE
Fix/14907 EOL - AppLauncher "Eintrag hinzufügen" does not open the actual day if "Tagebuch" is not selected

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
@@ -111,11 +111,17 @@ extension AppDelegate {
 	/// - Parameter shortcutItem: the item to launch
 	func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) {
 		Log.debug("Did open app via shortcut \(shortcutItem.type)", log: .ui)
+		
+		guard let tabBarController = coordinator.tabBarController else { return }
+
 		switch shortcutItem.type {
 		case QuickAction.qrCodeScanner.rawValue:
 			Log.info("Shortcut: QR code scanner", log: .ui)
-			guard let tabBarController = coordinator.tabBarController else { return }
-			tabBarController.selectedIndex = 0
+			
+			guard let indexToSelect = tabBarController.tabBar.items?.firstIndex(where: { $0.title == AppStrings.Tabbar.scannerTitle }) else {
+				return
+			}
+			tabBarController.selectedIndex = indexToSelect
 			
 			// dismiss an overlaying, modally presented view controller
 			coordinator.checkinTabCoordinator?.viewController.presentedViewController?.dismiss(animated: false, completion: nil)
@@ -125,35 +131,33 @@ extension AppDelegate {
 			
 		case QuickAction.showCertificates.rawValue:
 			Log.info("Shortcut: Certificates", log: .ui)
-			guard let tabBarController = coordinator.tabBarController else { return }
-			tabBarController.selectedIndex = 1
+
+			guard let indexToSelect = tabBarController.tabBar.items?.firstIndex(where: { $0.title == AppStrings.Tabbar.certificatesTitle }) else {
+				return
+			}
+			tabBarController.selectedIndex = indexToSelect
 			
 			// dismiss an overlaying, modally presented view controller
 			coordinator.checkinTabCoordinator?.viewController.presentedViewController?.dismiss(animated: false, completion: nil)
 			
 		case QuickAction.eventCheckin.rawValue:
 			Log.info("Shortcut: Event checkin 📷", log: .ui)
-			guard let tabBarController = coordinator.tabBarController else { return }
-			tabBarController.selectedIndex = 3
+
+			guard let indexToSelect = tabBarController.tabBar.items?.firstIndex(where: { $0.title == AppStrings.Tabbar.checkInTitle }) else {
+				return
+			}
+			tabBarController.selectedIndex = indexToSelect
 			
 			// dismiss an overlaying, modally presented view controller
 			coordinator.checkinTabCoordinator?.viewController.presentedViewController?.dismiss(animated: false, completion: nil)
 
 		case QuickAction.diaryNewEntry.rawValue:
 			Log.info("Shortcut: Open new diary entry", log: .ui)
-			guard let tabBarController = coordinator.tabBarController, let viewControllers = tabBarController.viewControllers else { return }
-			
-			guard let diaryOverviewTableViewControllerIndex = viewControllers.lastIndex(where: {
-				if let topViewController = ($0 as? UINavigationController)?.topViewController {
-					return topViewController is DiaryOverviewTableViewController || topViewController is DiaryDayViewController
-				} else {
-					return false
-				}
-			}) else {
+
+			guard let indexToSelect = tabBarController.tabBar.items?.firstIndex(where: { $0.title == AppStrings.Tabbar.diaryTitle }) else {
 				return
 			}
-			
-			tabBarController.selectedIndex = diaryOverviewTableViewControllerIndex
+			tabBarController.selectedIndex = indexToSelect
 
 			// dismiss an overlaying, modally presented view controller
 			coordinator.diaryCoordinator?.viewController.presentedViewController?.dismiss(animated: false, completion: nil)

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
@@ -141,8 +141,19 @@ extension AppDelegate {
 
 		case QuickAction.diaryNewEntry.rawValue:
 			Log.info("Shortcut: Open new diary entry", log: .ui)
-			guard let tabBarController = coordinator.tabBarController else { return }
-			tabBarController.selectedIndex = 4
+			guard let tabBarController = coordinator.tabBarController, let viewControllers = tabBarController.viewControllers else { return }
+			
+			guard let diaryOverviewTableViewControllerIndex = viewControllers.lastIndex(where: {
+				if let topViewController = ($0 as? UINavigationController)?.topViewController {
+					return topViewController is DiaryOverviewTableViewController || topViewController is DiaryDayViewController
+				} else {
+					return false
+				}
+			}) else {
+				return
+			}
+			
+			tabBarController.selectedIndex = diaryOverviewTableViewControllerIndex
 
 			// dismiss an overlaying, modally presented view controller
 			coordinator.diaryCoordinator?.viewController.presentedViewController?.dismiss(animated: false, completion: nil)


### PR DESCRIPTION
## Description
Fixes a bug, that the `QuickAction` _"Eintrag hinzufügen"_ opens the correct screen.
Simplify the `handleShortcutItem(:)` code, that the correct `UITabbarController` index will be selected by localized `UITabbarItem.title`.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14907

## Screenshots

https://user-images.githubusercontent.com/22373291/224489711-fca21e5a-a22c-450c-ba26-a6ab3a1c83e3.mov


