### PR TITLE
Fix/14992 deadman notification still comes when eol is already reached

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewModel.swift
@@ -27,6 +27,7 @@ class HealthCertificateOverviewViewModel {
 					.filter { !$0.healthCertificates.isEmpty }
 				self.decodingFailedHealthCertificates = $0
 					.flatMap { $0.decodingFailedHealthCertificates }
+				
 			}
 			.store(in: &subscriptions)
 

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewModel.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/Overview/HealthCertificateOverviewViewModel.swift
@@ -27,7 +27,6 @@ class HealthCertificateOverviewViewModel {
 					.filter { !$0.healthCertificates.isEmpty }
 				self.decodingFailedHealthCertificates = $0
 					.flatMap { $0.decodingFailedHealthCertificates }
-				
 			}
 			.store(in: &subscriptions)
 

--- a/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
@@ -28,7 +28,7 @@ struct DeadmanNotificationManager: DeadmanNotificationManageable {
 		/// Check if Deadman Notification is already scheduled
 		///
 		let numberOfHoursUntilEOL: Int
-		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil  {
+		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
 			// set numberOfHoursUntilEOL for unit testing as store is not initilized in the CWAHibernationProvider
 			numberOfHoursUntilEOL = 40
 		} else {
@@ -49,7 +49,7 @@ struct DeadmanNotificationManager: DeadmanNotificationManageable {
 				return
 			} else {
 				// check if we reach EOL will be reached in 36 hours or less then we do NOT schedule a deadman notification.
-				guard numberOfHoursUntilEOL < 36 else {
+				guard numberOfHoursUntilEOL > 36 else {
 					Log.debug("EOL will be reached in \(numberOfHoursUntilEOL) hours, so no need to schedule a deadman notification.")
 					return
 				}

--- a/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
@@ -26,8 +26,19 @@ struct DeadmanNotificationManager: DeadmanNotificationManageable {
 	/// Schedules a local notification to fire 36 hours from now, if there isn´t a notification already scheduled
 	func scheduleDeadmanNotificationIfNeeded() {
 		/// Check if Deadman Notification is already scheduled
+		///
+		let numberOfHoursUntilEOL = Calendar.current.dateComponents([.hour], from: Date(), to: CWAHibernationProvider.shared.hibernationStartDateForBuild).hour ?? 0
+		Log.debug("numberOfHours Until EOL: \(numberOfHoursUntilEOL).")
 		userNotificationCenter.getPendingNotificationRequests { notificationRequests in
-			if notificationRequests.contains(where: { $0.identifier == Self.deadmanNotificationIdentifier }) {
+			if notificationRequests.contains(where: {
+				 $0.identifier == Self.deadmanNotificationIdentifier
+			}) {
+				// A deadman notification is scheduled in 36 hours or less.
+				// check if we reach EOL in 36 hours or less then cancel the pending deadman notification.
+				if  numberOfHoursUntilEOL < 36 {
+					Log.debug("canceling scheduled deadman notifications as it will be fired during EOL")
+					cancelDeadmanNotification()
+				}
 				/// Deadman Notification already setup -> return
 				return
 			} else {

--- a/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
@@ -42,6 +42,11 @@ struct DeadmanNotificationManager: DeadmanNotificationManageable {
 				/// Deadman Notification already setup -> return
 				return
 			} else {
+				// check if we reach EOL will be reached in 36 hours or less then we do NOT schedule a deadman notification.
+				guard numberOfHoursUntilEOL < 36 else {
+					Log.debug("EOL will be reached in \(numberOfHoursUntilEOL) hours, so no need to schedule a deadman notification.")
+					return
+				}
 				/// No Deadman Notification setup, continue to setup a new one
 				let content = UNMutableNotificationContent()
 				content.title = AppStrings.Common.deadmanAlertTitle

--- a/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
+++ b/src/xcode/ENA/ENA/Source/Services/DeadmanNotification/DeadmanNotificationManager.swift
@@ -27,7 +27,13 @@ struct DeadmanNotificationManager: DeadmanNotificationManageable {
 	func scheduleDeadmanNotificationIfNeeded() {
 		/// Check if Deadman Notification is already scheduled
 		///
-		let numberOfHoursUntilEOL = Calendar.current.dateComponents([.hour], from: Date(), to: CWAHibernationProvider.shared.hibernationStartDateForBuild).hour ?? 0
+		let numberOfHoursUntilEOL: Int
+		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil  {
+			// set numberOfHoursUntilEOL for unit testing as store is not initilized in the CWAHibernationProvider
+			numberOfHoursUntilEOL = 40
+		} else {
+			numberOfHoursUntilEOL = Calendar.current.dateComponents([.hour], from: Date(), to: CWAHibernationProvider.shared.hibernationStartDateForBuild).hour ?? 0
+		}
 		Log.debug("numberOfHours Until EOL: \(numberOfHoursUntilEOL).")
 		userNotificationCenter.getPendingNotificationRequests { notificationRequests in
 			if notificationRequests.contains(where: {


### PR DESCRIPTION
## Description
- Deadman notification is scheduled "if not already scheduled" to fire in 36 hours. based on that we should cancel  scheduled deadman notifications if EOL will be reached in 36 hours or less, because there is no point of showing them in EOL.

NOTE: this is just an improvement to the proposed approached, we still have some limitations from the OS as we cant cancel we check pending notification if the app is terminated "i.e closed"
## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14992
