### PR TITLE
Fix/14997 eol most revelevant dcc only re calculated after additional app background

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -798,11 +798,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	private func applyEndOfLifeChanges() {
 		// Clear ddc Wallet cache
-		healthCertificateService.healthCertifiedPersons.forEach {
+		store.healthCertifiedPersons.forEach {
 			$0.dccWalletInfo = nil
-			$0.healthCertificates = $0.healthCertificates.filter {
-				$0.testEntry == nil
-			}
 		}
 		
 		// Clear all notifications including deadman notification

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/HealthCertificateService.swift
@@ -771,6 +771,10 @@ class HealthCertificateService: HealthCertificateServiceServable {
 	}
 
 	private func updateDCCWalletInfo(for person: HealthCertifiedPerson, completion: (() -> Void)? = nil) {
+		guard !CWAHibernationProvider.shared.isHibernationState else {
+			completion?()
+			return
+		}
 		person.queue.async {
 			let result = self.cclService.dccWalletInfo(
 				for: person.healthCertificates.map { $0.dccWalletCertificate }, with: self.cclService.dccAdmissionCheckScenariosEnabled ? self.store.lastSelectedScenarioIdentifier : ""

--- a/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
+++ b/src/xcode/ENA/ENA/Source/Services/HealthCertificate/Models/HealthCertifiedPerson.swift
@@ -53,7 +53,9 @@ class HealthCertifiedPerson: Codable, Equatable, Comparable {
 		var healthCertificates = [HealthCertificate]()
 		var decodingFailedHealthCertificates = try container.decodeIfPresent([DecodingFailedHealthCertificate].self, forKey: .decodingFailedHealthCertificates) ?? []
 		isPreferredPerson = try container.decodeIfPresent(Bool.self, forKey: .isPreferredPerson) ?? false
-		dccWalletInfo = try container.decodeIfPresent(DCCWalletInfo.self, forKey: .dccWalletInfo)
+		if !CWAHibernationProvider.shared.isHibernationState {
+			dccWalletInfo = try container.decodeIfPresent(DCCWalletInfo.self, forKey: .dccWalletInfo)
+		}
 		mostRecentWalletInfoUpdateFailed = try container.decodeIfPresent(Bool.self, forKey: .mostRecentWalletInfoUpdateFailed) ?? false
 		boosterRule = try container.decodeIfPresent(Rule.self, forKey: .boosterRule)
 		isNewBoosterRule = try container.decodeIfPresent(Bool.self, forKey: .isNewBoosterRule) ?? false


### PR DESCRIPTION
## Description
- make sure to delete the wallet info from the store not the service otherwise it will be fetched later on from the store.
- make sure updateDCCWalletInfo cant be called again in hibernation

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14997

## Screenshots
https://sap-my.sharepoint.com/personal/omar_abdelaziz_hanafy_abdelaziz_ahmed_sap_com/_layouts/15/stream.aspx?id=%2Fpersonal%2Fomar%5Fabdelaziz%5Fhanafy%5Fabdelaziz%5Fahmed%5Fsap%5Fcom%2FDocuments%2FRPReplay%5FFinal1680257940%2EMP4&ga=1
