### PR TITLE
Remove precondition failure for Production

### DIFF
--- a/src/xcode/ENA/ENA/Source/Models/Exposure/MockENManager.swift
+++ b/src/xcode/ENA/ENA/Source/Models/Exposure/MockENManager.swift
@@ -13,13 +13,6 @@ final class MockENManager: NSObject {
 	) {
 		super.init()
 		self.diagnosisKeysResult = (keys, enError)
-
-		#if RELEASE
-		// This whole class would/should be wrapped in a DEBUG block. However, there were some
-		// issues with the handling of community and debug builds so we chose this way to prevent
-		// malicious usage
-		preconditionFailure("Don't use this mock in production!")
-		#endif
 	}
 	
 	// MARK: - Activating


### PR DESCRIPTION
## Description
We had a Precondition Failure in case we run on a scheme other than Production in en the MockEnaManager.
- Is it safe to remove this line?
- this line was to avoid using ENAManager with no functionalities which didn't make sense back in the time it was written but now it is the case we need as we don't need any actual functionalities for the ramp down after 1.5.2023, 

To reproduce the crash Just change if #Prod to if #debug. in the MockENManager class.

To test that the solution is working remove the line as done in the PR, the app will start normally

## Jira Link:
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15088


