### PR TITLE
Fix/14911 EOL - Overview still visible after EOL and without AppRestart

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -134,9 +134,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	// MARK: - Deinit
 	
 	deinit {
-		if let didBecomeActiveNotificationObserver = didBecomeActiveNotificationObserver {
-			NotificationCenter.default.removeObserver(didBecomeActiveNotificationObserver)
-		}
+		NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
 	}
 
 	// MARK: - Overrides
@@ -152,7 +150,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshUIAfterResumingFromBackground), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(updateStatistics), name: NSNotification.Name.NSCalendarDayChanged, object: nil)
-		didBecomeActiveNotificationObserver = NotificationCenter.default.addObserver(
+		NotificationCenter.default.addObserver(
 			self,
 			selector: #selector(onDidBecomeActiveNotification),
 			name: UIApplication.didBecomeActiveNotification,
@@ -387,8 +385,6 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	private var familyTestCell: FamilyTestsHomeCell?
 
 	private var subscriptions = Set<AnyCancellable>()
-	
-	private var didBecomeActiveNotificationObserver: NSObjectProtocol?
 
 	private func setupBarButtonItems() {
 		navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Corona-Warn-App"), style: .plain, target: nil, action: nil)

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -130,6 +130,14 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	required init?(coder _: NSCoder) {
 		fatalError("init(coder:) has intentionally not been implemented")
 	}
+	
+	// MARK: - Deinit
+	
+	deinit {
+		if let didBecomeActiveNotificationObserver = didBecomeActiveNotificationObserver {
+			NotificationCenter.default.removeObserver(didBecomeActiveNotificationObserver)
+		}
+	}
 
 	// MARK: - Overrides
 
@@ -144,6 +152,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 
 		NotificationCenter.default.addObserver(self, selector: #selector(refreshUIAfterResumingFromBackground), name: UIApplication.willEnterForegroundNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(updateStatistics), name: NSNotification.Name.NSCalendarDayChanged, object: nil)
+		didBecomeActiveNotificationObserver = NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(onDidBecomeActiveNotification),
+			name: UIApplication.didBecomeActiveNotification,
+			object: nil
+		)
 
 		refreshUI()
 	}
@@ -373,6 +387,8 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	private var familyTestCell: FamilyTestsHomeCell?
 
 	private var subscriptions = Set<AnyCancellable>()
+	
+	private var didBecomeActiveNotificationObserver: NSObjectProtocol?
 
 	private func setupBarButtonItems() {
 		navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "Corona-Warn-App"), style: .plain, target: nil, action: nil)
@@ -1113,6 +1129,11 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		DispatchQueue.main.async { [weak self] in
 			self?.viewModel.state.updateStatistics()
 		}
+	}
+	
+	@objc
+	private func onDidBecomeActiveNotification() {
+		setupBarButtonItems()
 	}
 
 	// swiftlint:disable:next file_length

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -393,14 +393,18 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		navigationItem.leftBarButtonItem?.accessibilityTraits = .none
 		navigationItem.leftBarButtonItem?.accessibilityLabel = AppStrings.Home.leftBarButtonDescription
 		navigationItem.leftBarButtonItem?.accessibilityIdentifier = AccessibilityIdentifiers.Home.leftBarButtonDescription
-
-		if !CWAHibernationProvider.shared.isHibernationState {
+	}
+	
+	private func setupRightBarButtonItem() {
+		if CWAHibernationProvider.shared.isHibernationState {
+			navigationItem.rightBarButtonItem = nil
+		} else {
 			let infoButton = UIButton(type: .infoLight)
 			infoButton.addTarget(self, action: #selector(infoButtonTapped), for: .touchUpInside)
 			navigationItem.rightBarButtonItem = UIBarButtonItem(customView: infoButton)
 			navigationItem.rightBarButtonItem?.isAccessibilityElement = true
-			navigationItem.rightBarButtonItem?.accessibilityLabel = AppStrings.Home.rightBarButtonDescription
 			navigationItem.rightBarButtonItem?.accessibilityIdentifier = AccessibilityIdentifiers.Home.rightBarButtonDescription
+			navigationItem.rightBarButtonItem?.accessibilityLabel = AppStrings.Home.rightBarButtonDescription
 		}
 	}
 
@@ -1129,7 +1133,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	
 	@objc
 	private func onDidBecomeActiveNotification() {
-		setupBarButtonItems()
+		setupRightBarButtonItem()
 	}
 
 	// swiftlint:disable:next file_length


### PR DESCRIPTION
## Description
When hibernation is given, the Info-Overview icon (Home -> right Tabak Icon) isn't visible. When hibernation is not given, the icon is visible. 

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14911

## Screenshots

https://user-images.githubusercontent.com/22373291/224696521-846a3a1f-dd3d-40ba-bd78-abbecebe028c.mov


