### PR TITLE
Fix/14975 Set hibernation flag for the notice period

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -106,6 +106,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 		viewModel.cclService.shouldShowNoticeTile
 			.receive(on: DispatchQueue.OCombine(.main))
 			.sink { [weak self] shouldShowNoticeTile in
+				self?.viewModel.isHibernationState = CWAHibernationProvider.shared.isHibernationState
 				self?.viewModel.shouldShowAppClosureNotice = shouldShowNoticeTile
 				self?.tableView.reloadSections(
 					[


### PR DESCRIPTION
## Description
When we return from background in EOL state we are updating 2 things separatly:
1- the notice tile  "as it depends on the ccl flag"
2- the rest of the tableView sections.
I could reproduce the crash and i think the reason is the race condition if the notice tile is trying to update before setting the viewModel.isHibernationState which is currenly only being set in point 2.
so we should set it in both points.

After adding this the crash is gone for me

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14975
