### PR TITLE
Fix/14996 EOL - all statistics remain visible if app is running in background when EOL is reached

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/Cells/Statistics/HomeStatisticsTableViewCell.swift
@@ -135,6 +135,22 @@ class HomeStatisticsTableViewCell: UITableViewCell {
 			}
 			.store(in: &subscriptions)
 	}
+	
+	func configureForHibernation(
+		with keyFigureCellModel: HomeStatisticsCellModel,
+		onInfoButtonTap: @escaping () -> Void
+	) {
+		// Retaining cell model so it gets updated
+		self.cellModel = keyFigureCellModel
+		
+		clearStackView()
+		
+		configurePandemicRadarCard(
+			onInfoButtonTap: onInfoButtonTap,
+			onAccessibilityFocus: {},
+			onUpdate: {}
+		)
+	}
 
 	// swiftlint:disable:next function_parameter_count
 	func configureStatisticsCards(

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewModel.swift
@@ -366,10 +366,10 @@ class HomeTableViewModel {
 			return 1
 		}
 		#endif
-		if shouldShowAppClosureNotice, !isHibernationState {
-			return 1
-		} else {
+		
+		guard !isHibernationState else {
 			return 0
 		}
+		return shouldShowAppClosureNotice ? 1 : 0
 	}
 }


### PR DESCRIPTION
## Description
Hide statistic tiles when Hibernation is given, independent from former user behaviour:

- App to background
- App Switcher

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14996

## Screenshots

https://user-images.githubusercontent.com/22373291/228804051-635fd53a-f847-465a-8a9c-63f68b349462.mov

