### PR TITLE
Fix/15131 Quick actions are not reduced correctly in hibernation state

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
@@ -87,7 +87,7 @@ enum QuickAction: String {
 			
 			let status = AVCaptureDevice.authorizationStatus(for: .video)
 			if status == .authorized || status == .notDetermined {
-				// dont show camera related actions if no camera access is granted
+				// don't show the camera related actions if no camera access is granted
 				shortcutItems.append(
 					contentsOf: [
 						UIApplicationShortcutItem(

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
@@ -51,21 +51,40 @@ enum QuickAction: String {
 			application.shortcutItems = nil
 			return
 		}
-
-		var shortcutItems = [
-			UIApplicationShortcutItem(type: QuickAction.diaryNewEntry.rawValue, localizedTitle: AppStrings.QuickActions.contactDiaryNewEntry, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "book.closed")),
-			UIApplicationShortcutItem(type: QuickAction.showCertificates.rawValue, localizedTitle: AppStrings.QuickActions.showCertificates, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Certificates"))
-		]
 		
-		let status = AVCaptureDevice.authorizationStatus(for: .video)
-		if status == .authorized || status == .notDetermined {
-			// dont show camera related actions if no camera access is granted
-			shortcutItems.append(
-				contentsOf: [
-					UIApplicationShortcutItem(type: QuickAction.eventCheckin.rawValue, localizedTitle: AppStrings.QuickActions.eventCheckin, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Checkin")),
-					UIApplicationShortcutItem(type: QuickAction.qrCodeScanner.rawValue, localizedTitle: AppStrings.QuickActions.qrCodeScanner, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "qrcode.viewfinder"))
-				]
-			)
+		var shortcutItems = [UIApplicationShortcutItem]()
+		
+		if CWAHibernationProvider.shared.isHibernationState {
+			shortcutItems = [
+				UIApplicationShortcutItem(
+					type: QuickAction.diaryNewEntry.rawValue,
+					localizedTitle: AppStrings.QuickActions.contactDiaryNewEntry,
+					localizedSubtitle: nil,
+					icon: UIApplicationShortcutIcon(templateImageName: "book.closed")
+				),
+				UIApplicationShortcutItem(
+					type: QuickAction.showCertificates.rawValue,
+					localizedTitle: AppStrings.QuickActions.showCertificates,
+					localizedSubtitle: nil,
+					icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Certificates")
+				)
+			]
+		} else {
+			shortcutItems = [
+				UIApplicationShortcutItem(type: QuickAction.diaryNewEntry.rawValue, localizedTitle: AppStrings.QuickActions.contactDiaryNewEntry, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "book.closed")),
+				UIApplicationShortcutItem(type: QuickAction.showCertificates.rawValue, localizedTitle: AppStrings.QuickActions.showCertificates, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Certificates"))
+			]
+			
+			let status = AVCaptureDevice.authorizationStatus(for: .video)
+			if status == .authorized || status == .notDetermined {
+				// dont show camera related actions if no camera access is granted
+				shortcutItems.append(
+					contentsOf: [
+						UIApplicationShortcutItem(type: QuickAction.eventCheckin.rawValue, localizedTitle: AppStrings.QuickActions.eventCheckin, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Checkin")),
+						UIApplicationShortcutItem(type: QuickAction.qrCodeScanner.rawValue, localizedTitle: AppStrings.QuickActions.qrCodeScanner, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "qrcode.viewfinder"))
+					]
+				)
+			}
 		}
 		
 		application.shortcutItems = shortcutItems

--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate+QuickActions.swift
@@ -71,8 +71,18 @@ enum QuickAction: String {
 			]
 		} else {
 			shortcutItems = [
-				UIApplicationShortcutItem(type: QuickAction.diaryNewEntry.rawValue, localizedTitle: AppStrings.QuickActions.contactDiaryNewEntry, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "book.closed")),
-				UIApplicationShortcutItem(type: QuickAction.showCertificates.rawValue, localizedTitle: AppStrings.QuickActions.showCertificates, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Certificates"))
+				UIApplicationShortcutItem(
+					type: QuickAction.diaryNewEntry.rawValue,
+					localizedTitle: AppStrings.QuickActions.contactDiaryNewEntry,
+					localizedSubtitle: nil,
+					icon: UIApplicationShortcutIcon(templateImageName: "book.closed")
+				),
+				UIApplicationShortcutItem(
+					type: QuickAction.showCertificates.rawValue,
+					localizedTitle: AppStrings.QuickActions.showCertificates,
+					localizedSubtitle: nil,
+					icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Certificates")
+				)
 			]
 			
 			let status = AVCaptureDevice.authorizationStatus(for: .video)
@@ -80,8 +90,18 @@ enum QuickAction: String {
 				// dont show camera related actions if no camera access is granted
 				shortcutItems.append(
 					contentsOf: [
-						UIApplicationShortcutItem(type: QuickAction.eventCheckin.rawValue, localizedTitle: AppStrings.QuickActions.eventCheckin, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Checkin")),
-						UIApplicationShortcutItem(type: QuickAction.qrCodeScanner.rawValue, localizedTitle: AppStrings.QuickActions.qrCodeScanner, localizedSubtitle: nil, icon: UIApplicationShortcutIcon(templateImageName: "qrcode.viewfinder"))
+						UIApplicationShortcutItem(
+							type: QuickAction.eventCheckin.rawValue,
+							localizedTitle: AppStrings.QuickActions.eventCheckin,
+							localizedSubtitle: nil,
+							icon: UIApplicationShortcutIcon(templateImageName: "Icons_Tabbar_Checkin")
+						),
+						UIApplicationShortcutItem(
+							type: QuickAction.qrCodeScanner.rawValue,
+							localizedTitle: AppStrings.QuickActions.qrCodeScanner,
+							localizedSubtitle: nil,
+							icon: UIApplicationShortcutIcon(templateImageName: "qrcode.viewfinder")
+						)
 					]
 				)
 			}

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificate/HealthCertificateCoordinator.swift
@@ -108,7 +108,13 @@ final class HealthCertificateCoordinator {
 	private var validationCoordinator: HealthCertificateValidationCoordinator?
 	
 	private var infoScreenShown: Bool {
-		get { store.healthCertificateInfoScreenShown }
+		get {
+			if CWAHibernationProvider.shared.isHibernationState {
+				return true
+			} else {
+				return store.healthCertificateInfoScreenShown
+			}
+		}
 		set { store.healthCertificateInfoScreenShown = newValue }
 	}
 	

--- a/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
+++ b/src/xcode/ENA/ENA/Source/Scenes/HealthCertificates/HealthCertificatesTabCoordinator.swift
@@ -106,7 +106,13 @@ final class HealthCertificatesTabCoordinator {
 	private var printNavigationController: UINavigationController!
 	
 	private var infoScreenShown: Bool {
-		get { store.healthCertificateInfoScreenShown }
+		get {
+			if CWAHibernationProvider.shared.isHibernationState {
+				return true
+			} else {
+				return store.healthCertificateInfoScreenShown
+			}
+		}
 		set { store.healthCertificateInfoScreenShown = newValue }
 	}
 


### PR DESCRIPTION
## Description
The quick actions "QR-Codes sannen" & "Check-ins anzeigen" should not be shown in hibernation state.

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15131

## Screenshots
<img width="66%" alt="Screenshot 2023-05-03 at 11 53 32" src="https://user-images.githubusercontent.com/22373291/235885394-d32217a2-9c00-4a91-a6a2-61e53f30421d.png">

