### PR TITLE
Fix/14992 EOL - Remove notifications syncronously

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -268,8 +268,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 			taskScheduler?.scheduleTask()
 		}
 		
-		removeAllPendingNotificationRequestsForHibernationIfNeeded()
-
 		Log.info("Application did enter background.", log: .appLifecycle)
 	}
 
@@ -752,8 +750,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		}
 
 		// Remove all pending notifications
-		UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
-
+		removeAllPendingNotificationRequestsForHibernationIfNeeded()
+		
 		// Reset contact diary
 		contactDiaryStore.reset()
 
@@ -1178,24 +1176,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 	
 	/// Remove pending notification requests, if their trigger date is later than hibernation start date.
 	private func removeAllPendingNotificationRequestsForHibernationIfNeeded() {
-		Log.info("UNUserNotificationCenter: Get pending Notification requests...")
-		UNUserNotificationCenter.current().getPendingNotificationRequests { pendingNotificationRequests in
-			
-			Log.info("UNUserNotificationCenter: \(pendingNotificationRequests.count) pending notification requests were found.")
-			
-			/// The pending notification request identifiers, where the next trigger date is after hibernation start date
-			let relevantNotificationRequestIdentifiers = pendingNotificationRequests.filter { notificationRequest in
-
-				guard let notificationRequest = notificationRequest.trigger as? UNTimeIntervalNotificationTrigger, let nextTriggerDate = notificationRequest.nextTriggerDate() else {
-					return false
-				}
-
-				return nextTriggerDate > CWAHibernationProvider.shared.hibernationStartDateForBuild
-			}.map { $0.identifier }
-			
-			Log.info("UNUserNotificationCenter: \(relevantNotificationRequestIdentifiers.count) pending notification requests will be removed now, cause the trigger date is later than hibernation begins.")
-
-			UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: relevantNotificationRequestIdentifiers)
+		if CWAHibernationProvider.shared.isHibernationState {
+			Log.info("UNUserNotificationCenter: pending notification requests will be removed now because of EOL state")
+			UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
 		}
 	}
 }


### PR DESCRIPTION
## Description

- When we reach EOL and try to close the app we try to cancel notifications in an async method, this wont work properly as the app will be removed from memory before the async block is reached and the notifications are canceled
- the solutions is to call `UNUserNotificationCenter.current().removeAllPendingNotificationRequests()` which will do the same but synchronously.
The downside of reverting the previous  code:
We wont be able to stop notifications in the future if the EOL is not reached yet. e.g today is 3/4/2023 Eol is 4/4/2023 and we have a notification scheduled in 5/4/2023. this notification will not be canceled unless the user tries to open, close, of move the app to background **DURING** End of life.

a redundant call was removed from `applicationDidEnterBackground()` as we will cancel anyway in `applicationWillResignActive()` which has to be called before  `applicationDidEnterBackground`, so need to cancel twice

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14992