### PR TITLE
Fix App Release 3.2.0 crash

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -586,13 +586,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 		return MockExposureManager(exposureNotificationError: nil, diagnosisKeysResult: (keys, nil))
 	}()
 	#else
-	lazy var exposureManager: ExposureManager = {
-		if Date() >= CWAHibernationProvider.shared.hibernationStartDateDefault {
-			return ENAExposureManager(manager: MockENManager())
-		} else {
-			return ENAExposureManager()
-		}
-	}()
+	lazy var exposureManager: ExposureManager = ENAExposureManager()
 	#endif
 
 	/// A set of required dependencies


### PR DESCRIPTION
## Description
Revert code change:
Initialize `exposureManager` with `ENAExposureManager,` not `MockENManager` after hibernation starts.

**Side effect**
The reverted code was marked as a fix to prevent the EN popup after hibernation starts. 
For that  another approach is needed then.