### PR TITLE
Fix/14949 Stop updating test result in hibernation mode

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2486,6 +2486,66 @@ class CoronaTestServiceTests: CWATestCase {
 			accuracy: 10
 		)
 	}
+	
+	func testUpdatePCRTestResult_EOL_success_WithPreviousState() {
+		UserDefaults.standard.setValue(true, forKey: CWAHibernationProvider.isHibernationInUnitTest)
+		let restServiceProvider = RestServiceProviderStub(results: [
+			.success(TestResultReceiveModel(testResult: TestResult.serverResponse(for: .positive, on: .pcr), sc: nil, labId: nil)),
+			.success(RegistrationTokenReceiveModel(submissionTAN: "fake"))
+		])
+
+		let store = MockTestStore()
+		let appConfiguration = CachedAppConfigurationMock()
+
+		let healthCertificateService = HealthCertificateService(
+			store: store,
+			dccSignatureVerifier: DCCSignatureVerifyingStub(),
+			dscListProvider: MockDSCListProvider(),
+			appConfiguration: appConfiguration,
+			cclService: FakeCCLService(),
+			recycleBin: .fake(),
+			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
+		)
+
+		let deviceCheck = PPACDeviceCheckMock(true, deviceToken: "SomeToken")
+		let ppacService = PPACService(store: store, deviceCheck: deviceCheck)
+		
+		let service = CoronaTestService(
+			restServiceProvider: restServiceProvider,
+			store: store,
+			eventStore: MockEventStore(),
+			diaryStore: MockDiaryStore(),
+			appConfiguration: appConfiguration,
+			healthCertificateService: healthCertificateService,
+			healthCertificateRequestService: HealthCertificateRequestService(
+				store: store,
+				restServiceProvider: RestServiceProviderStub(),
+				appConfiguration: appConfiguration,
+				healthCertificateService: healthCertificateService
+			),
+			ppacService: ppacService,
+			recycleBin: .fake(),
+			badgeWrapper: .fake()
+		)
+		service.pcrTest.value = .mock(registrationToken: "regToken")
+
+		let expectation = self.expectation(description: "Expect to receive a result.")
+
+		service.updateTestResult(for: .pcr) { result in
+			UserDefaults.standard.setValue(false, forKey: CWAHibernationProvider.isHibernationInUnitTest)
+			expectation.fulfill()
+			switch result {
+			case .failure:
+				XCTFail("This test should always return a successful result.")
+			case .success(let testResult):
+				XCTFail("This test should always return the latest test result before the request.")
+				XCTAssertEqual(testResult, TestResult.pending)
+				
+			}
+		}
+
+		waitForExpectations(timeout: .short)
+	}
 
 	func testUpdateAntigenTestResult_success() {
 		let restServiceProvider = RestServiceProviderStub(results: [

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2508,7 +2508,7 @@ class CoronaTestServiceTests: CWATestCase {
 			revocationProvider: RevocationProvider(restService: RestServiceProviderStub(), store: MockTestStore())
 		)
 
-		let deviceCheck = PPACDeviceCheckMock(true, deviceToken: "SomeToken")
+		let deviceCheck = PPACDeviceCheckMock(true, deviceToken: "some-device-token")
 		let ppacService = PPACService(store: store, deviceCheck: deviceCheck)
 		
 		let service = CoronaTestService(

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2536,6 +2536,8 @@ class CoronaTestServiceTests: CWATestCase {
 		service.updateTestResult(for: .pcr) { result in
 			UserDefaults.standard.setValue(false, forKey: CWAHibernationProvider.isHibernationInUnitTest)
 			expectation.fulfill()
+
+		        // THEN
 			switch result {
 			case .failure:
 				XCTFail("This test should always return the latest test result before the request.")

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2528,7 +2528,7 @@ class CoronaTestServiceTests: CWATestCase {
 			recycleBin: .fake(),
 			badgeWrapper: .fake()
 		)
-		service.pcrTest.value = .mock(registrationToken: "regToken")
+		service.pcrTest.value = .mock(registrationToken: "some-registration-token")
 
 		let expectation = self.expectation(description: "Expect to receive a result.")
 

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2492,7 +2492,7 @@ class CoronaTestServiceTests: CWATestCase {
 		UserDefaults.standard.setValue(true, forKey: CWAHibernationProvider.isHibernationInUnitTest)
 		let restServiceProvider = RestServiceProviderStub(results: [
 			.success(TestResultReceiveModel(testResult: TestResult.serverResponse(for: .positive, on: .pcr), sc: nil, labId: nil)),
-			.success(RegistrationTokenReceiveModel(submissionTAN: "fake"))
+			.success(RegistrationTokenReceiveModel(submissionTAN: "some-submission-tan"))
 		])
 
 		let store = MockTestStore()

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2532,6 +2532,7 @@ class CoronaTestServiceTests: CWATestCase {
 
 		let expectation = self.expectation(description: "Expect to receive a result.")
 
+		// WHEN
 		service.updateTestResult(for: .pcr) { result in
 			UserDefaults.standard.setValue(false, forKey: CWAHibernationProvider.isHibernationInUnitTest)
 			expectation.fulfill()

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2536,9 +2536,8 @@ class CoronaTestServiceTests: CWATestCase {
 			expectation.fulfill()
 			switch result {
 			case .failure:
-				XCTFail("This test should always return a successful result.")
-			case .success(let testResult):
 				XCTFail("This test should always return the latest test result before the request.")
+			case .success(let testResult):
 				XCTAssertEqual(testResult, TestResult.pending)
 				
 			}

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/__tests__/CoronaTestServiceTests.swift
@@ -2488,6 +2488,7 @@ class CoronaTestServiceTests: CWATestCase {
 	}
 	
 	func testUpdatePCRTestResult_EOL_success_WithPreviousState() {
+		// GIVEN
 		UserDefaults.standard.setValue(true, forKey: CWAHibernationProvider.isHibernationInUnitTest)
 		let restServiceProvider = RestServiceProviderStub(results: [
 			.success(TestResultReceiveModel(testResult: TestResult.serverResponse(for: .positive, on: .pcr), sc: nil, labId: nil)),


### PR DESCRIPTION
## Description
iOS app seems to continue requesting test results or test certificates after ramp down time while it should stop updating test results

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14949