### PR TITLE
14949-EOL-test-result-and-test-certificate-still-updated-after-ramp-down

### DIFF
--- a/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/ExposureSubmission/View/Controller/ExposureSubmissionTestResultViewController.swift
@@ -152,10 +152,14 @@ class ExposureSubmissionTestResultViewController: DynamicTableViewController, Fo
 
 		viewModel.errorPublisher
 			.sink { [weak self] error in
-				guard let self = self, let error = error else { return }
+				guard let self = self,
+					  let error = error,
+					  !CWAHibernationProvider.shared.isHibernationState else {
+					return
+				}
 
 				self.viewModel.errorPublisher.value = nil
-
+				
 				let alert = self.setupErrorAlert(message: error.localizedDescription)
 				self.present(alert, animated: true)
 			}

--- a/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
+++ b/src/xcode/ENA/ENA/Source/Services/CoronaTestService/CoronaTestService.swift
@@ -492,6 +492,7 @@ class CoronaTestService: CoronaTestServiceProviding {
 			}
 			Log.info("[CoronaTestService] Will return the latest cached test result because of End of Life state. force: \(force), presentNotification: \(presentNotification)", log: .api)
 			completion(.success(coronaTest.testResult))
+			return
 		}
 		Log.info("[CoronaTestService] Updating test result (coronaTestType: \(coronaTestType)), force: \(force), presentNotification: \(presentNotification)", log: .api)
 		


### PR DESCRIPTION
## Description
prevent test result error popups

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14949
