### PR TITLE
Fix/14983 New link in Data Privacy text is is not clickable

### DIFF
--- a/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/bg.lproj/privacy-policy.html
@@ -16,7 +16,7 @@
 		<p>
 			PLEASE NOTE: The following notice applies from 1 May 2023. The privacy notice valid until 30
 			April 2023 can be found below.
-			All previous versions of the privacy notice can be found at: <a>https://www.coronawarn.app/en/privacy</a>
+			All previous versions of the privacy notice can be found at: <a href="https://www.coronawarn.app/en/privacy">https://www.coronawarn.app/en/privacy</a>
 		</p>
 
 		<p>

--- a/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/de.lproj/privacy-policy.html
@@ -15,7 +15,7 @@
 		<p>
 			ACHTUNG: Die nachfolgenden Hinweise gelten ab dem 1. Mai 2023. Die bis zum 30. April 2023
 			gültige Datenschutzerklärung ist unten angefügt.
-			Alle bisherigen Versionen der Datenschutzerklärung finden Sie unter: <a>https://www.coronawarn.app/de/privacy</a>
+			Alle bisherigen Versionen der Datenschutzerklärung finden Sie unter: <a href="https://www.coronawarn.app/de/privacy">https://www.coronawarn.app/de/privacy</a>
 		</p>
 		<p>
 			<strong>1. Beendigung der Datenverarbeitung</strong>

--- a/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/en.lproj/privacy-policy.html
@@ -16,7 +16,7 @@
 		<p>
 			PLEASE NOTE: The following notice applies from 1 May 2023. The privacy notice valid until 30
 			April 2023 can be found below.
-			All previous versions of the privacy notice can be found at: <a>https://www.coronawarn.app/en/privacy</a>
+			All previous versions of the privacy notice can be found at: <a href="https://www.coronawarn.app/en/privacy">https://www.coronawarn.app/en/privacy</a>
 		</p>
 
 		<p>

--- a/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/pl.lproj/privacy-policy.html
@@ -16,7 +16,7 @@
 		<p>
 			PLEASE NOTE: The following notice applies from 1 May 2023. The privacy notice valid until 30
 			April 2023 can be found below.
-			All previous versions of the privacy notice can be found at: <a>https://www.coronawarn.app/en/privacy</a>
+			All previous versions of the privacy notice can be found at: <a href="https://www.coronawarn.app/en/privacy">https://www.coronawarn.app/en/privacy</a>
 		</p>
 
 		<p>

--- a/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/ro.lproj/privacy-policy.html
@@ -16,7 +16,7 @@
 		<p>
 			PLEASE NOTE: The following notice applies from 1 May 2023. The privacy notice valid until 30
 			April 2023 can be found below.
-			All previous versions of the privacy notice can be found at: <a>https://www.coronawarn.app/en/privacy</a>
+			All previous versions of the privacy notice can be found at: <a href="https://www.coronawarn.app/en/privacy">https://www.coronawarn.app/en/privacy</a>
 		</p>
 
 		<p>

--- a/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/privacy-policy.html
+++ b/src/xcode/ENA/ENA/Resources/Localization/tr.lproj/privacy-policy.html
@@ -15,7 +15,7 @@
 		<p>
 			DİKKAT: Aşağıdaki bildirimler 1 Mayıs 2023 tarihinden itibaren geçerlidir. 30 Nisan 2023
 			tarihine kadar geçerli olan gizlilik politikası ektedir.
-			Gizlilik politikasının önceki tüm sürümleri şu adreste bulunabilir: <a>https://www.coronawarn.app/de/privacy</a>
+			Gizlilik politikasının önceki tüm sürümleri şu adreste bulunabilir: <a href="https://www.coronawarn.app/en/privacy">https://www.coronawarn.app/en/privacy</a>
 		</p>
 		<p>
 			<strong>1. Veri işlemenin sonlandırılması</strong>


### PR DESCRIPTION
## Description
Add the `href` attribute in the link tag for the **privacy notes** (DE/EN) for all 6 languages.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14983

## Screenshots

### German

https://user-images.githubusercontent.com/22373291/227474760-7027bfc0-e0c1-4025-8063-aa19acfb2033.mov

### English (and all other languages)

https://user-images.githubusercontent.com/22373291/227474785-1df4166f-b32b-478b-919a-625fbd03e7d8.mov


