### PR TITLE
Fix/14981 Blocked Vaccination and Recovery Certificates stay in Status BLOCKED after RampDown

### DIFF
--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -864,10 +864,8 @@ class HealthCertificateService: HealthCertificateServiceServable {
 		// Hibernation
 		guard !CWAHibernationProvider.shared.isHibernationState else {
 			
-			// In hibernation we set the validity state of any health certificate to expired or valid.
-			if Date() >= healthCertificate.expirationDate {
-				healthCertificate.validityState = .expired
-			} else {
+			// In hibernation we set the validity state of blocked health certificate to valid.
+			if healthCertificate.validityState == .blocked {
 				healthCertificate.validityState = .valid
 			}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -861,14 +861,10 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	}
 	
 	private func updateValidityState(for healthCertificate: HealthCertificate, person: HealthCertifiedPerson) {
-		// Hibernation
-		guard !CWAHibernationProvider.shared.isHibernationState else {
-			
-			// In hibernation we set the validity state of blocked health certificate to valid.
-			if healthCertificate.validityState == .blocked {
-				healthCertificate.validityState = .valid
-			}
 
+		if CWAHibernationProvider.shared.isHibernationState, healthCertificate.validityState == .blocked {
+			// In hibernation we set the validity state of blocked health certificate to valid.
+			healthCertificate.validityState = .valid
 			return
 		}
 

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -862,8 +862,8 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	
 	private func updateValidityState(for healthCertificate: HealthCertificate, person: HealthCertifiedPerson) {
 
+		// In hibernation we set the validity state of blocked health certificate to valid.
 		if CWAHibernationProvider.shared.isHibernationState, healthCertificate.validityState == .blocked {
-			// In hibernation we set the validity state of blocked health certificate to valid.
 			healthCertificate.validityState = .valid
 			return
 		}

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -894,6 +894,8 @@ class HealthCertificateService: HealthCertificateServiceServable {
 		if healthCertificate.validityState != previousValidityState {
 			// Only validity states that are considered newsworthy (and trigger a notification) should be marked as new for the user.
 			healthCertificate.isValidityStateNew = healthCertificate.validityStateIsConsideredNewsworthy
+			
+			guard !CWAHibernationProvider.shared.isHibernationState else { return }
 			updateDCCWalletInfo(for: person)
 		}
 	}


### PR DESCRIPTION
## Description
In hibernation we set the validity state of blocked health certificate to valid.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14981

## Screenshots
<img width="66%" alt="Screenshot 2023-03-30 at 16 16 27" src="https://user-images.githubusercontent.com/22373291/228865438-4a3ec255-e2c1-4504-aa25-56e91efb4986.png">

