### PR TITLE
Fix/15003 enf popups still showing

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -196,13 +196,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 		guard #available(iOS 13.5, *) else {
 			// Background task registration on iOS 12.5 requires us to activate the ENManager (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8919)
-			if store.isOnboarded, exposureManager.exposureManagerState.status == .unknown {
-				self.exposureManager.activate { error in
-					if let error = error {
-						Log.error("[ENATaskExecutionDelegate] Cannot activate the ENManager.", log: .api, error: error)
-					}
-				}
-			}
 			return handleQuickActions(with: launchOptions)
 		}
 		return handleQuickActions(with: launchOptions)
@@ -584,7 +577,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		return MockExposureManager(exposureNotificationError: nil, diagnosisKeysResult: (keys, nil))
 	}()
 	#else
-	lazy var exposureManager: ExposureManager = ENAExposureManager()
+	lazy var exposureManager: ExposureManager = {
+		if Date() >= CWAHibernationProvider.shared.hibernationStartDateDefault {
+			return ENAExposureManager(manager: MockENManager())
+		} else {
+			return ENAExposureManager()
+		}
+	}()
 	#endif
 
 	/// A set of required dependencies
@@ -1031,16 +1030,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		// On iOS 12.5 ENManager is already activated in didFinishLaunching (https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8919)
 		Log.debug("showHome Flow is called with current route: \(String(describing: route?.routeInformation)))")
 		if #available(iOS 13.5, *) {
-			if exposureManager.exposureManagerState.status == .unknown {
-				exposureManager.activate { [weak self] error in
-					if let error = error {
-						Log.error("Cannot activate the ENManager.", log: .api, error: error)
-					}
-					self?.presentHomeVC(route)
-				}
-			} else {
 				presentHomeVC(route)
-			}
 		} else if NSClassFromString("ENManager") != nil { // Make sure that ENManager is available. -> iOS 12.5.x
 			presentHomeVC(route)
 		}

--- a/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/Home/HomeTableViewController.swift
@@ -859,7 +859,7 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	}
 
 	private func showInformationHowRiskDetectionWorksIfNeeded(completion: @escaping () -> Void = {}) {
-		guard viewModel.store.userNeedsToBeInformedAboutHowRiskDetectionWorks else {
+		guard viewModel.store.userNeedsToBeInformedAboutHowRiskDetectionWorks, !CWAHibernationProvider.shared.isHibernationState else {
 			completion()
 			return
 		}
@@ -902,6 +902,10 @@ class HomeTableViewController: UITableViewController, NavigationBarOpacityDelega
 	/// This method checks whether the below conditions in regards to background fetching have been met
 	/// and shows the corresponding alert.
 	private func showBackgroundFetchAlertIfNeeded(completion: @escaping () -> Void = {}) {
+		if CWAHibernationProvider.shared.isHibernationState {
+			completion()
+		}
+		
 		let status = UIApplication.shared.backgroundRefreshStatus
 		let inLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
 		let hasSeenAlertBefore = viewModel.store.hasSeenBackgroundFetchAlert


### PR DESCRIPTION
## Description
in EOL, Disable popups for:
1. ENF activation
2. Risk calculation
3. background processing 

## IMPORTANT:
For the ENF popup this is shown at the initialization of the ENFManager in the appdelegate, this happens **before** initializing the store for the CWAHibernationProvider, so we can use the CWAHibernationProvider to test if reached for hibernation or not. for this specific case we have to manually check if Date() > HibernationDefaultDate.

For testers to test this please time travel **AFTER 1.5.2023**, the dev menu setting wont work here.
For the 2 other popups you can test using dev menu or time travel.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15003

## Screenshots
https://user-images.githubusercontent.com/15270737/228876967-2a8e8273-6c09-4745-b825-323dea24221a.MP4


