### PR TITLE
Fix/14966 EOL "PostIt" - Dark Mode - wrong font color

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Assets/ena-colors.xcassets/App Closure Notice Colors/ENA App Closure Text Subtitle Color.colorset/Contents.json
+++ b/src/xcode/ENA/ENA/Resources/Assets/ena-colors.xcassets/App Closure Notice Colors/ENA App Closure Text Subtitle Color.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.650",
+          "blue" : "0x1A",
+          "green" : "0x19",
+          "red" : "0x17"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.850",
+          "blue" : "0x1A",
+          "green" : "0x19",
+          "red" : "0x17"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.850",
+          "blue" : "0x1A",
+          "green" : "0x19",
+          "red" : "0x17"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x19",
+          "red" : "0x17"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/AppClosureNotice/HomeAppClosureNoticeTableViewCell.xib
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/AppClosureNotice/HomeAppClosureNoticeTableViewCell.xib
@@ -46,7 +46,7 @@
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BDV-jb-o80" userLabel="Subtitle Label" customClass="ENALabel" customModule="ENA" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="28.333333333333329" width="265" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <color key="textColor" name="ENA Text Primary 2 Color Constrast Color"/>
+                                                <color key="textColor" name="ENA App Closure Text Subtitle Color"/>
                                                 <nil key="highlightedColor"/>
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="string" keyPath="ibEnaStyle" value="body"/>
@@ -117,14 +117,14 @@
         <namedColor name="ENA App Closure Notice Color">
             <color red="1" green="0.96862745098039216" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <namedColor name="ENA App Closure Text Subtitle Color">
+            <color red="0.090196078431372548" green="0.098039215686274508" blue="0.10196078431372549" alpha="0.64999998569488526" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="ENA Chevron Dark Color">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.30000001192092896" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="ENA Text Primary 1 Contrast Color">
             <color red="0.090196078431372548" green="0.098039215686274508" blue="0.10196078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="ENA Text Primary 2 Color Constrast Color">
-            <color red="0.090196078431372548" green="0.098039215686274508" blue="0.10196078431372549" alpha="0.60000002384185791" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
## Description
Provide the exact unique text color for the `App Closure Notice` Subtitle to give a better contrast in front of the yellow background color.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14966

## Screenshots
<img width="399" alt="Screenshot 2023-03-17 at 15 02 44" src="https://user-images.githubusercontent.com/22373291/225927877-2345ab6f-e48d-480d-aabf-9c58028ede28.png">
