### PR TITLE
Fix/15010 EOL-Installation-Pandemie-Radar-Link-does-not-work

### DIFF
--- a/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
+++ b/src/xcode/ENA/ENA/Source/View Helpers/AppStrings.swift
@@ -60,7 +60,7 @@ enum AppStrings {
 		static let coronaWarnAppStoreLink = NSLocalizedString("TicketValidation_CoronaWarnAppLink", tableName: "Localizable.links", comment: "")
 		static let stikoVaccinationRecommendations = NSLocalizedString("Stiko_VaccinationRecommendations", tableName: "Localizable.links", comment: "")
 		static let warnWithoutTANFAQLink = NSLocalizedString("ExposureSubmission_WarnWithoutTAN_FAQLink", tableName: "Localizable.links", comment: "")
-		static let pandemicRadarLink = NSLocalizedString("Home_LinkCard_PandemicRadar_URL", comment: "")
+		static let pandemicRadarLink = NSLocalizedString("Home_LinkCard_PandemicRadar_URL", tableName: "Localizable.links", comment: "")
 	}
 
 	enum QuickActions {


### PR DESCRIPTION
## Description
add the table name for the linksotherwise the appsting will be read as a raw string and wont open the webpage

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15010