### PR TITLE
Fix/14909 CWA 3.2.0 (3) is unusable for Testing

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/CWAHibernationProvider.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/CWAHibernationProvider.swift
@@ -50,11 +50,7 @@ class CWAHibernationProvider: RequiresAppDependencies {
 	
 	/// CWA hibernation threshold date.
 	var hibernationStartDateForBuild: Date {
-		#if DEBUG
-		Log.debug("current hibernationStartDate \(String(describing: secureStore.hibernationStartDate))")
-		return secureStore.hibernationStartDate ?? hibernationStartDateDefault
-
-		#elseif !RELEASE
+		#if !RELEASE
 		Log.debug("current hibernationStartDate \(String(describing: secureStore.hibernationStartDate))")
 		return secureStore.hibernationStartDate ?? hibernationStartDateDefault
 

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/CWAHibernationProvider.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/CWAHibernationProvider.swift
@@ -28,14 +28,11 @@ class CWAHibernationProvider: RequiresAppDependencies {
 		if isUITesting {
 			return LaunchArguments.endOfLife.isHibernationStateEnabled.boolValue
 		}
-		return secureStore.hibernationComparisonDate >= hibernationStartDate
-		#else
-		return Date() >= hibernationStartDate
 		#endif
+		return Date() >= hibernationStartDateForBuild
 	}
 	
-	/// CWA hibernation threshold date.
-	private let hibernationStartDate: Date = {
+	let hibernationStartDateDefault: Date = {
 		var hibernationStartDateComponents = DateComponents()
 		hibernationStartDateComponents.year = 2023
 		hibernationStartDateComponents.month = 5
@@ -44,12 +41,27 @@ class CWAHibernationProvider: RequiresAppDependencies {
 		hibernationStartDateComponents.minute = 0
 		hibernationStartDateComponents.second = 0
 		
-		guard let hibernationStartDate = Calendar.current.date(from: hibernationStartDateComponents) else {
+		guard let hibernationStartDateDefault = Calendar.current.date(from: hibernationStartDateComponents) else {
 			fatalError("The hibernation start date couldn't be created.")
 		}
 		
-		return hibernationStartDate
+		return hibernationStartDateDefault
 	}()
+	
+	/// CWA hibernation threshold date.
+	var hibernationStartDateForBuild: Date {
+		#if DEBUG
+		Log.debug("current hibernationStartDate \(String(describing: secureStore.hibernationStartDate))")
+		return secureStore.hibernationStartDate ?? hibernationStartDateDefault
+
+		#elseif !RELEASE
+		Log.debug("current hibernationStartDate \(String(describing: secureStore.hibernationStartDate))")
+		return secureStore.hibernationStartDate ?? hibernationStartDateDefault
+
+		#else
+		return hibernationStartDateDefault
+		#endif
+	}
 	
 	private var secureStore: Store {
 		#if RELEASE

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/CWAHibernationProviderTests.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/__tests__/CWAHibernationProviderTests.swift
@@ -7,49 +7,31 @@ import XCTest
 
 final class CWAHibernationProviderTests: CWATestCase {
 	
-	func testIsHibernationState_Store_HibernationComparisonDate_before_false() throws {
+	func testIsHibernationState_HibernationStartDate_beforeSystemDate_true() throws {
 		// GIVEN
 		let mockTestStore = MockTestStore()
 		let sut = CWAHibernationProvider(customStore: mockTestStore)
+		let today = Date()
+		let yesterday = today.addingTimeInterval(-86400) // 1 day in seconds
 		
 		// WHEN
-		var beforeHibernationStartDateComponents = DateComponents()
-		beforeHibernationStartDateComponents.year = 2023
-		beforeHibernationStartDateComponents.month = 4
-		beforeHibernationStartDateComponents.day = 30
-		beforeHibernationStartDateComponents.hour = 23
-		beforeHibernationStartDateComponents.minute = 59
-		beforeHibernationStartDateComponents.second = 59
+		mockTestStore.hibernationStartDate = yesterday
 		
-		guard let hibernationComparisonDate = Calendar.current.date(from: beforeHibernationStartDateComponents) else {
-			return XCTFail("Expect the hibernation comparison date from the corresponding date components.")
-		}
-		mockTestStore.hibernationComparisonDate = hibernationComparisonDate
+		// THEN
+		XCTAssertTrue(sut.isHibernationState)
+	}
+	
+	func testIsHibernationState_HibernationStartDate_afterSystemDate_false() throws {
+		// GIVEN
+		let mockTestStore = MockTestStore()
+		let sut = CWAHibernationProvider(customStore: mockTestStore)
+		let today = Date()
+		let tomorrow = today.addingTimeInterval(86400) // 1 day in seconds
+		
+		// WHEN
+		mockTestStore.hibernationStartDate = tomorrow
 		
 		// THEN
 		XCTAssertFalse(sut.isHibernationState)
 	}
-
-    func testIsHibernationState_Store_HibernationComparisonDate_after_true() throws {
-		// GIVEN
-		let mockTestStore = MockTestStore()
-		let sut = CWAHibernationProvider(customStore: mockTestStore)
-		
-		// WHEN
-		var afterHibernationStartDateComponents = DateComponents()
-		afterHibernationStartDateComponents.year = 2023
-		afterHibernationStartDateComponents.month = 5
-		afterHibernationStartDateComponents.day = 1
-		afterHibernationStartDateComponents.hour = 0
-		afterHibernationStartDateComponents.minute = 0
-		afterHibernationStartDateComponents.second = 0
-
-		guard let hibernationComparisonDate = Calendar.current.date(from: afterHibernationStartDateComponents) else {
-			return XCTFail("Expect the hibernation comparison date from the corresponding date components.")
-		}
-		mockTestStore.hibernationComparisonDate = hibernationComparisonDate
-		
-		// THEN
-		XCTAssertTrue(sut.isHibernationState)
-    }
 }

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMHibernation/DMHibernationOptionsViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMHibernation/DMHibernationOptionsViewController.swift
@@ -83,8 +83,8 @@ class DMHibernationOptionsViewController: UITableViewController {
 		let cell = tableView.dequeueReusableCell(cellType: DMDatePickerTableViewCell.self, for: indexPath)
 		cell.configure(cellViewModel: cellViewModel)
 		
-		cell.didSelectDate = { [weak self] hibernationComparisonDateSelected in
-			self?.viewModel.hibernationComparisonDateSelected = hibernationComparisonDateSelected
+		cell.didSelectDate = { [weak self] customHibernationStartDateSelected in
+			self?.viewModel.customHibernationStartDateSelected = customHibernationStartDateSelected
 		}
 		
 		return cell

--- a/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMHibernation/DMHibernationOptionsViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Developer Menu/Features/DMHibernation/DMHibernationOptionsViewModel.swift
@@ -30,15 +30,11 @@ class DMHibernationOptionsViewModel {
 		
 		switch section {
 		case .hibernationStartDate:
-			if let customHibernationStartDate = store.hibernationStartDate {
-				return "App will shutdown after selecting a new date.\nCurrently the (custom) hibernation starts on: \(dateFormatter.string(from: customHibernationStartDate))"
-			} else {
-				return "App will shutdown after selecting a new date.\nCurrently the  (default) hibernation starts on: \(dateFormatter.string(from: CWAHibernationProvider.shared.hibernationStartDateForBuild))"
-			}
+			return "You can select a custom start here for testing. At the moment, the hibernation starts on \(dateFormatter.string(from: customHibernationStartDateSelected))."
 		case .storeButton:
-			return nil
+			return "App will exit after saving."
 		case .reset:
-			return "App will shutdown after reset."
+			return "App will exit after reset."
 		}
 	}
 	
@@ -50,7 +46,7 @@ class DMHibernationOptionsViewModel {
 		switch section {
 		case .hibernationStartDate:
 			return DMDatePickerCellViewModel(
-				title: "Hibernation Comparison Date",
+				title: "Hibernation Start Date",
 				accessibilityIdentifier: AccessibilityIdentifiers.DeveloperMenu.Hibernation.datePicker,
 				datePickerMode: .dateAndTime,
 				date: CWAHibernationProvider.shared.hibernationStartDateForBuild
@@ -81,14 +77,14 @@ class DMHibernationOptionsViewModel {
 	
 	private let dateFormatter: DateFormatter = {
 		let dateFormatter = DateFormatter()
-		dateFormatter.dateFormat = "yyyy-MM-dd, HH:mm"
+		dateFormatter.dateFormat = "dd.MM.yyyy, HH:mm"
 		return dateFormatter
 	}()
 
 	private func store(hibernationStartDate: Date) {
 		Log.debug("[Debug-Menu] Set hibernation start date to: \(dateFormatter.string(from: hibernationStartDate)).")
 		store.hibernationStartDate = hibernationStartDate
-		Log.debug("[Debug-Menu] Set hibernation start saved.")
+		Log.debug("[Debug-Menu] Set hibernation start done.")
 		
 		exitApp()
 	}

--- a/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
+++ b/src/xcode/ENA/ENA/Source/Services/__tests__/Mocks/MockTestStore.swift
@@ -63,7 +63,7 @@ final class MockTestStore: Store, PPAnalyticsData {
 	var forceAPITokenAuthorization = false
 	var recentTraceLocationCheckedInto: DMRecentTraceLocationCheckedInto?
 	var isSrsPrechecksEnabled = false
-	var hibernationComparisonDate = Date()
+	var hibernationStartDate: Date?
 	#endif
 
 	// MARK: - AppConfigCaching

--- a/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/SecureStore.swift
@@ -378,9 +378,9 @@ final class SecureStore: SecureKeyValueStoring, Store {
 		set { kvStore["recentTraceLocationCheckedInto"] = newValue }
 	}
 	
-	var hibernationComparisonDate: Date {
-		get { kvStore["hibernationComparisonDate"] as Date? ?? Date() }
-		set { kvStore["hibernationComparisonDate"] = newValue }
+	var hibernationStartDate: Date? {
+		get { kvStore["hibernationStartDate"] as Date? }
+		set { kvStore["hibernationStartDate"] = newValue }
 	}
 	#endif
 

--- a/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
+++ b/src/xcode/ENA/ENA/Source/Workers/Store/Store.swift
@@ -87,7 +87,7 @@ protocol StoreProtocol: AnyObject {
 	
 	var recentTraceLocationCheckedInto: DMRecentTraceLocationCheckedInto? { get set }
 	
-	var hibernationComparisonDate: Date { get set }
+	var hibernationStartDate: Date? { get set }
 
 	#endif
 

--- a/src/xcode/ENA/ENAUITests/Home/ENAUITests_01a_Home.swift
+++ b/src/xcode/ENA/ENAUITests/Home/ENAUITests_01a_Home.swift
@@ -276,7 +276,7 @@ class ENAUITests_01a_Home: CWATestCase {
 		app.setLaunchArgument(LaunchArguments.endOfLife.isHibernationStateEnabled, to: true)
 		app.launch()
 		
-		XCTAssertTrue(app.staticTexts[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.descriptionLabel].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.textViews[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.descriptionLabel].waitForExistence(timeout: .medium))
 		XCTAssertTrue(app.images[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.image].waitForExistence(timeout: .medium))
 		XCTAssertTrue(app.staticTexts[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.titleLabel].waitForExistence(timeout: .medium))
 	}

--- a/src/xcode/ENA/ENAUITests/Onboarding/ENAUITests_00_Onboarding.swift
+++ b/src/xcode/ENA/ENAUITests/Onboarding/ENAUITests_00_Onboarding.swift
@@ -33,7 +33,7 @@ class ENAUITests_00_Onboarding: CWATestCase {
 		app.buttons["AppStrings.Onboarding.onboardingContinue"].waitAndTap()
 
 		// check that the homescreen element AppStrings.home.activateTitle is visible onscreen
-		XCTAssertTrue(app.staticTexts[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.descriptionLabel].waitForExistence(timeout: .medium))
+		XCTAssertTrue(app.textViews[AccessibilityIdentifiers.Home.EndOfLifeThankYouCell.descriptionLabel].waitForExistence(timeout: .medium))
 	}
 
 	func test_0000_OnboardingFlow_DisablePermissions_normal_XXXL() throws {


### PR DESCRIPTION
## Description
Hibernation Start Date can be set freely. App changes into hibernation mode, when the mobiles system date/time (either actual or by time travel) reaches the set Hibernation Start Date. Hibernation mode can be released if the mobiles date/time is set to a value before Hibernation Start Date.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14909

## Screenshots
<!-- Please add screenshots (light & dark mode) depicting the current state of the implementation -->
<img width="593" alt="Screenshot 2023-03-12 at 09 49 27" src="https://user-images.githubusercontent.com/22373291/224534269-8b6b5af6-cec7-4dd3-997c-3a17561eee77.png">
