### PR TITLE
Fix/14908 EOL - TabBar unchanged after EOL and without AppRestart

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -256,6 +256,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 		// Cleanup recycle-bin. Remove old entries.
 		recycleBin.cleanup()
+		
+		// Refresh Tabbar if needed
+		coordinator.updateTabbarIfNeeded()
 	}
 
 	func applicationDidEnterBackground(_ application: UIApplication) {

--- a/src/xcode/ENA/ENA/Source/RootCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/RootCoordinator.swift
@@ -241,6 +241,23 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 		)
 		self.diaryCoordinator = diaryCoordinator
 		
+		setupTabbar()
+	}
+	
+	func updateTabbarIfNeeded() {
+		guard let viewControllers = tabBarController.viewControllers else { return }
+		
+		// Hibernation
+		if CWAHibernationProvider.shared.isHibernationState, viewControllers.count == 5 {
+			setupTabbar()
+		}
+		// No Hibernation
+		else if !CWAHibernationProvider.shared.isHibernationState, viewControllers.count == 3 {
+			setupTabbar()
+		}
+	}
+	
+	private func setupTabbar() {
 		// Tabbar
 		let startTabBarItem = UITabBarItem(
 			title: AppStrings.Tabbar.homeTitle,
@@ -248,7 +265,7 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 			selectedImage: UIImage(named: "Icons_Tabbar_Home_Selected")
 		)
 		startTabBarItem.accessibilityIdentifier = AccessibilityIdentifiers.TabBar.home
-		homeCoordinator.rootViewController.tabBarItem = startTabBarItem
+		homeCoordinator?.rootViewController.tabBarItem = startTabBarItem
 
 		let certificatesTabBarItem = UITabBarItem(
 			title: AppStrings.Tabbar.certificatesTitle,
@@ -256,7 +273,7 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 			selectedImage: UIImage(named: "Icons_Tabbar_Certificates_Selected")
 		)
 		certificatesTabBarItem.accessibilityIdentifier = AccessibilityIdentifiers.TabBar.certificates
-		healthCertificatesTabCoordinator.viewController.tabBarItem = certificatesTabBarItem
+		healthCertificatesTabCoordinator?.viewController.tabBarItem = certificatesTabBarItem
 
 		// CWA Hibernation hides scanner and check-in tab
 		if !cwaHibernationProvider.isHibernationState {
@@ -275,7 +292,7 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 				selectedImage: UIImage(named: "Icons_Tabbar_Checkin_Selected")
 			)
 			eventsTabBarItem.accessibilityIdentifier = AccessibilityIdentifiers.TabBar.checkin
-			checkinTabCoordinator.viewController.tabBarItem = eventsTabBarItem
+			checkinTabCoordinator?.viewController.tabBarItem = eventsTabBarItem
 		}
 
 		let diaryTabBarItem = UITabBarItem(
@@ -284,18 +301,18 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 			selectedImage: UIImage(named: "Icons_Tabbar_Diary_Selected")
 		)
 		diaryTabBarItem.accessibilityIdentifier = AccessibilityIdentifiers.TabBar.diary
-		diaryCoordinator.viewController.tabBarItem = diaryTabBarItem
+		diaryCoordinator?.viewController.tabBarItem = diaryTabBarItem
 
 		tabBarController.tabBar.tintColor = .enaColor(for: .tint)
 		tabBarController.tabBar.unselectedItemTintColor = .enaColor(for: .textPrimary2)
 		tabBarController.delegate = self
 		
 		let tabBarViewControllers = [
-			homeCoordinator.rootViewController,
-			healthCertificatesTabCoordinator.viewController,
+			homeCoordinator?.rootViewController,
+			healthCertificatesTabCoordinator?.viewController,
 			cwaHibernationProvider.isHibernationState ? nil : universalScannerDummyViewController,
-			cwaHibernationProvider.isHibernationState ? nil : checkinTabCoordinator.viewController,
-			diaryCoordinator.viewController
+			cwaHibernationProvider.isHibernationState ? nil : checkinTabCoordinator?.viewController,
+			diaryCoordinator?.viewController
 		].compactMap { $0 }
 		tabBarController.setViewControllers(tabBarViewControllers, animated: false)
 

--- a/src/xcode/ENA/ENA/Source/RootCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/RootCoordinator.swift
@@ -118,7 +118,6 @@ class RootCoordinator: NSObject, RequiresAppDependencies, UITabBarControllerDele
 		return viewController
 	}()
 
-	// swiftlint:disable function_body_length
 	func showHome(enStateHandler: ENStateHandler, route: Route?, startupErrors: [Error]) {
 		// only create and init the whole view stack if not done before
 		// there for we check if the homeCoordinator exists


### PR DESCRIPTION
## Description
- When `AppDelegate` calls `applicationDidBecomeActive(:)`, there will be a check, whether the `Tabbar` has to be refresh his items.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14908

## Screenshots
