### PR TITLE
Fix/14965 EOL - Notification for Universal scanner shown after onboarding

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -1000,6 +1000,12 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func showQRScannerTooltipIfNeeded(completion: @escaping () -> Void = {}) {
+		// Hibernation
+		guard !CWAHibernationProvider.shared.isHibernationState else {
+			completion()
+			return
+		}
+
 		guard viewModel.store.shouldShowQRScannerTooltip,
 			let tabBar = tabBarController?.tabBar else {
 			completion()


### PR DESCRIPTION
## Description
Prevent `showQRScannerTooltipIfNeeded(completion:)` when hibernation is given.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14965
