### PR TITLE
Fix/14981 EOL - Blocked Vaccination and Recovery Certificates stay in Stautus BLOCKED after RampDown

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -34,8 +34,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 		notificationCenter: UserNotificationCenter = UNUserNotificationCenter.current(),
 		cclService: CCLServable,
 		recycleBin: RecycleBin,
-		revocationProvider: RevocationProviding,
-		cwaHibernationProvider: CWAHibernationProvider = .shared
+		revocationProvider: RevocationProviding
 	) {
 		#if DEBUG
 		if isUITesting {
@@ -54,7 +53,6 @@ class HealthCertificateService: HealthCertificateServiceServable {
 			self.cclService = cclService
 			self.recycleBin = recycleBin
 			self.revocationProvider = revocationProvider
-			self.cwaHibernationProvider = cwaHibernationProvider
 
 			return
 		}
@@ -679,7 +677,6 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	private let recycleBin: RecycleBin
 	private let cclService: CCLServable
 	private let revocationProvider: RevocationProviding
-	private let cwaHibernationProvider: cwaHibernationProvider
 
 	private let setupQueue = DispatchQueue(label: "com.sap.HealthCertificateService.setup")
 	private let healthCertifiedPersonsQueue = DispatchQueue(label: "com.sap.HealthCertificateService.healthCertifiedPersons")

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -34,7 +34,8 @@ class HealthCertificateService: HealthCertificateServiceServable {
 		notificationCenter: UserNotificationCenter = UNUserNotificationCenter.current(),
 		cclService: CCLServable,
 		recycleBin: RecycleBin,
-		revocationProvider: RevocationProviding
+		revocationProvider: RevocationProviding,
+		cwaHibernationProvider: CWAHibernationProvider = .shared
 	) {
 		#if DEBUG
 		if isUITesting {
@@ -53,6 +54,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 			self.cclService = cclService
 			self.recycleBin = recycleBin
 			self.revocationProvider = revocationProvider
+			self.cwaHibernationProvider = cwaHibernationProvider
 
 			return
 		}
@@ -677,6 +679,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	private let recycleBin: RecycleBin
 	private let cclService: CCLServable
 	private let revocationProvider: RevocationProviding
+	private let cwaHibernationProvider: cwaHibernationProvider
 
 	private let setupQueue = DispatchQueue(label: "com.sap.HealthCertificateService.setup")
 	private let healthCertifiedPersonsQueue = DispatchQueue(label: "com.sap.HealthCertificateService.healthCertifiedPersons")
@@ -861,6 +864,11 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	}
 	
 	private func updateValidityState(for healthCertificate: HealthCertificate, person: HealthCertifiedPerson) {
+		guard !cwaHibernationProvider.shared.isHibernationState else {
+			healthCertificate.validityState = .valid
+			return
+		}
+
 		let previousValidityState = healthCertificate.validityState
 
 		if revocationProvider.isRevokedFromRevocationList(healthCertificate: healthCertificate) {

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -862,6 +862,7 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	
 	private func updateValidityState(for healthCertificate: HealthCertificate, person: HealthCertifiedPerson) {
 		guard !CWAHibernationProvider.shared.isHibernationState else {
+			// In hibernation we set the validity state of any health certificate to valid.
 			healthCertificate.validityState = .valid
 			return
 		}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -861,6 +861,11 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	}
 	
 	private func updateValidityState(for healthCertificate: HealthCertificate, person: HealthCertifiedPerson) {
+		guard !CWAHibernationProvider.shared.isHibernationState else {
+			healthCertificate.validityState = .valid
+			return
+		}
+
 		let previousValidityState = healthCertificate.validityState
 
 		if revocationProvider.isRevokedFromRevocationList(healthCertificate: healthCertificate) {


### PR DESCRIPTION
## Description
14981: Set `ValidityState` of a `HealthCertificate` always to `.valid`, if hibernation is given.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14981

## Screenshots
<img width="33%" src="https://user-images.githubusercontent.com/22373291/227472927-0758a331-1b17-40d2-88cb-50e59f969716.png" />
