### PR TITLE
15162-use the correct manager to disable enf

### DIFF
--- a/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
+++ b/src/xcode/ENA/ENA/Source/AppDelegate & Globals/AppDelegate.swift
@@ -1184,8 +1184,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CoronaWarnAppDelegate, Re
 
 	private func disableExposureNotification() {
 		Log.info("Try to disable exposure notification.")
-
-		exposureManager.disable { exposureNotificationError in
+		ENAExposureManager().disable { exposureNotificationError in
 			if let exposureNotificationError = exposureNotificationError {
 				Log.error("The exposure notification couldn't be disabled by ExposureManager: \(exposureNotificationError.localizedDescription)")
 			} else {


### PR DESCRIPTION
## Description
Use the ENAExposureMAnager for disabling ENF instead of the MockManager

## Link to Jira
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15162
